### PR TITLE
Fix incorrect CurrentTemperature parameter

### DIFF
--- a/lib/AirConditionerAccessory.js
+++ b/lib/AirConditionerAccessory.js
@@ -55,7 +55,7 @@ class AirConditionerAccessory extends BaseAccessory {
         const {Service, Characteristic} = this.hap;
         const service = this.accessory.getService(Service.HeaterCooler);
         this._checkServiceName(service, this.device.context.name);
-        
+
         this.dpActive = this._getCustomDP(this.device.context.dpActive) || '1';
         this.dpThreshold = this._getCustomDP(this.device.context.dpThreshold) || '2';
         this.dpCurrentTemperature = this._getCustomDP(this.device.context.dpCurrentTemperature) || '3';
@@ -64,7 +64,7 @@ class AirConditionerAccessory extends BaseAccessory {
         this.dpChildLock = this._getCustomDP(this.device.context.dpChildLock) || '6';
         this.dpTempUnits = this._getCustomDP(this.device.context.dpTempUnits) || '19';
         this.dpSwingMode = this._getCustomDP(this.device.context.dpSwingMode) || '104';
-        
+
         const characteristicActive = service.getCharacteristic(Characteristic.Active)
             .updateValue(this._getActive(this.dpActive))
             .on('get', this.getActive.bind(this))
@@ -89,8 +89,8 @@ class AirConditionerAccessory extends BaseAccessory {
             .on('set', this.setTargetHeaterCoolerState.bind(this));
 
         const characteristicCurrentTemperature = service.getCharacteristic(Characteristic.CurrentTemperature)
-            .updateValue(dps[this.dpSwingMode])
-            .on('get', this.getState.bind(this, this.dpSwingMode));
+            .updateValue(dps[this.dpCurrentTemperature])
+            .on('get', this.getState.bind(this, this.dpCurrentTemperature));
 
         let characteristicSwingMode;
         if (!this.device.context.noSwing) {


### PR DESCRIPTION
https://github.com/iRayanKhan/homebridge-tuya/pull/504

Original description:
```
Related to https://github.com/iRayanKhan/homebridge-tuya/issues/502

[homebridge-tuya/lib/AirConditionerAccessory.js](https://github.com/iRayanKhan/homebridge-tuya/blob/78feb4ca97f7b876da5b2006337d3dbccab1aa3d/lib/AirConditionerAccessory.js#L91-L93)
Lines 91 to 93 in [78feb4c](https://github.com/iRayanKhan/homebridge-tuya/commit/78feb4ca97f7b876da5b2006337d3dbccab1aa3d)
 const characteristicCurrentTemperature = service.getCharacteristic(Characteristic.CurrentTemperature) 
     .updateValue(dps[this.dpSwingMode]) 
     .on('get', this.getState.bind(this, this.dpSwingMode)); 
I fixed incorrect parameter and after that CurrentTemperature works well

I guess it was a typo

[TESTED]
```