### PR TITLE
Fixing multiple RGBTWLightAccessory issues

### DIFF
--- a/lib/BaseAccessory.js
+++ b/lib/BaseAccessory.js
@@ -154,18 +154,16 @@ class BaseAccessory {
         const min = this.device.context.minWhiteColor || 140;
         const max = this.device.context.maxWhiteColor || 400;
         const scale = this.device.context.scaleWhiteColor || 255;
-        const adjustedValue = (value - 71) * (max - min) / (600 - 71) + 153;
-        const convertedValue = Math.round((scale * min / (max - min)) * ((max / adjustedValue) - 1));
-        return Math.min(scale, Math.max(0, convertedValue));
+        const result = Math.round(Math.max(Math.min(scale-(scale-1)/(max-min)*(value-min),scale),1));
+        return result;
     }
 
     convertColorTemperatureFromTuyaToHomeKit(value) {
         const min = this.device.context.minWhiteColor || 140;
         const max = this.device.context.maxWhiteColor || 400;
         const scale = this.device.context.scaleWhiteColor || 255;
-        const unadjustedValue = max / ((value * (max - min) / (scale * min)) + 1);
-        const convertedValue = Math.round((unadjustedValue - 153) * (600 - 71) / (max - min) + 71);
-        return Math.min(600, Math.max(71, convertedValue));
+        const result = Math.round(Math.max(Math.min((scale-value)/((scale-1)/(max-min))+min,max),min));
+        return Math.min(600, Math.max(71, result));
     }
 
     convertColorFromHomeKitToTuya(value, dpValue) {

--- a/lib/RGBTWLightAccessory.js
+++ b/lib/RGBTWLightAccessory.js
@@ -58,10 +58,10 @@ class RGBTWLightAccessory extends BaseAccessory {
 
         const characteristicColorTemperature = service.getCharacteristic(Characteristic.ColorTemperature)
             .setProps({
-                minValue: 0,
-                maxValue: 600
+                minValue: this.device.context.minWhiteColor,
+                maxValue: this.device.context.maxWhiteColor
             })
-            .updateValue(dps[this.dpMode] === this.cmdWhite ? this.convertColorTemperatureFromTuyaToHomeKit(dps[this.dpColorTemperature]) : 0)
+            .updateValue(dps[this.dpMode] === this.cmdWhite ? this.convertColorTemperatureFromTuyaToHomeKit(dps[this.dpColorTemperature]) : this.device.context.minWhiteColor)
             .on('get', this.getColorTemperature.bind(this))
             .on('set', this.setColorTemperature.bind(this));
 
@@ -128,10 +128,10 @@ class RGBTWLightAccessory extends BaseAccessory {
 
                         if (oldColor.s !== newColor.s) characteristicSaturation.updateValue(newColor.h);
 
-                        if (characteristicColorTemperature.value !== 0) characteristicColorTemperature.updateValue(0);
+                        if (characteristicColorTemperature.value !== this.device.context.minWhiteColor) characteristicColorTemperature.updateValue(this.device.context.minWhiteColor);
 
                     } else if (changes[this.dpMode]) {
-                        if (characteristicColorTemperature.value !== 0) characteristicColorTemperature.updateValue(0);
+                        if (characteristicColorTemperature.value !== this.device.context.minWhiteColor) characteristicColorTemperature.updateValue(this.device.context.minWhiteColor);
                     }
             }
         });
@@ -148,7 +148,7 @@ class RGBTWLightAccessory extends BaseAccessory {
     }
 
     getColorTemperature(callback) {
-        if (this.device.state[this.dpMode] !== this.cmdWhite) return callback(null, 0);
+        if (this.device.state[this.dpMode] !== this.cmdWhite) return callback(null, this.device.context.minWhiteColor);
         callback(null, this.convertColorTemperatureFromTuyaToHomeKit(this.device.state[this.dpColorTemperature]));
     }
 
@@ -160,12 +160,20 @@ class RGBTWLightAccessory extends BaseAccessory {
         this.characteristicHue.updateValue(newColor.h);
         this.characteristicSaturation.updateValue(newColor.s);
 
-        this.setMultiState({[this.dpMode]: this.cmdWhite, [this.dpColorTemperature]: this.convertColorTemperatureFromHomeKitToTuya(value)}, callback);
+        if (this.device.state[this.dpMode] !== this.cmdWhite) {
+            this.setMultiState({[this.dpMode]: this.cmdWhite, [this.dpColorTemperature]: this.convertColorTemperatureFromHomeKitToTuya(value), [this.dpBrightness]: this.convertBrightnessFromHomeKitToTuya(this.convertColorFromTuyaToHomeKit(this.device.state[this.dpColor]).b)}, callback);
+        } else {
+            this.setMultiState({[this.dpMode]: this.cmdWhite, [this.dpColorTemperature]: this.convertColorTemperatureFromHomeKitToTuya(value)}, callback);
+        }
     }
 
     getHue(callback) {
-        if (this.device.state[this.dpMode] === this.cmdWhite) return callback(null, 0);
-        callback(null, this.convertColorFromTuyaToHomeKit(this.device.state[this.dpColor]).h);
+        if (this.device.state[this.dpMode] === this.cmdWhite) {
+            const prepareHue = this.convertHomeKitColorTemperatureToHomeKitColor(this.convertColorTemperatureFromTuyaToHomeKit(this.device.state[this.dpColorTemperature]));
+            callback(null, prepareHue.h);
+        } else {
+            callback(null, this.convertColorFromTuyaToHomeKit(this.device.state[this.dpColor]).h);
+        }
     }
 
     setHue(value, callback) {
@@ -173,8 +181,12 @@ class RGBTWLightAccessory extends BaseAccessory {
     }
 
     getSaturation(callback) {
-        if (this.device.state[this.dpMode] === this.cmdWhite) return callback(null, 0);
-        callback(null, this.convertColorFromTuyaToHomeKit(this.device.state[this.dpColor]).s);
+        if (this.device.state[this.dpMode] === this.cmdWhite) {
+            const prepareSaturation = this.convertHomeKitColorTemperatureToHomeKitColor(this.convertColorTemperatureFromTuyaToHomeKit(this.device.state[this.dpColorTemperature]));
+            callback(null, prepareSaturation.s);
+        } else {
+            callback(null, this.convertColorFromTuyaToHomeKit(this.device.state[this.dpColor]).s);
+        }
     }
 
     setSaturation(value, callback) {
@@ -208,9 +220,12 @@ class RGBTWLightAccessory extends BaseAccessory {
                 } catch (ex) {}
                 next();
             }, () => {
-                this.characteristicColorTemperature.updateValue(0);
+                this.characteristicColorTemperature.updateValue(this.device.context.minWhiteColor);
             });
         };
+
+        if (this.device.state[this.dpMode] !== this.cmdColor)
+            this._pendingHueSaturation.props.b = this.convertBrightnessFromTuyaToHomeKit(this.device.state[this.dpBrightness]);
 
         const isSham = this._pendingHueSaturation.props.h === 0 && this._pendingHueSaturation.props.s === 0;
         const newValue = this.convertColorFromHomeKitToTuya(this._pendingHueSaturation.props);


### PR DESCRIPTION
https://github.com/iRayanKhan/homebridge-tuya/pull/497

Original description:
```
As @ekobres mentioned in https://github.com/iRayanKhan/homebridge-tuya/issues/357 RGBTW Color Temp Range is hardcoded to 0-600 - those commits fix this along with some other issues (like showing proper color temperature in HomeKit and syncing brightness between RGB and white modes which is expected behaviour by HomeKit)
```