### PR TITLE
Add brightness conversion for fanlight

### DIFF
--- a/lib/SimpleFanLightAccessory.js
+++ b/lib/SimpleFanLightAccessory.js
@@ -83,9 +83,11 @@ class SimpleFanLightAccessory extends BaseAccessory {
             if (changes.hasOwnProperty(this.dpLightOn) && characteristicLightOn && characteristicLightOn.value !== changes[this.dpLightOn])
                 characteristicLightOn.updateValue(changes[this.dpLightOn]);
 
-            if (changes.hasOwnProperty(this.dpBrightness) && characteristicBrightness && characteristicBrightness.value !== changes[this.dpBrightness])
-                characteristicBrightness.updateValue(changes[this.dpBrightness]);
-
+            if (changes.hasOwnProperty(this.dpBrightness) && characteristicBrightness && cha
+racteristicBrightness.value !== changes[this.dpBrightness])
+                characteristicBrightness.updateValue(this.convertBrightnessFromTuyaToHomeKit
+(changes[this.dpBrightness]));
+                
             this.log.debug('SimpleFanLight changed: ' + JSON.stringify(state));
         });
     }
@@ -182,23 +184,14 @@ class SimpleFanLightAccessory extends BaseAccessory {
         callback();
     }
 
-    //Lightbulb Brightness
     getBrightness(callback) {
-        this.getState(this.dpBrightness, (err, dp) => {
-            if (err) return callback(err);
-            callback(null, this._getBrightness(dp));
-        });
-    }
-
-    _getBrightness(dp) {
-        const {Characteristic} = this.hap;
-        return dp;
+        callback(null, this.convertBrightnessFromTuyaToHomeKit(this.device.state[this.dpBrig
+htness]));
     }
 
     setBrightness(value, callback) {
-        const {Characteristic} = this.hap;
-        return this.setState(this.dpBrightness, value, callback);
-        callback();
+        this.setState(this.dpBrightness, this.convertBrightnessFromHomeKitToTuya(value), cal
+lback);
     }
 }
 

--- a/lib/SimpleFanLightAccessory.js
+++ b/lib/SimpleFanLightAccessory.js
@@ -63,8 +63,8 @@ class SimpleFanLightAccessory extends BaseAccessory {
                 characteristicBrightness = serviceLightbulb.getCharacteristic(Characteristic.Brightness)
                     .setProps({
                         minValue: 0,
-                        maxValue: 1000,
-                        minStep: 100
+                        maxValue: 100,
+                        minStep: 1
                     })
                     .updateValue(this.convertBrightnessFromTuyaToHomeKit(dps[this.dpBrightness]))
                     .on('get', this.getBrightness.bind(this))


### PR DESCRIPTION
https://github.com/iRayanKhan/homebridge-tuya/pull/500

Original description:
```
Fixes https://github.com/iRayanKhan/homebridge-tuya/issues/480 by adding an conversion between Tuya brightness values (on my device, 0-1000; on some others 0-255) and HomeKit (0-100) as is done in the SimpleDimmerAccessory.

Requires adding similar config parameters to SimpleDimmerAccessory, i.e:

{
                    "type": "FanLight",
                    "useBrightness": true,
                    "minBrightness": 10,
                    "scaleBrightness": 1000,
                    "maxSpeed": 3,
                    "dpActive": 60,
                    "dpRotationSpeed": 62,
                    "dpLightOn": 20,
                    "dpBrightness": 22
                }
```                