### PR TITLE
Customizable white color temperature range for tunable white lights

### DIFF
--- a/lib/TWLightAccessory.js
+++ b/lib/TWLightAccessory.js
@@ -1,6 +1,9 @@
 const BaseAccessory = require('./BaseAccessory');
 const async = require('async');
 
+const DEFAULT_MIN_WHITE_COLOR = 0;
+const DEFAULT_MAX_WHITE_COLOR = 600;
+
 class TWLightAccessory extends BaseAccessory {
     static getCategory(Categories) {
         return Categories.LIGHTBULB;
@@ -39,8 +42,8 @@ class TWLightAccessory extends BaseAccessory {
 
         const characteristicColorTemperature = service.getCharacteristic(Characteristic.ColorTemperature)
             .setProps({
-                minValue: 0,
-                maxValue: 600
+                minValue: this.device.context.minWhiteColor ?? DEFAULT_MIN_WHITE_COLOR,
+                maxValue: this.device.context.maxWhiteColor ?? DEFAULT_MAX_WHITE_COLOR
             })
             .updateValue(this.convertColorTemperatureFromTuyaToHomeKit(dps[this.dpColorTemperature]))
             .on('get', this.getColorTemperature.bind(this))


### PR DESCRIPTION
https://github.com/iRayanKhan/homebridge-tuya/pull/471

Original description:
```
Having fixed white color temperature values would potentially make the Home app use a spectrum which the light would not be fully capable of emitting.
```