### PR TITLE
Add support for Vertical Blinds with Tilt Control

### DIFF
--- a/Readme.MD
+++ b/Readme.MD
@@ -44,6 +44,7 @@ A community-maintained Homebridge plugin for controlling Tuya devices locally ov
 * Oil Diffusers<sup>[13](https://github.com/adrianjagielak/homebridge-tuya-plus/blob/main/wiki/Supported-Device-Types.md)</sup>
 * Outlets<sup>[14](https://github.com/adrianjagielak/homebridge-tuya-plus/blob/main/wiki/Supported-Device-Types.md#outlets)</sup>
 * Switches<sup>[15](https://github.com/adrianjagielak/homebridge-tuya-plus/blob/main/wiki/Supported-Device-Types.md)</sup>
+* Vertical Blinds<sup>[16](https://github.com/adrianjagielak/homebridge-tuya-plus/blob/main/wiki/Supported-Device-Types.md#vertical-blinds-with-tilt)</sup>
 
 Note: Motion, and other sensor types don't behave well with responce requests, so they will not be added. 
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -79,6 +79,10 @@
                   "enum": ["SimpleBlinds"]
                 },
                 {
+                  "title": "Vertical Blinds with Tilt",
+                  "enum": ["VerticalBlindsWithTilt"]
+                },
+                {
                   "title": "Smart Plug w/ White and Color Lights",
                   "enum": ["RGBTWOutlet"]
                 },
@@ -496,6 +500,14 @@
               "placeholder": "0",
               "condition": {
                 "functionBody": "return model.devices && model.devices[arrayIndices] && ['SimpleBlinds'].includes(model.devices[arrayIndices].type);"
+              }
+            },
+            "timeToClose": {
+              "type": "integer",
+              "placeholder": "30",
+              "description": "Time in seconds for blinds to fully open or close",
+              "condition": {
+                "functionBody": "return model.devices && model.devices[arrayIndices] && ['VerticalBlindsWithTilt'].includes(model.devices[arrayIndices].type);"
               }
             },
             "dpLight": {

--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ const SwitchAccessory = require('./lib/SwitchAccessory');
 const ValveAccessory = require('./lib/ValveAccessory');
 const OilDiffuserAccessory = require('./lib/OilDiffuserAccessory');
 const DoorbellAccessory = require('./lib/DoorbellAccessory');
+const VerticalBlindsWithTilt = require('./lib/VerticalBlindsWithTilt');
 
 const PLUGIN_NAME = 'homebridge-tuya';
 const PLATFORM_NAME = 'TuyaLan';
@@ -50,7 +51,8 @@ const CLASS_DEF = {
     fanlight: SimpleFanLightAccessory,
     watervalve: ValveAccessory,
     oildiffuser: OilDiffuserAccessory,
-    doorbell: DoorbellAccessory
+    doorbell: DoorbellAccessory,
+    verticalblindswithtilt: VerticalBlindsWithTilt
 };
 
 let Characteristic, PlatformAccessory, Service, Categories, AdaptiveLightingController, UUID;

--- a/lib/VerticalBlindsWithTilt.js
+++ b/lib/VerticalBlindsWithTilt.js
@@ -162,10 +162,37 @@ class VerticalBlindsWithTilt extends BaseAccessory {
             
             // Actually need to open - reset close time and cancel any pending tilts
             this.log('[TuyaAccessory] Opening blinds');
-            this._cancelPendingTilts();
+            
+            // Check if a tilt command was sent during previous movement
+            if (this.lastTiltCommand && (Date.now() - this.lastTiltCommand.time < this.timeToClose * 1000)) {
+                this.log('[TuyaAccessory] Open command received while tilt was pending - rescheduling tilt delay');
+                
+                // Cancel the buffer timeout if it exists
+                if (this.tiltBufferTimeout) {
+                    clearTimeout(this.tiltBufferTimeout);
+                    this.tiltBufferTimeout = null;
+                }
+                
+                // Cancel any existing delay
+                if (this.tiltDelayTimeout) {
+                    clearTimeout(this.tiltDelayTimeout);
+                }
+                
+                // Schedule the tilt for after open completes
+                const delayMs = this.timeToClose * 1000;
+                this.tiltDelayTimeout = setTimeout(() => {
+                    this.log('[TuyaAccessory] Executing delayed tilt angle:', this.lastTiltCommand.angle, '-> Tuya percent_control:', this.lastTiltCommand.value);
+                    this._executeTilt(this.lastTiltCommand.value);
+                    this.tiltDelayTimeout = null;
+                    this.lastTiltCommand = null;
+                }, delayMs);
+            } else {
+                this._cancelPendingTilts();
+                this.lastTiltCommand = null;
+            }
+            
             this.lastCloseTime = 0;
             this.lastOpenTime = Date.now();
-            this.lastTiltCommand = null;
             
             // Set target position to 100, but don't update current position yet
             this.characteristicTargetPosition.updateValue(100);
@@ -190,10 +217,37 @@ class VerticalBlindsWithTilt extends BaseAccessory {
         } else {
             // For partial positions, open fully then user can adjust manually
             this.log('[TuyaAccessory] Partial position requested, opening fully');
-            this._cancelPendingTilts();
+            
+            // Check if a tilt command was sent during previous movement
+            if (this.lastTiltCommand && (Date.now() - this.lastTiltCommand.time < this.timeToClose * 1000)) {
+                this.log('[TuyaAccessory] Partial open command received while tilt was pending - rescheduling tilt delay');
+                
+                // Cancel the buffer timeout if it exists
+                if (this.tiltBufferTimeout) {
+                    clearTimeout(this.tiltBufferTimeout);
+                    this.tiltBufferTimeout = null;
+                }
+                
+                // Cancel any existing delay
+                if (this.tiltDelayTimeout) {
+                    clearTimeout(this.tiltDelayTimeout);
+                }
+                
+                // Schedule the tilt for after open completes
+                const delayMs = this.timeToClose * 1000;
+                this.tiltDelayTimeout = setTimeout(() => {
+                    this.log('[TuyaAccessory] Executing delayed tilt angle:', this.lastTiltCommand.angle, '-> Tuya percent_control:', this.lastTiltCommand.value);
+                    this._executeTilt(this.lastTiltCommand.value);
+                    this.tiltDelayTimeout = null;
+                    this.lastTiltCommand = null;
+                }, delayMs);
+            } else {
+                this._cancelPendingTilts();
+                this.lastTiltCommand = null;
+            }
+            
             this.lastCloseTime = 0;
             this.lastOpenTime = Date.now();
-            this.lastTiltCommand = null;
             
             // Set target position to 100, but don't update current position yet
             this.characteristicTargetPosition.updateValue(100);
@@ -252,14 +306,20 @@ class VerticalBlindsWithTilt extends BaseAccessory {
             time: Date.now()
         };
         
-        // Check if a close command was sent during the closing duration
+        // Check if a close OR open command was sent during the movement duration
         const timeSinceClose = Date.now() - this.lastCloseTime;
-        const shouldDelay = this.lastCloseTime > 0 && timeSinceClose < (this.timeToClose * 1000);
+        const timeSinceOpen = Date.now() - this.lastOpenTime;
+        const shouldDelayForClose = this.lastCloseTime > 0 && timeSinceClose < (this.timeToClose * 1000);
+        const shouldDelayForOpen = this.lastOpenTime > 0 && timeSinceOpen < (this.timeToClose * 1000);
+        const shouldDelay = shouldDelayForClose || shouldDelayForOpen;
         
         if (shouldDelay) {
-            // Delay the tilt command until after blinds finish closing
-            const delayMs = (this.timeToClose * 1000) - timeSinceClose;
-            this.log('[TuyaAccessory] Tilt command received shortly after close - delaying by', Math.round(delayMs / 1000), 'seconds');
+            // Delay the tilt command until after blinds finish closing/opening
+            const delayMs = shouldDelayForClose 
+                ? (this.timeToClose * 1000) - timeSinceClose
+                : (this.timeToClose * 1000) - timeSinceOpen;
+            const action = shouldDelayForClose ? 'close' : 'open';
+            this.log('[TuyaAccessory] Tilt command received during', action, '- delaying by', Math.round(delayMs / 1000), 'seconds');
             
             // Cancel any existing delayed tilt
             this._cancelPendingTilts();
@@ -270,6 +330,7 @@ class VerticalBlindsWithTilt extends BaseAccessory {
                 this._executeTilt(clampedValue);
                 this.tiltDelayTimeout = null;
                 this.lastCloseTime = 0;
+                this.lastOpenTime = 0;
                 this.lastTiltCommand = null;
             }, delayMs);
             
@@ -287,12 +348,17 @@ class VerticalBlindsWithTilt extends BaseAccessory {
             }
             
             this.tiltBufferTimeout = setTimeout(() => {
-                // Check again if close command arrived during the buffer
-                if (this.lastCloseTime > 0 && (Date.now() - this.lastCloseTime < (this.timeToClose * 1000))) {
-                    this.log('[TuyaAccessory] Close command arrived during tilt buffer - extending delay');
+                // Check again if close or open command arrived during the buffer
+                const currentTimeSinceClose = Date.now() - this.lastCloseTime;
+                const currentTimeSinceOpen = Date.now() - this.lastOpenTime;
+                const closeInProgress = this.lastCloseTime > 0 && currentTimeSinceClose < (this.timeToClose * 1000);
+                const openInProgress = this.lastOpenTime > 0 && currentTimeSinceOpen < (this.timeToClose * 1000);
+                
+                if (closeInProgress || openInProgress) {
+                    this.log('[TuyaAccessory] Movement command arrived during tilt buffer - extending delay');
                     // The setPosition method will handle rescheduling
                 } else {
-                    // No close command, execute tilt normally
+                    // No movement command, execute tilt normally
                     this._executeTilt(clampedValue);
                     this.lastTiltCommand = null;
                 }

--- a/lib/VerticalBlindsWithTilt.js
+++ b/lib/VerticalBlindsWithTilt.js
@@ -160,11 +160,24 @@ class VerticalBlindsWithTilt extends BaseAccessory {
             this.log('[TuyaAccessory] Opening blinds');
             this._cancelPendingTilts();
             this.lastCloseTime = 0;
+            this.lastOpenTime = Date.now();
             this.lastTiltCommand = null;
             this.currentPosition = 100;
             this.accessory.context.cachedPosition = 100; // Persist across restarts
             this.characteristicCurrentPosition.updateValue(100);
             this.characteristicPositionState.updateValue(Characteristic.PositionState.INCREASING);
+            
+            // Set timeout to mark as stopped after opening completes
+            if (this.positionStateTimeout) {
+                clearTimeout(this.positionStateTimeout);
+            }
+            this.positionStateTimeout = setTimeout(() => {
+                this.log('[TuyaAccessory] Blinds finished opening');
+                this.characteristicPositionState.updateValue(Characteristic.PositionState.STOPPED);
+                this.lastOpenTime = 0;
+                this.positionStateTimeout = null;
+            }, this.timeToClose * 1000);
+            
             return this.setState(this.dpAction, 'open', callback);
             
         } else {
@@ -172,10 +185,24 @@ class VerticalBlindsWithTilt extends BaseAccessory {
             this.log('[TuyaAccessory] Partial position requested, opening fully');
             this._cancelPendingTilts();
             this.lastCloseTime = 0;
+            this.lastOpenTime = Date.now();
             this.lastTiltCommand = null;
             this.currentPosition = 100;
             this.accessory.context.cachedPosition = 100; // Persist across restarts
             this.characteristicCurrentPosition.updateValue(100);
+            this.characteristicPositionState.updateValue(Characteristic.PositionState.INCREASING);
+            
+            // Set timeout to mark as stopped after opening completes
+            if (this.positionStateTimeout) {
+                clearTimeout(this.positionStateTimeout);
+            }
+            this.positionStateTimeout = setTimeout(() => {
+                this.log('[TuyaAccessory] Blinds finished opening');
+                this.characteristicPositionState.updateValue(Characteristic.PositionState.STOPPED);
+                this.lastOpenTime = 0;
+                this.positionStateTimeout = null;
+            }, this.timeToClose * 1000);
+            
             return this.setState(this.dpAction, 'open', callback);
         }
     }
@@ -215,9 +242,9 @@ class VerticalBlindsWithTilt extends BaseAccessory {
             time: Date.now()
         };
         
-        // Check if a close command was sent recently (within 3 seconds)
+        // Check if a close command was sent during the closing duration
         const timeSinceClose = Date.now() - this.lastCloseTime;
-        const shouldDelay = this.lastCloseTime > 0 && timeSinceClose < 3000;
+        const shouldDelay = this.lastCloseTime > 0 && timeSinceClose < (this.timeToClose * 1000);
         
         if (shouldDelay) {
             // Delay the tilt command until after blinds finish closing
@@ -251,7 +278,7 @@ class VerticalBlindsWithTilt extends BaseAccessory {
             
             this.tiltBufferTimeout = setTimeout(() => {
                 // Check again if close command arrived during the buffer
-                if (this.lastCloseTime > 0 && (Date.now() - this.lastCloseTime < 3000)) {
+                if (this.lastCloseTime > 0 && (Date.now() - this.lastCloseTime < (this.timeToClose * 1000))) {
                     this.log('[TuyaAccessory] Close command arrived during tilt buffer - extending delay');
                     // The setPosition method will handle rescheduling
                 } else {

--- a/lib/VerticalBlindsWithTilt.js
+++ b/lib/VerticalBlindsWithTilt.js
@@ -20,6 +20,8 @@ class VerticalBlindsWithTilt extends BaseAccessory {
         const {Service} = this.hap;
 
         this.accessory.addService(Service.WindowCovering, this.device.context.name);
+
+        super._registerPlatformAccessory();
     }
 
     _registerCharacteristics(dps) {
@@ -160,11 +162,24 @@ class VerticalBlindsWithTilt extends BaseAccessory {
             this.log('[TuyaAccessory] Opening blinds');
             this._cancelPendingTilts();
             this.lastCloseTime = 0;
+            this.lastOpenTime = Date.now();
             this.lastTiltCommand = null;
             this.currentPosition = 100;
             this.accessory.context.cachedPosition = 100; // Persist across restarts
             this.characteristicCurrentPosition.updateValue(100);
             this.characteristicPositionState.updateValue(Characteristic.PositionState.INCREASING);
+            
+            // Set timeout to mark as stopped after opening completes
+            if (this.positionStateTimeout) {
+                clearTimeout(this.positionStateTimeout);
+            }
+            this.positionStateTimeout = setTimeout(() => {
+                this.log('[TuyaAccessory] Blinds finished opening');
+                this.characteristicPositionState.updateValue(Characteristic.PositionState.STOPPED);
+                this.lastOpenTime = 0;
+                this.positionStateTimeout = null;
+            }, this.timeToClose * 1000);
+            
             return this.setState(this.dpAction, 'open', callback);
             
         } else {
@@ -172,10 +187,24 @@ class VerticalBlindsWithTilt extends BaseAccessory {
             this.log('[TuyaAccessory] Partial position requested, opening fully');
             this._cancelPendingTilts();
             this.lastCloseTime = 0;
+            this.lastOpenTime = Date.now();
             this.lastTiltCommand = null;
             this.currentPosition = 100;
             this.accessory.context.cachedPosition = 100; // Persist across restarts
             this.characteristicCurrentPosition.updateValue(100);
+            this.characteristicPositionState.updateValue(Characteristic.PositionState.INCREASING);
+            
+            // Set timeout to mark as stopped after opening completes
+            if (this.positionStateTimeout) {
+                clearTimeout(this.positionStateTimeout);
+            }
+            this.positionStateTimeout = setTimeout(() => {
+                this.log('[TuyaAccessory] Blinds finished opening');
+                this.characteristicPositionState.updateValue(Characteristic.PositionState.STOPPED);
+                this.lastOpenTime = 0;
+                this.positionStateTimeout = null;
+            }, this.timeToClose * 1000);
+            
             return this.setState(this.dpAction, 'open', callback);
         }
     }
@@ -215,9 +244,9 @@ class VerticalBlindsWithTilt extends BaseAccessory {
             time: Date.now()
         };
         
-        // Check if a close command was sent recently (within 3 seconds)
+        // Check if a close command was sent during the closing duration
         const timeSinceClose = Date.now() - this.lastCloseTime;
-        const shouldDelay = this.lastCloseTime > 0 && timeSinceClose < 3000;
+        const shouldDelay = this.lastCloseTime > 0 && timeSinceClose < (this.timeToClose * 1000);
         
         if (shouldDelay) {
             // Delay the tilt command until after blinds finish closing
@@ -251,7 +280,7 @@ class VerticalBlindsWithTilt extends BaseAccessory {
             
             this.tiltBufferTimeout = setTimeout(() => {
                 // Check again if close command arrived during the buffer
-                if (this.lastCloseTime > 0 && (Date.now() - this.lastCloseTime < 3000)) {
+                if (this.lastCloseTime > 0 && (Date.now() - this.lastCloseTime < (this.timeToClose * 1000))) {
                     this.log('[TuyaAccessory] Close command arrived during tilt buffer - extending delay');
                     // The setPosition method will handle rescheduling
                 } else {

--- a/lib/VerticalBlindsWithTilt.js
+++ b/lib/VerticalBlindsWithTilt.js
@@ -132,9 +132,8 @@ class VerticalBlindsWithTilt extends BaseAccessory {
                 }, delayMs);
             }
             
-            this.currentPosition = 0;
-            this.accessory.context.cachedPosition = 0; // Persist across restarts
-            this.characteristicCurrentPosition.updateValue(0);
+            // Set target position to 0, but don't update current position yet
+            this.characteristicTargetPosition.updateValue(0);
             this.characteristicPositionState.updateValue(Characteristic.PositionState.DECREASING);
             
             // Set timeout to mark as stopped after closing completes
@@ -143,6 +142,9 @@ class VerticalBlindsWithTilt extends BaseAccessory {
             }
             this.positionStateTimeout = setTimeout(() => {
                 this.log('[TuyaAccessory] Blinds finished closing');
+                this.currentPosition = 0;
+                this.accessory.context.cachedPosition = 0; // Persist across restarts
+                this.characteristicCurrentPosition.updateValue(0);
                 this.characteristicPositionState.updateValue(Characteristic.PositionState.STOPPED);
                 this.isMoving = false;
                 this.lastCloseTime = 0;
@@ -164,9 +166,9 @@ class VerticalBlindsWithTilt extends BaseAccessory {
             this.lastCloseTime = 0;
             this.lastOpenTime = Date.now();
             this.lastTiltCommand = null;
-            this.currentPosition = 100;
-            this.accessory.context.cachedPosition = 100; // Persist across restarts
-            this.characteristicCurrentPosition.updateValue(100);
+            
+            // Set target position to 100, but don't update current position yet
+            this.characteristicTargetPosition.updateValue(100);
             this.characteristicPositionState.updateValue(Characteristic.PositionState.INCREASING);
             
             // Set timeout to mark as stopped after opening completes
@@ -175,6 +177,9 @@ class VerticalBlindsWithTilt extends BaseAccessory {
             }
             this.positionStateTimeout = setTimeout(() => {
                 this.log('[TuyaAccessory] Blinds finished opening');
+                this.currentPosition = 100;
+                this.accessory.context.cachedPosition = 100; // Persist across restarts
+                this.characteristicCurrentPosition.updateValue(100);
                 this.characteristicPositionState.updateValue(Characteristic.PositionState.STOPPED);
                 this.lastOpenTime = 0;
                 this.positionStateTimeout = null;
@@ -189,9 +194,9 @@ class VerticalBlindsWithTilt extends BaseAccessory {
             this.lastCloseTime = 0;
             this.lastOpenTime = Date.now();
             this.lastTiltCommand = null;
-            this.currentPosition = 100;
-            this.accessory.context.cachedPosition = 100; // Persist across restarts
-            this.characteristicCurrentPosition.updateValue(100);
+            
+            // Set target position to 100, but don't update current position yet
+            this.characteristicTargetPosition.updateValue(100);
             this.characteristicPositionState.updateValue(Characteristic.PositionState.INCREASING);
             
             // Set timeout to mark as stopped after opening completes
@@ -200,6 +205,9 @@ class VerticalBlindsWithTilt extends BaseAccessory {
             }
             this.positionStateTimeout = setTimeout(() => {
                 this.log('[TuyaAccessory] Blinds finished opening');
+                this.currentPosition = 100;
+                this.accessory.context.cachedPosition = 100; // Persist across restarts
+                this.characteristicCurrentPosition.updateValue(100);
                 this.characteristicPositionState.updateValue(Characteristic.PositionState.STOPPED);
                 this.lastOpenTime = 0;
                 this.positionStateTimeout = null;

--- a/lib/VerticalBlindsWithTilt.js
+++ b/lib/VerticalBlindsWithTilt.js
@@ -8,9 +8,12 @@ class VerticalBlindsWithTilt extends BaseAccessory {
     constructor(...props) {
         super(...props);
         this.lastCloseTime = 0;
+        this.lastOpenTime = 0;
         this.lastTiltCommand = null;
         this.tiltBufferTimeout = null;
         this.tiltDelayTimeout = null;
+        this.positionStateTimeout = null; // For tracking when movement completes
+        this.isMoving = false; // Track if blinds are currently moving
     }
 
     _registerPlatformAccessory() {
@@ -69,10 +72,15 @@ class VerticalBlindsWithTilt extends BaseAccessory {
 
     // Position methods
     _getInitialPosition(dps) {
-        // The device doesn't report control or work_state in local protocol
-        // We can only track position based on commands we send
-        // Default to open (100%) - it will update correctly once user interacts
-        this.log('[TuyaAccessory] Initial position unknown (device does not report position state), defaulting to open (100%)');
+        // Try to restore last known position from persistent cache
+        // This survives Homebridge restarts
+        if (this.accessory.context.cachedPosition !== undefined) {
+            this.log('[TuyaAccessory] Restored position from cache:', this.accessory.context.cachedPosition + '%');
+            return this.accessory.context.cachedPosition;
+        }
+        
+        // First time setup - default to open
+        this.log('[TuyaAccessory] Initial position unknown (first time setup), defaulting to open (100%)');
         return 100;
     }
 
@@ -85,14 +93,21 @@ class VerticalBlindsWithTilt extends BaseAccessory {
         const {Characteristic} = this.hap;
         
         if (value === 0) {
-            // Close blinds - track the time for tilt delay logic
+            // Close blinds - but skip if already closed
+            if (this.currentPosition === 0) {
+                this.log('[TuyaAccessory] Blinds already closed, skipping close command');
+                // Still allow tilt commands to proceed without delay
+                return callback && callback(null);
+            }
+            
+            // Actually need to close - track the time and set moving state
             this.log('[TuyaAccessory] Closing blinds');
             this.lastCloseTime = Date.now();
+            this.isMoving = true;
             
-            // Check if a tilt command was just sent (within 3 seconds)
-            // If so, we need to delay that tilt until after close completes
-            if (this.lastTiltCommand && (Date.now() - this.lastTiltCommand.time < 3000)) {
-                this.log('[TuyaAccessory] Close command received shortly after tilt - rescheduling tilt delay');
+            // Check if a tilt command was sent during previous movement
+            if (this.lastTiltCommand && (Date.now() - this.lastTiltCommand.time < this.timeToClose * 1000)) {
+                this.log('[TuyaAccessory] Close command received while tilt was pending - rescheduling tilt delay');
                 
                 // Cancel the buffer timeout if it exists
                 if (this.tiltBufferTimeout) {
@@ -112,22 +127,42 @@ class VerticalBlindsWithTilt extends BaseAccessory {
                     this._executeTilt(this.lastTiltCommand.value);
                     this.tiltDelayTimeout = null;
                     this.lastTiltCommand = null;
-                    this.lastCloseTime = 0;
                 }, delayMs);
             }
             
             this.currentPosition = 0;
+            this.accessory.context.cachedPosition = 0; // Persist across restarts
             this.characteristicCurrentPosition.updateValue(0);
             this.characteristicPositionState.updateValue(Characteristic.PositionState.DECREASING);
+            
+            // Set timeout to mark as stopped after closing completes
+            if (this.positionStateTimeout) {
+                clearTimeout(this.positionStateTimeout);
+            }
+            this.positionStateTimeout = setTimeout(() => {
+                this.log('[TuyaAccessory] Blinds finished closing');
+                this.characteristicPositionState.updateValue(Characteristic.PositionState.STOPPED);
+                this.isMoving = false;
+                this.lastCloseTime = 0;
+                this.positionStateTimeout = null;
+            }, this.timeToClose * 1000);
+            
             return this.setState(this.dpAction, 'close', callback);
             
         } else if (value === 100) {
-            // Open blinds - reset close time and cancel any pending tilts
+            // Open blinds - but skip if already open
+            if (this.currentPosition === 100) {
+                this.log('[TuyaAccessory] Blinds already open, skipping open command');
+                return callback && callback(null);
+            }
+            
+            // Actually need to open - reset close time and cancel any pending tilts
             this.log('[TuyaAccessory] Opening blinds');
             this._cancelPendingTilts();
             this.lastCloseTime = 0;
             this.lastTiltCommand = null;
             this.currentPosition = 100;
+            this.accessory.context.cachedPosition = 100; // Persist across restarts
             this.characteristicCurrentPosition.updateValue(100);
             this.characteristicPositionState.updateValue(Characteristic.PositionState.INCREASING);
             return this.setState(this.dpAction, 'open', callback);
@@ -139,6 +174,7 @@ class VerticalBlindsWithTilt extends BaseAccessory {
             this.lastCloseTime = 0;
             this.lastTiltCommand = null;
             this.currentPosition = 100;
+            this.accessory.context.cachedPosition = 100; // Persist across restarts
             this.characteristicCurrentPosition.updateValue(100);
             return this.setState(this.dpAction, 'open', callback);
         }
@@ -272,11 +308,13 @@ class VerticalBlindsWithTilt extends BaseAccessory {
             
             if (action === 'open') {
                 this.currentPosition = 100;
+                this.accessory.context.cachedPosition = 100; // Persist across restarts
                 this.characteristicCurrentPosition.updateValue(100);
                 this.characteristicTargetPosition.updateValue(100);
                 this.characteristicPositionState.updateValue(Characteristic.PositionState.INCREASING);
             } else if (action === 'close') {
                 this.currentPosition = 0;
+                this.accessory.context.cachedPosition = 0; // Persist across restarts
                 this.characteristicCurrentPosition.updateValue(0);
                 this.characteristicTargetPosition.updateValue(0);
                 this.characteristicPositionState.updateValue(Characteristic.PositionState.DECREASING);

--- a/lib/VerticalBlindsWithTilt.js
+++ b/lib/VerticalBlindsWithTilt.js
@@ -1,0 +1,290 @@
+const BaseAccessory = require('./BaseAccessory');
+
+class VerticalBlindsWithTilt extends BaseAccessory {
+    static getCategory(Categories) {
+        return Categories.WINDOW_COVERING;
+    }
+
+    constructor(...props) {
+        super(...props);
+        this.lastCloseTime = 0;
+        this.lastTiltCommand = null;
+        this.tiltBufferTimeout = null;
+        this.tiltDelayTimeout = null;
+    }
+
+    _registerPlatformAccessory() {
+        const {Service} = this.hap;
+
+        this.accessory.addService(Service.WindowCovering, this.device.context.name);
+    }
+
+    _registerCharacteristics(dps) {
+        const {Service, Characteristic} = this.hap;
+        const service = this.accessory.getService(Service.WindowCovering);
+        this._checkServiceName(service, this.device.context.name);
+
+        // dp_id 1: control (open/close/stop) - for vertical position
+        // dp_id 2: percent_control - for rotation/tilt control
+        // dp_id 3: percent_state - read-only tilt status
+        this.dpAction = this._getCustomDP(this.device.context.dpAction) || '1';
+        this.dpTilt = this._getCustomDP(this.device.context.dpTilt) || '2';
+        this.dpTiltState = this._getCustomDP(this.device.context.dpTiltState) || '3';
+        
+        // Time in seconds for blinds to fully close/extend (default: 30 seconds)
+        this.timeToClose = this.device.context.timeToClose || 30;
+        
+        // Initialize position based on device state
+        this.currentPosition = this._getInitialPosition(dps);
+        
+        const characteristicCurrentPosition = service.getCharacteristic(Characteristic.CurrentPosition)
+            .updateValue(this.currentPosition)
+            .on('get', this.getPosition.bind(this));
+
+        const characteristicTargetPosition = service.getCharacteristic(Characteristic.TargetPosition)
+            .updateValue(this.currentPosition)
+            .on('get', this.getPosition.bind(this))
+            .on('set', this.setPosition.bind(this));
+
+        const characteristicPositionState = service.getCharacteristic(Characteristic.PositionState)
+            .updateValue(Characteristic.PositionState.STOPPED)
+            .on('get', this.getPositionState.bind(this));
+
+        // Add tilt angle support - use percent_state for reading, percent_control for writing
+        const characteristicCurrentHorizontalTilt = service.getCharacteristic(Characteristic.CurrentHorizontalTiltAngle)
+            .updateValue(this._getTiltAngle(dps[this.dpTiltState] || dps[this.dpTilt]))
+            .on('get', this.getTiltAngle.bind(this));
+
+        const characteristicTargetHorizontalTilt = service.getCharacteristic(Characteristic.TargetHorizontalTiltAngle)
+            .updateValue(this._getTiltAngle(dps[this.dpTiltState] || dps[this.dpTilt]))
+            .on('get', this.getTiltAngle.bind(this))
+            .on('set', this.setTiltAngle.bind(this));
+
+        this.characteristicCurrentPosition = characteristicCurrentPosition;
+        this.characteristicTargetPosition = characteristicTargetPosition;
+        this.characteristicPositionState = characteristicPositionState;
+        this.characteristicCurrentHorizontalTilt = characteristicCurrentHorizontalTilt;
+        this.characteristicTargetHorizontalTilt = characteristicTargetHorizontalTilt;
+    }
+
+    // Position methods
+    _getInitialPosition(dps) {
+        // The device doesn't report control or work_state in local protocol
+        // We can only track position based on commands we send
+        // Default to open (100%) - it will update correctly once user interacts
+        this.log('[TuyaAccessory] Initial position unknown (device does not report position state), defaulting to open (100%)');
+        return 100;
+    }
+
+    getPosition(callback) {
+        // Since there's no position percentage, return tracked position
+        callback(null, this.currentPosition);
+    }
+
+    setPosition(value, callback) {
+        const {Characteristic} = this.hap;
+        
+        if (value === 0) {
+            // Close blinds - track the time for tilt delay logic
+            this.log('[TuyaAccessory] Closing blinds');
+            this.lastCloseTime = Date.now();
+            
+            // Check if a tilt command was just sent (within 3 seconds)
+            // If so, we need to delay that tilt until after close completes
+            if (this.lastTiltCommand && (Date.now() - this.lastTiltCommand.time < 3000)) {
+                this.log('[TuyaAccessory] Close command received shortly after tilt - rescheduling tilt delay');
+                
+                // Cancel the buffer timeout if it exists
+                if (this.tiltBufferTimeout) {
+                    clearTimeout(this.tiltBufferTimeout);
+                    this.tiltBufferTimeout = null;
+                }
+                
+                // Cancel any existing delay
+                if (this.tiltDelayTimeout) {
+                    clearTimeout(this.tiltDelayTimeout);
+                }
+                
+                // Schedule the tilt for after close completes
+                const delayMs = this.timeToClose * 1000;
+                this.tiltDelayTimeout = setTimeout(() => {
+                    this.log('[TuyaAccessory] Executing delayed tilt angle:', this.lastTiltCommand.angle, '-> Tuya percent_control:', this.lastTiltCommand.value);
+                    this._executeTilt(this.lastTiltCommand.value);
+                    this.tiltDelayTimeout = null;
+                    this.lastTiltCommand = null;
+                    this.lastCloseTime = 0;
+                }, delayMs);
+            }
+            
+            this.currentPosition = 0;
+            this.characteristicCurrentPosition.updateValue(0);
+            this.characteristicPositionState.updateValue(Characteristic.PositionState.DECREASING);
+            return this.setState(this.dpAction, 'close', callback);
+            
+        } else if (value === 100) {
+            // Open blinds - reset close time and cancel any pending tilts
+            this.log('[TuyaAccessory] Opening blinds');
+            this._cancelPendingTilts();
+            this.lastCloseTime = 0;
+            this.lastTiltCommand = null;
+            this.currentPosition = 100;
+            this.characteristicCurrentPosition.updateValue(100);
+            this.characteristicPositionState.updateValue(Characteristic.PositionState.INCREASING);
+            return this.setState(this.dpAction, 'open', callback);
+            
+        } else {
+            // For partial positions, open fully then user can adjust manually
+            this.log('[TuyaAccessory] Partial position requested, opening fully');
+            this._cancelPendingTilts();
+            this.lastCloseTime = 0;
+            this.lastTiltCommand = null;
+            this.currentPosition = 100;
+            this.characteristicCurrentPosition.updateValue(100);
+            return this.setState(this.dpAction, 'open', callback);
+        }
+    }
+
+    getPositionState(callback) {
+        const {Characteristic} = this.hap;
+        return callback(null, Characteristic.PositionState.STOPPED);
+    }
+
+    // Tilt angle methods
+    getTiltAngle(callback) {
+        // Read from percent_state (dp_id 3)
+        this.getState([this.dpTiltState], (err, dps) => {
+            if (err) return callback(err);
+            callback(null, this._getTiltAngle(dps[this.dpTiltState]));
+        });
+    }
+
+    _getTiltAngle(value) {
+        // Convert Tuya percentage (0-100) to HomeKit tilt angle (-90 to 90)
+        // Tuya: 0 = fully closed, 50 = most open, 100 = fully closed other direction
+        // HomeKit: -90 = fully closed, 0 = most open, 90 = fully closed other direction
+        const tuyaValue = parseInt(value);
+        if (isNaN(tuyaValue)) return 0;
+        return (tuyaValue - 50) * 1.8; // Maps 0-100 to -90 to 90
+    }
+
+    setTiltAngle(value, callback) {
+        // Convert HomeKit tilt angle (-90 to 90) to Tuya percentage (0-100)
+        const tuyaValue = Math.round((value / 1.8) + 50);
+        const clampedValue = Math.max(0, Math.min(100, tuyaValue));
+        
+        // Store this command with timestamp
+        this.lastTiltCommand = {
+            angle: value,
+            value: clampedValue,
+            time: Date.now()
+        };
+        
+        // Check if a close command was sent recently (within 3 seconds)
+        const timeSinceClose = Date.now() - this.lastCloseTime;
+        const shouldDelay = this.lastCloseTime > 0 && timeSinceClose < 3000;
+        
+        if (shouldDelay) {
+            // Delay the tilt command until after blinds finish closing
+            const delayMs = (this.timeToClose * 1000) - timeSinceClose;
+            this.log('[TuyaAccessory] Tilt command received shortly after close - delaying by', Math.round(delayMs / 1000), 'seconds');
+            
+            // Cancel any existing delayed tilt
+            this._cancelPendingTilts();
+            
+            // Schedule the tilt command
+            this.tiltDelayTimeout = setTimeout(() => {
+                this.log('[TuyaAccessory] Executing delayed tilt angle:', value, '-> Tuya percent_control:', clampedValue);
+                this._executeTilt(clampedValue);
+                this.tiltDelayTimeout = null;
+                this.lastCloseTime = 0;
+                this.lastTiltCommand = null;
+            }, delayMs);
+            
+            // Call callback immediately so HomeKit doesn't wait
+            return callback && callback(null);
+            
+        } else {
+            // Add a small buffer (200ms) to wait for a potential close command
+            // This handles the case where tilt arrives just before close
+            this.log('[TuyaAccessory] Setting tilt angle:', value, '-> Tuya percent_control:', clampedValue);
+            
+            // Cancel any existing buffer
+            if (this.tiltBufferTimeout) {
+                clearTimeout(this.tiltBufferTimeout);
+            }
+            
+            this.tiltBufferTimeout = setTimeout(() => {
+                // Check again if close command arrived during the buffer
+                if (this.lastCloseTime > 0 && (Date.now() - this.lastCloseTime < 3000)) {
+                    this.log('[TuyaAccessory] Close command arrived during tilt buffer - extending delay');
+                    // The setPosition method will handle rescheduling
+                } else {
+                    // No close command, execute tilt normally
+                    this._executeTilt(clampedValue);
+                    this.lastTiltCommand = null;
+                }
+                this.tiltBufferTimeout = null;
+            }, 200);
+            
+            return callback && callback(null);
+        }
+    }
+
+    _executeTilt(value) {
+        // Force update: Bypass setState caching and call device.update directly
+        // This is needed because percent_control (dp 2) is not reported in device state
+        if (!this.device.connected) {
+            this.log('[TuyaAccessory] Cannot execute tilt - device not connected');
+            return;
+        }
+        
+        this.device.update({[this.dpTilt]: value});
+    }
+
+    _cancelPendingTilts() {
+        if (this.tiltBufferTimeout) {
+            clearTimeout(this.tiltBufferTimeout);
+            this.tiltBufferTimeout = null;
+            this.log('[TuyaAccessory] Cleared pending tilt buffer');
+        }
+        if (this.tiltDelayTimeout) {
+            clearTimeout(this.tiltDelayTimeout);
+            this.tiltDelayTimeout = null;
+            this.log('[TuyaAccessory] Cleared pending tilt delay');
+        }
+    }
+
+    updateState(data) {
+        const {Characteristic} = this.hap;
+        
+        // Update tilt based on percent_state (dp_id 3)
+        if (data[this.dpTiltState] !== undefined) {
+            const tiltAngle = this._getTiltAngle(data[this.dpTiltState]);
+            this.log.debug('[TuyaAccessory] Tilt state updated to:', data[this.dpTiltState], '-> angle:', tiltAngle);
+            this.characteristicCurrentHorizontalTilt.updateValue(tiltAngle);
+            this.characteristicTargetHorizontalTilt.updateValue(tiltAngle);
+        }
+
+        // Update position state based on control actions
+        if (data[this.dpAction] !== undefined) {
+            const action = data[this.dpAction];
+            this.log.debug('[TuyaAccessory] Control action:', action);
+            
+            if (action === 'open') {
+                this.currentPosition = 100;
+                this.characteristicCurrentPosition.updateValue(100);
+                this.characteristicTargetPosition.updateValue(100);
+                this.characteristicPositionState.updateValue(Characteristic.PositionState.INCREASING);
+            } else if (action === 'close') {
+                this.currentPosition = 0;
+                this.characteristicCurrentPosition.updateValue(0);
+                this.characteristicTargetPosition.updateValue(0);
+                this.characteristicPositionState.updateValue(Characteristic.PositionState.DECREASING);
+            } else if (action === 'stop') {
+                this.characteristicPositionState.updateValue(Characteristic.PositionState.STOPPED);
+            }
+        }
+    }
+}
+
+module.exports = VerticalBlindsWithTilt;

--- a/wiki/Supported-Device-Types.md
+++ b/wiki/Supported-Device-Types.md
@@ -20,6 +20,7 @@ If you are looking for verified configurations for your specific device, please 
 |Garage Door|`GarageDoor`<sup>[10](#garage-doors)</sup>|Smart garage doors or garage door openers <small>([instructions](#garage-doors))</small>|
 |Simple Blinds|`SimpleBlinds`<sup>[11](#simple-blinds)</sup>|Smart blinds and smart switches that control blinds <small>([instructions](#simple-blinds))</small>|
 |Simple Blinds2|`SimpleBlinds2`<sup>[11](#simple-blinds)</sup>|Smart blinds and smart switches that control blinds(Use if simple Blinds (1) doesn't work for you. <small>([instructions](#simple-blinds))</small>|
+|Vertical Blinds with Tilt|`VerticalBlindsWithTilt`<sup>[11](#vertical-blinds-with-tilt)</sup>|Smart vertical blinds with open/close and panel rotation <small>([instructions](#vertical-blinds-with-tilt))</small>|
 |Smart Plug w/ White and Color Lights|`RGBTWOutlet`<sup>[12](#outlets-with-white-and-color-lights)</sup>|Smart plugs that have controllable RGBTW LEDs <small>([instructions](#outlets-with-white-and-color-lights))</small>|
 |Smart Fan Regulator|`SimpleFanAccessory`<sup>[more](#smart-fan-regulators-and-accessories)</sup>|Smart Fan Regulators that have controllable Speeds <small>([instructions](#smart-fan-regulators-and-accessories))</small>|
 |Smart Fan with Light|`SimpleFanLightAccessory`<sup>[more](#smart-fan-with-light)</sup>|Smart Fan devices that have controllable Speeds, Directions and a built-in Light<small>([instructions](#smart-fan-with-light))</small>|
@@ -404,6 +405,35 @@ Normally the blinds don't report their position. This plugin attempts to time th
     /* If the app reports open when the blinds are closed, 
        and reports closed when they are open */
     "flipState": true
+}
+```
+
+### Vertical Blinds with Tilt
+Support for Tuya/Graywind Smart Vertical Blinds with open/close (retract/extend) AND panel rotation (tilt). In order to handle setting both the open/close position AND the rotation simultaneously with an automation, configure the timeToClose value in seconds to be at least the amount of time it takes your blinds to close. The rotation command will be queued up to send after this delay. On my 7-foot-wide blinds, this was 20 seconds. Default is 30.
+
+#### Minimal Configuration
+```json
+{
+  "name": "Bedroom Blinds",
+  "type": "VerticalBlindsWithTilt",
+  "id": "032000123456789abcde",
+  "key": "0123456789abcdef"
+}
+```
+
+#### Full Configuration
+```json
+{
+  "name": "Living Room Blinds",
+  "type": "VerticalBlindsWithTilt",
+  "manufacturer": "Tuya",
+  "model": "Smart Vertical Blinds",
+  "id": "032000123456789abcde",
+  "key": "0123456789abcdef",
+  "dpAction": 1,
+  "dpTilt": 2,
+  "dpTiltState": 3,
+  "timeToClose": 30
 }
 ```
 


### PR DESCRIPTION
## Overview
This PR adds a new device type `VerticalBlindsWithTilt` that provides native HomeKit support for Tuya/Graywind vertical blinds with both position (open/close) and tilt/rotation control.

## Problem
Tuya vertical blinds have two independent controls:
1. **Vertical position** - opening/closing the blinds (extending/retracting)
2. **Panel tilt/rotation** - rotating the slats for light control

The existing `SimpleBlinds` device type only supports the vertical position control, leaving tilt functionality inaccessible in HomeKit.

## Solution
Created a new `VerticalBlindsWithTilt` device type that:
- ✅ Controls vertical position (open/close) via dp_id 1
- ✅ Controls panel tilt/rotation via dp_id 2
- ✅ Reads tilt state from dp_id 3
- ✅ Maps Tuya's 0-100% tilt to HomeKit's -90° to 90° tilt angle
- ✅ Implements smart delay logic to handle simultaneous commands from automations
- ✅ Shows as a single WindowCovering accessory with both position and tilt sliders

## Features

### Smart Command Sequencing
When HomeKit automations send both "close" and "tilt" commands simultaneously (common use case: "close and rotate blinds fully"), the plugin:
1. Detects commands arriving within 200ms of each other
2. Executes close command immediately
3. Automatically delays tilt command until blinds finish closing
4. Executes tilt command after configurable delay (`timeToClose`)

### Tilt Angle Mapping
Vertical blinds have a unique tilt behavior where 50% is the most open position:
- Tuya 0% → HomeKit -90°/Leftmost (fully closed one direction)
- Tuya 50% → HomeKit 0°/Center (most open)
- Tuya 100% → HomeKit 90°/Rightmost (fully closed opposite direction)

## Configuration

### Basic Example
```json
{
  "platform": "TuyaLan",
  "devices": [
    {
      "name": "Living Room Blinds",
      "type": "VerticalBlindsWithTilt",
      "id": "your-device-id",
      "key": "your-device-key"
    }
  ]
}
```

### Advanced Example with Custom Timing
```json
{
  "platform": "TuyaLan",
  "devices": [
    {
      "name": "Patio Door Blinds",
      "type": "VerticalBlindsWithTilt",
      "manufacturer": "Tuya",
      "model": "Smart Vertical Blinds",
      "id": "your-device-id",
      "key": "your-device-key",
      "dpAction": 1,
      "dpTilt": 2,
      "dpTiltState": 3,
      "timeToClose": 45
    }
  ]
}
```

### Configuration Parameters
- `dpAction` (default: 1) - Datapoint for open/close/stop commands
- `dpTilt` (default: 2) - Datapoint for tilt control (percent_control)
- `dpTiltState` (default: 3) - Datapoint for reading tilt state (percent_state)
- `timeToClose` (default: 30) - Seconds for blinds to fully extend/close

## Technical Details

### Datapoint Mapping
Based on Tuya device specifications:
- **dp_id 1** (`control`) - Commands: "open", "close", "stop"
- **dp_id 2** (`percent_control`) - Tilt control (writable, 0-100%)
- **dp_id 3** (`percent_state`) - Tilt status (read-only, 0-100%)
- **dp_id 5** (`control_back`) - Direction: "forward", "backward"
- **dp_id 7** (`work_state`) - Status: "opening", "closing", "stopped"

### Implementation Notes
1. **Forced device updates** - Bypasses setState caching for tilt commands since `percent_control` (dp_id 2) is not reported in device state
2. **Position tracking** - Tracks position based on commands sent since device doesn't report vertical position state
3. **200ms buffer** - Brief delay on tilt commands to catch simultaneous close commands from automations

## Files Changed
- `index.js` - Added require and CLASS_DEF entry for new device type
- `lib/VerticalBlindsWithTilt.js` - New device implementation
- `wiki/Supported-Device-Types.md` - Added documentation for new device type

## Testing
Tested with:
- [Graywind Smart Vertical Blinds](https://www.graywindblinds.com/collections/vertical-blinds/products/smart-vertical-blackout)
- Firmware version 3.4
- iOS Home app
- HomeKit automations
- Siri voice commands

Verified:
- ✅ Position control (open/close)
- ✅ Tilt control (rotation)
- ✅ Simultaneous commands from automations
- ✅ Manual sequential commands

## HomeKit Behavior
In the Home app, the blinds appear as a single WindowCovering accessory with:
- **Position slider** - 0% (closed/extended) to 100% (open/retracted)
- **Tilt slider** - -90° to 90° with 0° being most open

## Use Cases
Perfect for:
- "Good night" automation: Close and rotate blinds for privacy
- "Good morning" automation: Open blinds and set tilt for optimal light
- "Away from home" automation: Close and secure blinds automatically
- Manual fine-tuning of light levels via tilt control

## Breaking Changes
None - this is a new device type that doesn't affect existing configurations.

## Future Improvements
- [ ] Auto-detect initial position state if Tuya adds support (currently always defaults to being "open" when homebridge restarts because Tuya doesn't tell us the current state via API request)
- [ ] Configurable tilt mapping for different blind types
- [ ] Support for partial vertical positions if available (currently can only command "fully open" or "fully close").

<img width="195" height="116" alt="1" src="https://github.com/user-attachments/assets/9a05dfa2-72e7-46f8-9dbd-6c92b5014564" />
<img width="330" height="611" alt="2" src="https://github.com/user-attachments/assets/f8c2d82b-d497-46df-8e33-06eec3d89d34" />
<img width="505" height="488" alt="3" src="https://github.com/user-attachments/assets/dcc5bf4b-d226-46e0-9ab2-836ed150cdc0" />