### PR TITLE
Homebridge 2.0 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
-package-lock.json
 .idea
 .DS_Store

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ const OilDiffuserAccessory = require('./lib/OilDiffuserAccessory');
 const DoorbellAccessory = require('./lib/DoorbellAccessory');
 const VerticalBlindsWithTilt = require('./lib/VerticalBlindsWithTilt');
 
-const PLUGIN_NAME = 'homebridge-tuya';
+const PLUGIN_NAME = 'homebridge-tuya-plus';
 const PLATFORM_NAME = 'TuyaLan';
 const DEFAULT_DISCOVER_TIMEOUT = 60000;
 
@@ -55,12 +55,12 @@ const CLASS_DEF = {
     verticalblindswithtilt: VerticalBlindsWithTilt
 };
 
-let Characteristic, PlatformAccessory, Service, Categories, AdaptiveLightingController, UUID;
+let Characteristic, Formats, Perms, Categories, PlatformAccessory, Service, AdaptiveLightingController, UUID;
 
 module.exports = function(homebridge) {
     ({
         platformAccessory: PlatformAccessory,
-        hap: {Characteristic, Service, AdaptiveLightingController, Accessory: {Categories}, uuid: UUID}
+        hap: {Characteristic, Formats, Perms, Categories, Service, AdaptiveLightingController, uuid: UUID}
     } = homebridge);
 
     homebridge.registerPlatform(PLUGIN_NAME, PLATFORM_NAME, TuyaLan, true);
@@ -71,7 +71,7 @@ class TuyaLan {
         [this.log, this.config, this.api] = [...props];
 
         this.cachedAccessories = new Map();
-        this.api.hap.EnergyCharacteristics = require('./lib/EnergyCharacteristics')(this.api.hap.Characteristic);
+        this.api.hap.EnergyCharacteristics = require('./lib/EnergyCharacteristics')(this.api.hap);
 
         if(!this.config || !this.config.devices) {
             this.log("No devices found. Check that you have specified them in your config.json file.");
@@ -174,7 +174,7 @@ class TuyaLan {
                     if (!characteristic.props ||
                         !Array.isArray(characteristic.props.perms) ||
                         characteristic.props.perms.length !== 3 ||
-                        !(characteristic.props.perms.includes(Characteristic.Perms.WRITE) && characteristic.props.perms.includes(Characteristic.Perms.NOTIFY))
+                        !(characteristic.props.perms.includes(Perms.WRITE) && characteristic.props.perms.includes(Perms.NOTIFY))
                     ) return;
 
                     this.log.info('Marked %s unreachable by faulting Service.%s.%s', accessory.displayName, service.displayName, characteristic.displayName);
@@ -236,7 +236,7 @@ class TuyaLan {
         this.log.warn('Unregistering', homebridgeAccessory.displayName);
 
         delete this.cachedAccessories[homebridgeAccessory.UUID];
-        this.api.unregisterPlatformAccessories(PLATFORM_NAME, PLATFORM_NAME, [homebridgeAccessory]);
+        this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [homebridgeAccessory]);
     }
 
     removeAccessoryByUUID(uuid) {

--- a/lib/AirConditionerAccessory.js
+++ b/lib/AirConditionerAccessory.js
@@ -28,7 +28,6 @@ class AirConditionerAccessory extends BaseAccessory {
             else throw new Error('The cmdAuto doesn\'t appear to be valid: ' + this.device.context.cmdAuto);
         }
 
-        // Disabling auto mode because I have not found a Tuya device config that has a temperature range for AUTO
         this.device.context.noAuto = true;
 
         if (!this.device.context.noRotationSpeed) {
@@ -67,12 +66,12 @@ class AirConditionerAccessory extends BaseAccessory {
 
         const characteristicActive = service.getCharacteristic(Characteristic.Active)
             .updateValue(this._getActive(this.dpActive))
-            .on('get', this.getActive.bind(this))
-            .on('set', this.setActive.bind(this));
+            .onGet(() => this.getActive())
+            .onSet(value => this.setActive(value));
 
         const characteristicCurrentHeaterCoolerState = service.getCharacteristic(Characteristic.CurrentHeaterCoolerState)
             .updateValue(this._getCurrentHeaterCoolerState(dps))
-            .on('get', this.getCurrentHeaterCoolerState.bind(this));
+            .onGet(() => this.getCurrentHeaterCoolerState());
 
         const _validTargetHeaterCoolerStateValues = [STATE_OTHER];
         if (!this.device.context.noCool) _validTargetHeaterCoolerStateValues.unshift(Characteristic.TargetHeaterCoolerState.COOL);
@@ -80,32 +79,29 @@ class AirConditionerAccessory extends BaseAccessory {
         if (!this.device.context.noAuto) _validTargetHeaterCoolerStateValues.unshift(Characteristic.TargetHeaterCoolerState.AUTO);
 
         const characteristicTargetHeaterCoolerState = service.getCharacteristic(Characteristic.TargetHeaterCoolerState)
-            .setProps({
-                maxValue: 9,
-                validValues: _validTargetHeaterCoolerStateValues
-            })
+            .setProps({ maxValue: 9, validValues: _validTargetHeaterCoolerStateValues })
             .updateValue(this._getTargetHeaterCoolerState(dps[this.dpMode]))
-            .on('get', this.getTargetHeaterCoolerState.bind(this))
-            .on('set', this.setTargetHeaterCoolerState.bind(this));
+            .onGet(() => this.getTargetHeaterCoolerState())
+            .onSet(value => this.setTargetHeaterCoolerState(value));
 
         const characteristicCurrentTemperature = service.getCharacteristic(Characteristic.CurrentTemperature)
             .updateValue(dps[this.dpCurrentTemperature])
-            .on('get', this.getState.bind(this, this.dpCurrentTemperature));
+            .onGet(() => this.getStateAsync(this.dpCurrentTemperature));
 
         let characteristicSwingMode;
         if (!this.device.context.noSwing) {
             characteristicSwingMode = service.getCharacteristic(Characteristic.SwingMode)
                 .updateValue(this._getSwingMode(dps[this.dpSwingMode]))
-                .on('get', this.getSwingMode.bind(this))
-                .on('set', this.setSwingMode.bind(this));
+                .onGet(() => this.getSwingMode())
+                .onSet(value => this.setSwingMode(value));
         } else this._removeCharacteristic(service, Characteristic.SwingMode);
 
         let characteristicLockPhysicalControls;
         if (!this.device.context.noChildLock) {
             characteristicLockPhysicalControls = service.getCharacteristic(Characteristic.LockPhysicalControls)
                 .updateValue(this._getLockPhysicalControls(dps[this.dpChildLock]))
-                .on('get', this.getLockPhysicalControls.bind(this))
-                .on('set', this.setLockPhysicalControls.bind(this));
+                .onGet(() => this.getLockPhysicalControls())
+                .onSet(value => this.setLockPhysicalControls(value));
         } else this._removeCharacteristic(service, Characteristic.LockPhysicalControls);
 
         let characteristicCoolingThresholdTemperature;
@@ -117,8 +113,8 @@ class AirConditionerAccessory extends BaseAccessory {
                     minStep: this.device.context.minTemperatureSteps || 1
                 })
                 .updateValue(this.dpThreshold)
-                .on('get', this.getState.bind(this, this.dpThreshold))
-                .on('set', this.setTargetThresholdTemperature.bind(this, 'cool'));
+                .onGet(() => this.getStateAsync(this.dpThreshold))
+                .onSet(value => this.setTargetThresholdTemperature('cool', value));
         } else this._removeCharacteristic(service, Characteristic.CoolingThresholdTemperature);
 
         let characteristicHeatingThresholdTemperature;
@@ -130,21 +126,21 @@ class AirConditionerAccessory extends BaseAccessory {
                     minStep: this.device.context.minTemperatureSteps || 1
                 })
                 .updateValue(dps[this.dpThreshold])
-                .on('get', this.getState.bind(this, this.dpThreshold))
-                .on('set', this.setTargetThresholdTemperature.bind(this, 'heat'));
+                .onGet(() => this.getStateAsync(this.dpThreshold))
+                .onSet(value => this.setTargetThresholdTemperature('heat', value));
         } else this._removeCharacteristic(service, Characteristic.HeatingThresholdTemperature);
 
         const characteristicTemperatureDisplayUnits = service.getCharacteristic(Characteristic.TemperatureDisplayUnits)
             .updateValue(this._getTemperatureDisplayUnits(dps[this.dpTempUnits]))
-            .on('get', this.getTemperatureDisplayUnits.bind(this))
-            .on('set', this.setTemperatureDisplayUnits.bind(this));
+            .onGet(() => this.getTemperatureDisplayUnits())
+            .onSet(value => this.setTemperatureDisplayUnits(value));
 
         let characteristicRotationSpeed;
         if (!this.device.context.noRotationSpeed) {
             characteristicRotationSpeed = service.getCharacteristic(Characteristic.RotationSpeed)
                 .updateValue(this._getRotationSpeed(dps))
-                .on('get', this.getRotationSpeed.bind(this))
-                .on('set', this.setRotationSpeed.bind(this));
+                .onGet(() => this.getRotationSpeed())
+                .onSet(value => this.setRotationSpeed(value));
         } else this._removeCharacteristic(service, Characteristic.RotationSpeed);
 
         this.characteristicCoolingThresholdTemperature = characteristicCoolingThresholdTemperature;
@@ -155,22 +151,14 @@ class AirConditionerAccessory extends BaseAccessory {
                 const newActive = this._getActive(changes[this.dpActive]);
                 if (characteristicActive.value !== newActive) {
                     characteristicActive.updateValue(newActive);
-
-                    if (!changes.hasOwnProperty(this.dpMode)) {
-                        characteristicCurrentHeaterCoolerState.updateValue(this._getCurrentHeaterCoolerState(state));
-                    }
-
-                    if (!changes.hasOwnProperty(this.dpRotationSpeed)) {
-                        characteristicRotationSpeed.updateValue(this._getRotationSpeed(state));
-                    }
+                    if (!changes.hasOwnProperty(this.dpMode)) characteristicCurrentHeaterCoolerState.updateValue(this._getCurrentHeaterCoolerState(state));
+                    if (!changes.hasOwnProperty(this.dpRotationSpeed)) characteristicRotationSpeed && characteristicRotationSpeed.updateValue(this._getRotationSpeed(state));
                 }
             }
 
             if (characteristicLockPhysicalControls && changes.hasOwnProperty(this.dpChildLock)) {
                 const newLockPhysicalControls = this._getLockPhysicalControls(changes[this.dpChildLock]);
-                if (characteristicLockPhysicalControls.value !== newLockPhysicalControls) {
-                    characteristicLockPhysicalControls.updateValue(newLockPhysicalControls);
-                }
+                if (characteristicLockPhysicalControls.value !== newLockPhysicalControls) characteristicLockPhysicalControls.updateValue(newLockPhysicalControls);
             }
 
             if (changes.hasOwnProperty(this.dpThreshold)) {
@@ -180,7 +168,8 @@ class AirConditionerAccessory extends BaseAccessory {
                     characteristicHeatingThresholdTemperature.updateValue(changes[this.dpThreshold]);
             }
 
-            if (changes.hasOwnProperty(this.dpCurrentTemperature) && characteristicCurrentTemperature.value !== changes[this.dpCurrentTemperature]) characteristicCurrentTemperature.updateValue(changes[this.dpCurrentTemperature]);
+            if (changes.hasOwnProperty(this.dpCurrentTemperature) && characteristicCurrentTemperature.value !== changes[this.dpCurrentTemperature])
+                characteristicCurrentTemperature.updateValue(changes[this.dpCurrentTemperature]);
 
             if (changes.hasOwnProperty(this.dpMode)) {
                 const newTargetHeaterCoolerState = this._getTargetHeaterCoolerState(changes[this.dpMode]);
@@ -189,7 +178,7 @@ class AirConditionerAccessory extends BaseAccessory {
                 if (characteristicCurrentHeaterCoolerState.value !== newCurrentHeaterCoolerState) characteristicCurrentHeaterCoolerState.updateValue(newCurrentHeaterCoolerState);
             }
 
-            if (changes.hasOwnProperty(this.dpSwingMode)) {
+            if (characteristicSwingMode && changes.hasOwnProperty(this.dpSwingMode)) {
                 const newSwingMode = this._getSwingMode(changes[this.dpSwingMode]);
                 if (characteristicSwingMode.value !== newSwingMode) characteristicSwingMode.updateValue(newSwingMode);
             }
@@ -201,235 +190,163 @@ class AirConditionerAccessory extends BaseAccessory {
 
             if (changes.hasOwnProperty(this.dpRotationSpeed)) {
                 const newRotationSpeed = this._getRotationSpeed(state);
-                if (characteristicRotationSpeed.value !== newRotationSpeed) characteristicRotationSpeed.updateValue(newRotationSpeed);
-
-                if (!changes.hasOwnProperty(this.dpMode)) {
-                    characteristicCurrentHeaterCoolerState.updateValue(this._getCurrentHeaterCoolerState(state));
-                }
+                if (characteristicRotationSpeed && characteristicRotationSpeed.value !== newRotationSpeed) characteristicRotationSpeed.updateValue(newRotationSpeed);
+                if (!changes.hasOwnProperty(this.dpMode)) characteristicCurrentHeaterCoolerState.updateValue(this._getCurrentHeaterCoolerState(state));
             }
         });
     }
 
-    getActive(callback) {
-        this.getState(this.dpActive, (err, dp) => {
-            if (err) return callback(err);
-
-            callback(null, this._getActive(dp));
-        });
+    getActive() {
+        return this._getActive(this.getStateAsync(this.dpActive));
     }
 
     _getActive(dp) {
         const {Characteristic} = this.hap;
-
         return dp ? Characteristic.Active.ACTIVE : Characteristic.Active.INACTIVE;
     }
 
-    setActive(value, callback) {
+    setActive(value) {
         const {Characteristic} = this.hap;
-
         switch (value) {
             case Characteristic.Active.ACTIVE:
-                return this.setState(this.dpActive, true, callback);
-
+                return this.setStateAsync(this.dpActive, true);
             case Characteristic.Active.INACTIVE:
-                return this.setState(this.dpActive, false, callback);
+                return this.setStateAsync(this.dpActive, false);
         }
-
-        callback();
     }
 
-    getLockPhysicalControls(callback) {
-        this.getState(this.dpChildLock, (err, dp) => {
-            if (err) return callback(err);
-
-            callback(null, this._getLockPhysicalControls(dp));
-        });
+    getLockPhysicalControls() {
+        return this._getLockPhysicalControls(this.getStateAsync(this.dpChildLock));
     }
 
     _getLockPhysicalControls(dp) {
         const {Characteristic} = this.hap;
-
         return dp ? Characteristic.LockPhysicalControls.CONTROL_LOCK_ENABLED : Characteristic.LockPhysicalControls.CONTROL_LOCK_DISABLED;
     }
 
-    setLockPhysicalControls(value, callback) {
+    setLockPhysicalControls(value) {
         const {Characteristic} = this.hap;
-
         switch (value) {
             case Characteristic.LockPhysicalControls.CONTROL_LOCK_ENABLED:
-                return this.setState(this.dpChildLock, true, callback);
-
+                return this.setStateAsync(this.dpChildLock, true);
             case Characteristic.LockPhysicalControls.CONTROL_LOCK_DISABLED:
-                return this.setState(this.dpChildLock, false, callback);
+                return this.setStateAsync(this.dpChildLock, false);
         }
-
-        callback();
     }
 
-    getCurrentHeaterCoolerState(callback) {
-        this.getState([this.dpActive, this.dpMode], (err, dps) => {
-            if (err) return callback(err);
-
-            callback(null, this._getCurrentHeaterCoolerState(dps));
-        });
+    getCurrentHeaterCoolerState() {
+        return this._getCurrentHeaterCoolerState(this.getStateAsync([this.dpActive, this.dpMode]));
     }
 
     _getCurrentHeaterCoolerState(dps) {
         const {Characteristic} = this.hap;
         if (!dps[this.dpActive]) return Characteristic.CurrentHeaterCoolerState.INACTIVE;
-
         switch (dps[this.dpMode]) {
-            case this.cmdCool:
-                return Characteristic.CurrentHeaterCoolerState.COOLING;
-
-            case this.cmdHeat:
-                return Characteristic.CurrentHeaterCoolerState.HEATING;
-
-            default:
-                return Characteristic.CurrentHeaterCoolerState.IDLE;
+            case this.cmdCool: return Characteristic.CurrentHeaterCoolerState.COOLING;
+            case this.cmdHeat: return Characteristic.CurrentHeaterCoolerState.HEATING;
+            default: return Characteristic.CurrentHeaterCoolerState.IDLE;
         }
     }
 
-    getTargetHeaterCoolerState(callback) {
-        this.getState(this.dpMode, (err, dp) => {
-            if (err) return callback(err);
-
-            callback(null, this._getTargetHeaterCoolerState(dp));
-        });
+    getTargetHeaterCoolerState() {
+        return this._getTargetHeaterCoolerState(this.getStateAsync(this.dpMode));
     }
 
     _getTargetHeaterCoolerState(dp) {
         const {Characteristic} = this.hap;
-
         switch (dp) {
             case this.cmdCool:
                 if (this.device.context.noCool) return STATE_OTHER;
                 return Characteristic.TargetHeaterCoolerState.COOL;
-
             case this.cmdHeat:
                 if (this.device.context.noHeat) return STATE_OTHER;
                 return Characteristic.TargetHeaterCoolerState.HEAT;
-
             case this.cmdAuto:
                 if (this.device.context.noAuto) return STATE_OTHER;
                 return Characteristic.TargetHeaterCoolerState.AUTO;
-
             default:
                 return STATE_OTHER;
         }
     }
 
-    setTargetHeaterCoolerState(value, callback) {
+    setTargetHeaterCoolerState(value) {
         const {Characteristic} = this.hap;
-
         switch (value) {
             case Characteristic.TargetHeaterCoolerState.COOL:
-                if (this.device.context.noCool) return callback();
-                return this.setState(this.dpMode, this.cmdCool, callback);
-
+                if (this.device.context.noCool) return;
+                return this.setStateAsync(this.dpMode, this.cmdCool);
             case Characteristic.TargetHeaterCoolerState.HEAT:
-                if (this.device.context.noHeat) return callback();
-                return this.setState(this.dpMode, this.cmdHeat, callback);
-
+                if (this.device.context.noHeat) return;
+                return this.setStateAsync(this.dpMode, this.cmdHeat);
             case Characteristic.TargetHeaterCoolerState.AUTO:
-                if (this.device.context.noAuto) return callback();
-                return this.setState(this.dpMode, this.cmdAuto, callback);
+                if (this.device.context.noAuto) return;
+                return this.setStateAsync(this.dpMode, this.cmdAuto);
         }
-
-        callback();
     }
 
-    getSwingMode(callback) {
-        this.getState(this.dpSwingMode, (err, dp) => {
-            if (err) return callback(err);
-
-            callback(null, this._getSwingMode(dp));
-        });
+    getSwingMode() {
+        return this._getSwingMode(this.getStateAsync(this.dpSwingMode));
     }
 
     _getSwingMode(dp) {
         const {Characteristic} = this.hap;
-
         return dp ? Characteristic.SwingMode.SWING_ENABLED : Characteristic.SwingMode.SWING_DISABLED;
     }
 
-    setSwingMode(value, callback) {
-        if (this.device.context.noSwing) return callback();
-
+    setSwingMode(value) {
+        if (this.device.context.noSwing) return;
         const {Characteristic} = this.hap;
-
         switch (value) {
             case Characteristic.SwingMode.SWING_ENABLED:
-                return this.setState(this.dpSwingMode, true, callback);
-
+                return this.setStateAsync(this.dpSwingMode, true);
             case Characteristic.SwingMode.SWING_DISABLED:
-                return this.setState(this.dpSwingMode, false, callback);
+                return this.setStateAsync(this.dpSwingMode, false);
         }
-
-        callback();
     }
 
-    setTargetThresholdTemperature(mode, value, callback) {
-        this.setState(this.dpThreshold, value, err => {
-            if (err) return callback(err);
-
-            if (mode === 'cool' && !this.device.context.noHeat && this.characteristicHeatingThresholdTemperature) {
-                this.characteristicHeatingThresholdTemperature.updateValue(value);
-            } else if (mode === 'heat' && !this.device.context.noCool && this.characteristicCoolingThresholdTemperature) {
-                this.characteristicCoolingThresholdTemperature.updateValue(value);
-            }
-
-            callback();
-        });
+    async setTargetThresholdTemperature(mode, value) {
+        await this.setStateAsync(this.dpThreshold, value);
+        if (mode === 'cool' && !this.device.context.noHeat && this.characteristicHeatingThresholdTemperature) {
+            this.characteristicHeatingThresholdTemperature.updateValue(value);
+        } else if (mode === 'heat' && !this.device.context.noCool && this.characteristicCoolingThresholdTemperature) {
+            this.characteristicCoolingThresholdTemperature.updateValue(value);
+        }
     }
-    getTemperatureDisplayUnits(callback) {
-        this.getState(this.dpTempUnits, (err, dp) => {
-            if (err) return callback(err);
 
-            callback(null, this._getTemperatureDisplayUnits(dp));
-        });
+    getTemperatureDisplayUnits() {
+        return this._getTemperatureDisplayUnits(this.getStateAsync(this.dpTempUnits));
     }
 
     _getTemperatureDisplayUnits(dp) {
         const {Characteristic} = this.hap;
-
         return dp === 'F' ? Characteristic.TemperatureDisplayUnits.FAHRENHEIT : Characteristic.TemperatureDisplayUnits.CELSIUS;
     }
 
-    setTemperatureDisplayUnits(value, callback) {
+    setTemperatureDisplayUnits(value) {
         const {Characteristic} = this.hap;
-
-        this.setState(this.dpTempUnits, value === Characteristic.TemperatureDisplayUnits.FAHRENHEIT ? 'F' : 'C', callback);
+        return this.setStateAsync(this.dpTempUnits, value === Characteristic.TemperatureDisplayUnits.FAHRENHEIT ? 'F' : 'C');
     }
 
-    getRotationSpeed(callback) {
-        this.getState([this.dpActive, this.dpRotationSpeed], (err, dps) => {
-            if (err) return callback(err);
-
-            callback(null, this._getRotationSpeed(dps));
-        });
+    getRotationSpeed() {
+        return this._getRotationSpeed(this.getStateAsync([this.dpActive, this.dpRotationSpeed]));
     }
 
     _getRotationSpeed(dps) {
         if (!dps[this.dpActive]) return 0;
-
         if (this._hkRotationSpeed) {
             const currntRotationSpeed = this.convertRotationSpeedFromHomeKitToTuya(this._hkRotationSpeed);
-
             return currntRotationSpeed === dps[this.dpRotationSpeed] ? this._hkRotationSpeed : this.convertRotationSpeedFromTuyaToHomeKit(dps[this.dpRotationSpeed]);
         }
-
         return this._hkRotationSpeed = this.convertRotationSpeedFromTuyaToHomeKit(dps[this.dpRotationSpeed]);
     }
 
-    setRotationSpeed(value, callback) {
+    setRotationSpeed(value) {
         const {Characteristic} = this.hap;
-
         if (value === 0) {
-            this.setActive(Characteristic.Active.INACTIVE, callback);
+            return this.setActive(Characteristic.Active.INACTIVE);
         } else {
             this._hkRotationSpeed = value;
-            this.setMultiState({[this.dpActive]: true, [this.dpRotationSpeed]: this.convertRotationSpeedFromHomeKitToTuya(value)}, callback);
+            return this.setMultiStateAsync({[this.dpActive]: true, [this.dpRotationSpeed]: this.convertRotationSpeedFromHomeKitToTuya(value)});
         }
     }
 

--- a/lib/AirPurifierAccessory.js
+++ b/lib/AirPurifierAccessory.js
@@ -1,111 +1,35 @@
 const BaseAccessory = require('./BaseAccessory');
+
 const DP_SWITCH = '1';
 const DP_PM25 = '2';
-const DP_MODE = '3'
+const DP_MODE = '3';
 const DP_FAN_SPEED = '4';
 const DP_LOCK_PHYSICAL_CONTROLS = '7';
 const DP_AIR_QUALITY = '22';
 const STATE_OTHER = 9;
-/**
- * Accessory for Air Purifiers, with an optional setting to also include Air Quality sensor details.
- *
- *
- * Extra settings:
- * - noRotationSpeed - boolean which, if set to true, will disable the fan speed control
- * - fanSpeedSteps -   The number of fan speed stops that the device supports. The default is 100.
- * - showAirQuality -  boolean for enabling the air quality service. The default is false, which
- *                     will not include air quality values.
- * - nameAirQuality -  Allows customisation of the air quality sensor name. Default is 'Air Quality'
- * - noChildLock -     boolean for disabling the child lock feature. The default is false, which
- *                     will enable the child lock feature
- *
- * Standard Air Purifier Data Points (dp):
- * 1. switch
- * 2. pm25
- * 3. mode
- * 4. fan_speed_enum
- * 5. filter (Filter Usage)
- * 6. anion
- * 7. child_lock
- * 8. light
- * 9. uv (UV Disinfection)
- * 10. wet (Humidify)
- * 11. filter_reset (Reset Filter)
- * 12. temp_indoor (Indoor Temp)
- * 13. humidity (Indoor Humidity)
- * 14. tvoc
- * 15. eco2 (eCO2)
- * 16. filter_days (Filter Days Left)
- * 17. total_runtime
- * 18. countdown_sete
- * 19. countdown_left
- * 20. total_pm
- * 21. ???
- * 22. air_quality (verified on Breville Smart Air Connect)
- * ???. fault (Fault Alarm)
- *
- * This accessory maps the DP ids to the following Characteristics:
- * - 1 - Characteristic.ACTIVE / Characteristic.CurrentAirPurifierState
- * - 2 - Characteristic.PM2_5Density / Characteristic.AirQuality
- * - 3 - Characteristic.TargetAirPurifierState
- * - 4 - Characteristic.RotationSpeed
- * - 7 - Characteristic.LockPhysicalControls
- *
- * Device compatability:
- * - Some devices, like the Breville Smart Air Connect, return and expect text rather than numeric Characteristics. To handle these properly, ensure that you set the 'manufacturer' configuration to 'Breville'.
- *
- * Future Enhancements:
- * - Some of this implementation is very similar to AirConditionerAccessory. Likely some scope
- *   for refactoring this.
- * - Some air purifiers support more of the standard data points than the original test device,
- *   so additional services like Filter Maintenance could be added
- *   https://developers.homebridge.io/#/service/FilterMaintenance
- * - _getAirQuality currenly calculates a value based on the pm25 value. I do not have a device
- *   that supports the air_quality data point to see what the return type would be
- *
- * Notes:
- * Initial testing was performed on a Elechomes KJ200G-A3B-UK. This required in the configuration for the API version to
- * be specified. This device returned data point ids: 1, 2, 3, 4, 6, 7, 17, 20
- *
- * Sample configuration for KJ200G-A3B-UK:
- * {
- *    "name": "Living Room Air Purifier",
- *    "type": "AirPurifier",
- *    "manufacturer": "Elechomes",
- *    "model": "KJ200G-A3B-UK",
- *    "id": "REDACTED",
- *    "key": "REDACTED",
- *    "ip": "192.168.99.50",
- *    "version": "3.3",
- *    "fanSpeedSteps": 3,
- *    "showAirQuality": true
- * }
- *
- *
- */
+
 class AirPurifierAccessory extends BaseAccessory {
     static getCategory(Categories) {
         return Categories.AIR_PURIFIER;
     }
+
     constructor(...props) {
         super(...props);
         const {Characteristic} = this.hap;
 
-         if (this.device.context.noRotationSpeed) {
-
-             let fanSpeedSteps = (
-                 this.device.context.fanSpeedSteps &&
-                 isFinite(this.device.context.fanSpeedSteps) &&
-                 this.device.context.fanSpeedSteps > 0 &&
+        if (this.device.context.noRotationSpeed) {
+            let fanSpeedSteps = (
+                this.device.context.fanSpeedSteps &&
+                isFinite(this.device.context.fanSpeedSteps) &&
+                this.device.context.fanSpeedSteps > 0 &&
                 this.device.context.fanSpeedSteps < 100) ? this.device.context.fanSpeedSteps : 100;
             let _fanSpeedLabels = {};
-            // Special handling for particular devices //
             switch (this.device.context.manufacturer) {
-                 case 'Breville':
-                     _fanSpeedLabels = {0: 'off', 1: 'low', 2: 'mid', 3: 'high', 4: 'turbo'};
-                     this._rotationSteps = [...Array(5).keys()];
-                     fanSpeedSteps = 5;
-                     break;
+                case 'Breville':
+                    _fanSpeedLabels = {0: 'off', 1: 'low', 2: 'mid', 3: 'high', 4: 'turbo'};
+                    this._rotationSteps = [...Array(5).keys()];
+                    fanSpeedSteps = 5;
+                    break;
                 case 'Proscenic':
                     _fanSpeedLabels = {0: 'sleep', 1: 'mid', 2: 'high', 3: 'auto'};
                     fanSpeedSteps = 3;
@@ -115,19 +39,20 @@ class AirPurifierAccessory extends BaseAccessory {
                     _fanSpeedLabels = {0: 'sleep', 1: 'auto'};
                     fanSpeedSteps = 2;
                     this._rotationSteps = [...Array(2).keys()];
-                     break;
-                 default: // Just use numeric values
-                     this._rotationSteps = [...Array(fanSpeedSteps).keys()];
+                    break;
+                default:
+                    this._rotationSteps = [...Array(fanSpeedSteps).keys()];
                     for (let i = 0; i <= fanSpeedSteps; i++) {
-                      _fanSpeedLabels[i] = i;
+                        _fanSpeedLabels[i] = i;
                     }
             }
             this._rotationStops = {0: _fanSpeedLabels[0]};
             for (let i = 0; i < 100; i++) {
                 const _rotationStep = Math.floor(fanSpeedSteps * i / 100);
-                this._rotationStops[i+1] = _fanSpeedLabels[_rotationStep];
+                this._rotationStops[i + 1] = _fanSpeedLabels[_rotationStep];
             }
         }
+
         this.airQualityLevels = [
             [200, Characteristic.AirQuality.POOR],
             [150, Characteristic.AirQuality.INFERIOR],
@@ -135,299 +60,214 @@ class AirPurifierAccessory extends BaseAccessory {
             [50, Characteristic.AirQuality.GOOD],
             [0, Characteristic.AirQuality.EXCELLENT],
         ];
+
         this.cmdAuto = 'AUTO';
         if (this.device.context.cmdAuto) {
             if (/^a[a-z]+$/i.test(this.device.context.cmdAuto)) this.cmdAuto = ('' + this.device.context.cmdAuto).trim();
             else throw new Error('The cmdAuto doesn\'t appear to be valid: ' + this.device.context.cmdAuto);
         }
     }
-    /**
-     * Register the services that this accessory supports.
-     */
+
     _registerPlatformAccessory() {
         const {Service} = this.hap;
-        /* Add the main air purifier */
         this.accessory.addService(Service.AirPurifier, this.device.context.name);
-        /* If configured to include air quality data, include that service too */
         if (this.device.context.showAirQuality) {
             this._addAirQualityService();
         }
         super._registerPlatformAccessory();
     }
-    /**
-     * Method to add the AirQualitySensor service to the accessory.
-     *
-     * This is seperate as it may be called after the initial _registerPlatformAccessory call,
-     * if the configuration is updated after the device is first added.
-     */
+
     _addAirQualityService() {
         const {Service} = this.hap;
         const nameAirQuality = this.device.context.nameAirQuality || 'Air Quality';
         this.log.info('Adding air quality sensor: %s', nameAirQuality);
         this.accessory.addService(Service.AirQualitySensor, nameAirQuality);
     }
-    /**
-     * Register the Characteristics that this accessory supports.
-     * @param {*} dps
-     */
+
     _registerCharacteristics(dps) {
         const {Service, Characteristic} = this.hap;
-        /* Air purifier service characteristics */
         const airPurifierService = this.accessory.getService(Service.AirPurifier);
         this._checkServiceName(airPurifierService, this.device.context.name);
         this.log.debug('_registerCharacteristics dps: %o', dps);
+
         const characteristicActive = airPurifierService.getCharacteristic(Characteristic.Active)
             .updateValue(this._getActive(dps[DP_SWITCH]))
-            .on('get', this.getActive.bind(this))
-            .on('set', this.setActive.bind(this));
+            .onGet(() => this.getActive())
+            .onSet(value => this.setActive(value));
+
         const characteristicCurrentAirPurifierState = airPurifierService.getCharacteristic(Characteristic.CurrentAirPurifierState)
             .updateValue(this._getCurrentAirPurifierState(dps[DP_SWITCH]))
-            .on('get', this.getCurrentAirPurifierState.bind(this));
+            .onGet(() => this._getCurrentAirPurifierState(this.getStateAsync(DP_SWITCH)));
 
-
-         const characteristicTargetAirPurifierState = airPurifierService.getCharacteristic(Characteristic.TargetAirPurifierState)
-             .updateValue(this._getTargetAirPurifierState(this._getMode(dps)))
-             .on('get', this.getTargetAirPurifierState.bind(this))
-             .on('set', this.setTargetAirPurifierState.bind(this));
+        const characteristicTargetAirPurifierState = airPurifierService.getCharacteristic(Characteristic.TargetAirPurifierState)
+            .updateValue(this._getTargetAirPurifierState(this._getMode(dps)))
+            .onGet(() => this.getTargetAirPurifierState())
+            .onSet(value => this.setTargetAirPurifierState(value));
 
         let characteristicLockPhysicalControls;
         if (!this.device.context.noChildLock) {
             characteristicLockPhysicalControls = airPurifierService.getCharacteristic(Characteristic.LockPhysicalControls)
                 .updateValue(this._getLockPhysicalControls(dps[DP_LOCK_PHYSICAL_CONTROLS]))
-                .on('get', this.getLockPhysicalControls.bind(this))
-                .on('set', this.setLockPhysicalControls.bind(this));
+                .onGet(() => this.getLockPhysicalControls())
+                .onSet(value => this.setLockPhysicalControls(value));
         } else {
             this._removeCharacteristic(airPurifierService, Characteristic.LockPhysicalControls);
         }
+
         const characteristicRotationSpeed = airPurifierService.getCharacteristic(Characteristic.RotationSpeed)
             .updateValue(this._getRotationSpeed(dps))
-            .on('get', this.getRotationSpeed.bind(this))
-            .on('set', this.setRotationSpeed.bind(this));
-        /* Air quality sensor characteristics */
+            .onGet(() => this.getRotationSpeed())
+            .onSet(value => this.setRotationSpeed(value));
+
         let airQualitySensorService = this.accessory.getService(Service.AirQualitySensor);
         let characteristicAirQuality;
         let characteristicPM25Density;
-        /* Ensure the air quality sensor service existance aligns with the configuration.
-         * If configured to include air quality data, and the service was not already registered, register it.
-         * If configured to not include it, but the service this there, remove it
-         */
+
         if (!airQualitySensorService && this.device.context.showAirQuality) {
             this._addAirQualityService();
             airQualitySensorService = this.accessory.getService(Service.AirQualitySensor);
         } else if (airQualitySensorService && !this.device.context.showAirQuality) {
             this.accessory.removeService(airQualitySensorService);
         }
+
         if (airQualitySensorService) {
             const nameAirQuality = this.device.context.nameAirQuality || 'Air Quality';
             this._checkServiceName(airQualitySensorService, nameAirQuality);
             characteristicAirQuality = airQualitySensorService.getCharacteristic(Characteristic.AirQuality)
                 .updateValue(this._getAirQuality(dps))
-                .on('get', this.getAirQuality.bind(this));
+                .onGet(() => this._getAirQuality(this.getStateAsync([DP_PM25, DP_AIR_QUALITY])));
             characteristicPM25Density = airQualitySensorService.getCharacteristic(Characteristic.PM2_5Density)
                 .updateValue(dps[DP_PM25])
-                .on('get', this.getPM25.bind(this));
+                .onGet(() => this.getStateAsync(DP_PM25));
         }
-        /* Listen for changes */
+
         this.device.on('change', (changes, state) => {
             this.log.debug('Changes: %o, State: %o', changes, state);
-             if (changes.hasOwnProperty(DP_SWITCH)) {
-                 /* On/Off state change */
-                 const newActive = this._getActive(changes[DP_SWITCH]);
+            if (changes.hasOwnProperty(DP_SWITCH)) {
+                const newActive = this._getActive(changes[DP_SWITCH]);
 
-                 // switch power on before other updates to avoid "Turning on..." state
-                 if (changes[DP_SWITCH]) {
-                     this.log.debug("Switching state first");
-                     characteristicActive.updateValue(newActive);
-
-                     characteristicCurrentAirPurifierState.updateValue(
-                         this._getCurrentAirPurifierState(changes[DP_SWITCH]));
-                 }
-
-                 if (!changes.hasOwnProperty(DP_FAN_SPEED)) {
-                     characteristicRotationSpeed.updateValue(this._getRotationSpeed(state));
-                 }
-                 if (!changes.hasOwnProperty(DP_MODE)) {
-                     characteristicTargetAirPurifierState.updateValue(
-                         this._getTargetAirPurifierState(this._getMode(state)));
-                 }
-
-                 // switch power off after other updates to avoid "Turning off..." state
-                 if (!changes[DP_SWITCH]) {
-                     this.log.debug("Switching state last");
-                     characteristicCurrentAirPurifierState.updateValue(
-                         this._getCurrentAirPurifierState(changes[DP_SWITCH]));
-
-                     characteristicActive.updateValue(newActive);
-                 }
-             }
-
-             if (changes.hasOwnProperty(DP_FAN_SPEED)) {
-                 /* Fan speed change */
-                 const newRotationSpeed = this._getRotationSpeed(state);
-                 // Proscenic "auto" fan speed is not mapped and should not trigger a rotation speed update
-                 if (newRotationSpeed) {
-                     if (characteristicRotationSpeed.value !== newRotationSpeed) {
-                         characteristicRotationSpeed.updateValue(newRotationSpeed);
-                     }
-                 }
-
-                if (!changes.hasOwnProperty(DP_MODE)) {
-                    characteristicTargetAirPurifierState.updateValue(
-                        this._getTargetAirPurifierState(this._getMode(state)));
+                if (changes[DP_SWITCH]) {
+                    this.log.debug('Switching state first');
+                    characteristicActive.updateValue(newActive);
+                    characteristicCurrentAirPurifierState.updateValue(this._getCurrentAirPurifierState(changes[DP_SWITCH]));
                 }
+
+                if (!changes.hasOwnProperty(DP_FAN_SPEED)) characteristicRotationSpeed.updateValue(this._getRotationSpeed(state));
+                if (!changes.hasOwnProperty(DP_MODE)) characteristicTargetAirPurifierState.updateValue(this._getTargetAirPurifierState(this._getMode(state)));
+
+                if (!changes[DP_SWITCH]) {
+                    this.log.debug('Switching state last');
+                    characteristicCurrentAirPurifierState.updateValue(this._getCurrentAirPurifierState(changes[DP_SWITCH]));
+                    characteristicActive.updateValue(newActive);
+                }
+            }
+
+            if (changes.hasOwnProperty(DP_FAN_SPEED)) {
+                const newRotationSpeed = this._getRotationSpeed(state);
+                if (newRotationSpeed) {
+                    if (characteristicRotationSpeed.value !== newRotationSpeed) characteristicRotationSpeed.updateValue(newRotationSpeed);
+                }
+                if (!changes.hasOwnProperty(DP_MODE)) characteristicTargetAirPurifierState.updateValue(this._getTargetAirPurifierState(this._getMode(state)));
             }
 
             if (characteristicLockPhysicalControls && changes.hasOwnProperty(DP_LOCK_PHYSICAL_CONTROLS)) {
-                /* Child Lock change */
                 const newLockPhysicalControls = this._getLockPhysicalControls(changes[DP_LOCK_PHYSICAL_CONTROLS]);
-                if (characteristicLockPhysicalControls.value !== newLockPhysicalControls) {
-                    characteristicLockPhysicalControls.updateValue(newLockPhysicalControls);
-                }
+                if (characteristicLockPhysicalControls.value !== newLockPhysicalControls) characteristicLockPhysicalControls.updateValue(newLockPhysicalControls);
             }
+
             if (changes.hasOwnProperty(DP_MODE)) {
-                /* Change to the running mode */
                 const newTargetAirPurifierState = this._getTargetAirPurifierState(changes[DP_MODE]);
-                if (characteristicTargetAirPurifierState.value !== newTargetAirPurifierState) {
-                    characteristicTargetAirPurifierState.updateValue(newTargetAirPurifierState);
-                }
+                if (characteristicTargetAirPurifierState.value !== newTargetAirPurifierState) characteristicTargetAirPurifierState.updateValue(newTargetAirPurifierState);
             }
+
             if (airQualitySensorService && changes.hasOwnProperty(DP_PM25)) {
-                /* Change to the air quality */
                 const newPM25 = changes[DP_PM25];
-                if (characteristicPM25Density.value !== newPM25) {
-                    characteristicPM25Density.updateValue(newPM25);
-                }
-                if (!changes.hasOwnProperty(DP_AIR_QUALITY)) {
-                    characteristicAirQuality.updateValue(this._getAirQuality(state));
-                }
+                if (characteristicPM25Density.value !== newPM25) characteristicPM25Density.updateValue(newPM25);
+                if (!changes.hasOwnProperty(DP_AIR_QUALITY)) characteristicAirQuality.updateValue(this._getAirQuality(state));
             }
-         });
-     }
-
-     /* Proscenic air purifier does not support DP_MODE but has fan speed 'auto' */
-     _getMode(state) {
-         if (state[DP_MODE]) {
-             return state[DP_MODE];
-         } else {
-             return state[DP_FAN_SPEED] == 'auto' ? 'auto' : 'manual';
-         }
-     }
-
-     getActive(callback) {
-         this.getState(DP_SWITCH, (err, dp) => {
-             if (err) {
-                return callback(err);
-            }
-            callback(null, this._getActive(dp));
         });
     }
+
+    _getMode(state) {
+        if (state[DP_MODE]) {
+            return state[DP_MODE];
+        } else {
+            return state[DP_FAN_SPEED] == 'auto' ? 'auto' : 'manual';
+        }
+    }
+
+    getActive() {
+        return this._getActive(this.getStateAsync(DP_SWITCH));
+    }
+
     _getActive(dp) {
         const {Characteristic} = this.hap;
         return dp ? Characteristic.Active.ACTIVE : Characteristic.Active.INACTIVE;
     }
-    setActive(value, callback) {
+
+    setActive(value) {
         const {Characteristic} = this.hap;
         switch (value) {
             case Characteristic.Active.ACTIVE:
-                return this.setState(DP_SWITCH, true, callback);
+                return this.setStateAsync(DP_SWITCH, true);
             case Characteristic.Active.INACTIVE:
-                return this.setState(DP_SWITCH, false, callback);
+                return this.setStateAsync(DP_SWITCH, false);
         }
-        callback();
     }
-    getAirQuality(callback) {
-        this.getState([DP_PM25], (err, dps) => {
-            if (err) {
-                return callback(err);
-            }
-            callback(null, this._getAirQuality(dps));
-        });
-    }
+
     _getAirQuality(dps) {
         const {Characteristic} = this.hap;
-        /* TODO: Other DP values can be used for Air Quality */
         switch (this.device.context.manufacturer) {
             case 'Breville':
                 if (dps[DP_AIR_QUALITY]) {
-                  switch (dps[DP_AIR_QUALITY]) {
-                      case 'poor':
-                          return Characteristic.AirQuality.POOR
-                      case 'good':
-                          return Characteristic.AirQuality.GOOD
-                      case 'great':
-                          return Characteristic.AirQuality.EXCELLENT
-                      default:
-                          this.log.warn('Unhandled _getAirQuality value: %s', dps[DP_AIR_QUALITY]);
-                          return Characteristic.AirQuality.UNKNOWN
-                  }
+                    switch (dps[DP_AIR_QUALITY]) {
+                        case 'poor': return Characteristic.AirQuality.POOR;
+                        case 'good': return Characteristic.AirQuality.GOOD;
+                        case 'great': return Characteristic.AirQuality.EXCELLENT;
+                        default:
+                            this.log.warn('Unhandled _getAirQuality value: %s', dps[DP_AIR_QUALITY]);
+                            return Characteristic.AirQuality.UNKNOWN;
+                    }
                 }
                 break;
             default:
-              if (dps[DP_PM25]) {
-                  /* Loop through the air quality levels until a match is found */
-                  for (var item of this.airQualityLevels) {
-                      if (dps[DP_PM25] >= item[0]) {
-                          return item[1];
-                      }
-                  }
-              }
+                if (dps[DP_PM25]) {
+                    for (var item of this.airQualityLevels) {
+                        if (dps[DP_PM25] >= item[0]) return item[1];
+                    }
+                }
         }
-        /* Default return value if nothing has already returned */
         return 0;
     }
-    getCurrentAirPurifierState(callback) {
-        this.getState(DP_SWITCH, (err, dp) => {
-            if (err) return callback(err);
-            callback(null, this._getCurrentAirPurifierState(dp));
-        });
-    }
+
     _getCurrentAirPurifierState(dp) {
         const {Characteristic} = this.hap;
-        /* There isn't really a direct mapping to this from the purifier,
-         * so just using as inactive or purifying.
-         */
         return dp ? Characteristic.CurrentAirPurifierState.PURIFYING_AIR : Characteristic.CurrentAirPurifierState.INACTIVE;
     }
-    getLockPhysicalControls(callback) {
-        this.getState(DP_LOCK_PHYSICAL_CONTROLS, (err, dp) => {
-            if (err) {
-                return callback(err);
-            }
-            callback(null, this._getLockPhysicalControls(dp));
-        });
+
+    getLockPhysicalControls() {
+        return this._getLockPhysicalControls(this.getStateAsync(DP_LOCK_PHYSICAL_CONTROLS));
     }
+
     _getLockPhysicalControls(dp) {
         const {Characteristic} = this.hap;
         return dp ? Characteristic.LockPhysicalControls.CONTROL_LOCK_ENABLED : Characteristic.LockPhysicalControls.CONTROL_LOCK_DISABLED;
     }
-    setLockPhysicalControls(value, callback) {
+
+    setLockPhysicalControls(value) {
         const {Characteristic} = this.hap;
         switch (value) {
             case Characteristic.LockPhysicalControls.CONTROL_LOCK_ENABLED:
-                return this.setState(DP_LOCK_PHYSICAL_CONTROLS, true, callback);
+                return this.setStateAsync(DP_LOCK_PHYSICAL_CONTROLS, true);
             case Characteristic.LockPhysicalControls.CONTROL_LOCK_DISABLED:
-                return this.setState(DP_LOCK_PHYSICAL_CONTROLS, false, callback);
+                return this.setStateAsync(DP_LOCK_PHYSICAL_CONTROLS, false);
         }
-        callback();
-     }
-
-     getPM25(callback) {
-         this.getState(DP_PM25, (err, dp) => {
-             if (err) {
-                 return callback(err);
-             }
-             callback(null, dp);
-         });
-     }
-
-    getRotationSpeed(callback) {
-        this.getState([DP_SWITCH, DP_FAN_SPEED], (err, dps) => {
-            if (err) {
-                return callback(err);
-            }
-            callback(null, this._getRotationSpeed(dps));
-        });
     }
+
+    getRotationSpeed() {
+        return this._getRotationSpeed(this.getStateAsync([DP_SWITCH, DP_FAN_SPEED]));
+    }
+
     _getRotationSpeed(dps) {
         if (!dps[DP_SWITCH]) {
             return 0;
@@ -437,29 +277,20 @@ class AirPurifierAccessory extends BaseAccessory {
         }
         return this._hkRotationSpeed = this.convertRotationSpeedFromTuyaToHomeKit(dps[DP_FAN_SPEED]);
     }
-    setRotationSpeed(value, callback) {
+
+    setRotationSpeed(value) {
         const {Characteristic} = this.hap;
         if (value === 0) {
-            this.setActive(Characteristic.Active.INACTIVE, callback);
+            return this.setActive(Characteristic.Active.INACTIVE);
         } else {
             this._hkRotationSpeed = value;
-            // This code was only sending the first code, not the second...
-            //const newState = {DP_SWITCH: true, DP_FAN_SPEED: this.convertRotationSpeedFromHomeKitToTuya(value)};
-            //this.log.debug('setRotationSpeed value: %s. State: %s', value, newState);
-            //return this.setMultiState(newState, callback);
-            return this.setState(DP_FAN_SPEED, this.convertRotationSpeedFromHomeKitToTuya(value), callback);
+            return this.setStateAsync(DP_FAN_SPEED, this.convertRotationSpeedFromHomeKitToTuya(value));
         }
-     }
+    }
 
-     getTargetAirPurifierState(callback) {
-         this.getState([DP_MODE, DP_FAN_SPEED], (err, dps) => {
-             if (err) {
-                 return callback(err);
-             }
-
-             callback(null, this._getTargetAirPurifierState(this._getMode(dps)));
-         });
-     }
+    getTargetAirPurifierState() {
+        return this._getTargetAirPurifierState(this._getMode(this.getStateAsync([DP_MODE, DP_FAN_SPEED])));
+    }
 
     _getTargetAirPurifierState(dp) {
         const {Characteristic} = this.hap;
@@ -468,8 +299,7 @@ class AirPurifierAccessory extends BaseAccessory {
             case 'Manual':
                 return Characteristic.TargetAirPurifierState.MANUAL;
             case 'Sleep':
-                //TODO: Handle differently than passing through?
-                // eslint-disable-next-line no-fallthrough
+            // eslint-disable-next-line no-fallthrough
             case 'auto':
             case 'Auto':
                 return Characteristic.TargetAirPurifierState.AUTO;
@@ -478,55 +308,40 @@ class AirPurifierAccessory extends BaseAccessory {
                 return STATE_OTHER;
         }
     }
-    setTargetAirPurifierState(value, callback) {
+
+    setTargetAirPurifierState(value) {
         const {Characteristic} = this.hap;
         switch (value) {
-             case Characteristic.TargetAirPurifierState.MANUAL:
-                if (this.device.context.manufacturer == 'Breville') {
-                     return this.setState(DP_MODE, 'manual', callback);
-                } else if (this.device.context.manufacturer == 'Proscenic') {
-                    // When going from auto to manual, set to the lowest speed
-                    return this.setState(DP_FAN_SPEED, 'sleep', callback); 
-
-                } else if (this.device.context.manufacturer == 'siguro') {
-                    // When going from auto to manual, set to the lowest speed
-                    return this.setState(DP_FAN_SPEED, 'sleep', callback); 
-                } else {
-                    return this.setState(DP_MODE, 'Manual', callback);
-                }
-
-             case Characteristic.TargetAirPurifierState.AUTO:
-                if (this.device.context.manufacturer == 'Breville') {
-                     return this.setState(DP_MODE, 'auto', callback);
-                } else if (this.device.context.manufacturer == 'Proscenic') {
-                    return this.setState(DP_FAN_SPEED, 'auto', callback);
-                } else if (this.device.context.manufacturer == 'siguro') {
-                     return this.setState(DP_FAN_SPEED, 'auto', callback);
-                } else {
-                     return this.setState(DP_MODE, 'Auto', callback);
-                }
+            case Characteristic.TargetAirPurifierState.MANUAL:
+                if (this.device.context.manufacturer == 'Breville') return this.setStateAsync(DP_MODE, 'manual');
+                else if (this.device.context.manufacturer == 'Proscenic') return this.setStateAsync(DP_FAN_SPEED, 'sleep');
+                else if (this.device.context.manufacturer == 'siguro') return this.setStateAsync(DP_FAN_SPEED, 'sleep');
+                else return this.setStateAsync(DP_MODE, 'Manual');
+            case Characteristic.TargetAirPurifierState.AUTO:
+                if (this.device.context.manufacturer == 'Breville') return this.setStateAsync(DP_MODE, 'auto');
+                else if (this.device.context.manufacturer == 'Proscenic') return this.setStateAsync(DP_FAN_SPEED, 'auto');
+                else if (this.device.context.manufacturer == 'siguro') return this.setStateAsync(DP_FAN_SPEED, 'auto');
+                else return this.setStateAsync(DP_MODE, 'Auto');
             default:
-                //TODO: Can we do anything about Sleep?
                 this.log.warn('Unhandled setTargetAirPurifierState value: %s', value);
         }
-        callback();
     }
+
     getKeyByValue(object, value) {
-      return Object.keys(object).find(key => object[key] === value);
+        return Object.keys(object).find(key => object[key] === value);
     }
+
     convertRotationSpeedFromHomeKitToTuya(value) {
         this.log.debug('convertRotationSpeedFromHomeKitToTuya: %s: %s', value, this._rotationStops[parseInt(value)]);
         return this._rotationStops[parseInt(value)];
     }
 
-     convertRotationSpeedFromTuyaToHomeKit(value) {
-         this.log.debug('convertRotationSpeedFromTuyaToHomeKit: %s: %s', value, this.getKeyByValue(this._rotationStops, value));
-         let speed = this.device.context.fanSpeedSteps ? '' + this.getKeyByValue(this._rotationStops, value) : this.getKeyByValue(this._rotationStops, value);
-         if (speed === undefined) {
-             return 0;
-         }
-         return speed;
-     }
+    convertRotationSpeedFromTuyaToHomeKit(value) {
+        this.log.debug('convertRotationSpeedFromTuyaToHomeKit: %s: %s', value, this.getKeyByValue(this._rotationStops, value));
+        let speed = this.device.context.fanSpeedSteps ? '' + this.getKeyByValue(this._rotationStops, value) : this.getKeyByValue(this._rotationStops, value);
+        if (speed === undefined) return 0;
+        return speed;
+    }
+}
 
- }
 module.exports = AirPurifierAccessory;

--- a/lib/BaseAccessory.js
+++ b/lib/BaseAccessory.js
@@ -106,6 +106,40 @@ class BaseAccessory {
         });
     }
 
+    getStateAsync(dp) {
+        if (!this.device.connected) throw new Error('Not connected');
+        if (Array.isArray(dp)) {
+            const ret = {};
+            dp.forEach(p => { ret[p] = this.device.state[p]; });
+            return ret;
+        }
+        return this.device.state[dp];
+    }
+
+    setStateAsync(dp, value) {
+        return this.setMultiStateAsync({[dp.toString()]: value});
+    }
+
+    setMultiStateAsync(dps) {
+        if (!this.device.connected) throw new Error('Not connected');
+        for (const dp in dps) {
+            if (dps.hasOwnProperty(dp) && dps[dp] !== this.device.state[dp]) {
+                this.device.update({[dp.toString()]: dps[dp]});
+            }
+        }
+    }
+
+    setMultiStateLegacyAsync(dps) {
+        if (!this.device.connected) throw new Error('Not connected');
+        this.device.update(dps);
+    }
+
+    getDividedStateAsync(dp, divisor) {
+        const data = this.getStateAsync(dp);
+        if (!isFinite(data)) throw new Error('Invalid state');
+        return this._getDividedState(data, divisor);
+    }
+
     _getDividedState(dp, divisor) {
         return (parseFloat(dp) / divisor) || 0;
     }

--- a/lib/ConvectorAccessory.js
+++ b/lib/ConvectorAccessory.js
@@ -45,27 +45,22 @@ class ConvectorAccessory extends BaseAccessory {
 
         const characteristicActive = service.getCharacteristic(Characteristic.Active)
             .updateValue(this._getActive(dps[this.dpActive]))
-            .on('get', this.getActive.bind(this))
-            .on('set', this.setActive.bind(this));
+            .onGet(() => this.getActive())
+            .onSet(value => this.setActive(value));
 
         service.getCharacteristic(Characteristic.CurrentHeaterCoolerState)
             .updateValue(this._getCurrentHeaterCoolerState(dps))
-            .on('get', this.getCurrentHeaterCoolerState.bind(this));
+            .onGet(() => this.getCurrentHeaterCoolerState());
 
         service.getCharacteristic(Characteristic.TargetHeaterCoolerState)
-            .setProps({
-                minValue: 1,
-                maxValue: 1,
-                validValues: [Characteristic.TargetHeaterCoolerState.HEAT]
-            })
+            .setProps({ minValue: 1, maxValue: 1, validValues: [Characteristic.TargetHeaterCoolerState.HEAT] })
             .updateValue(this._getTargetHeaterCoolerState())
-            .on('get', this.getTargetHeaterCoolerState.bind(this))
-            .on('set', this.setTargetHeaterCoolerState.bind(this));
+            .onGet(() => this._getTargetHeaterCoolerState())
+            .onSet(() => this.setStateAsync(this.dpActive, true));
 
         const characteristicCurrentTemperature = service.getCharacteristic(Characteristic.CurrentTemperature)
             .updateValue(dps[this.dpCurrentTemperature])
-            .on('get', this.getState.bind(this, this.dpCurrentTemperature));
-
+            .onGet(() => this.getStateAsync(this.dpCurrentTemperature));
 
         const characteristicHeatingThresholdTemperature = service.getCharacteristic(Characteristic.HeatingThresholdTemperature)
             .setProps({
@@ -74,30 +69,29 @@ class ConvectorAccessory extends BaseAccessory {
                 minStep: this.device.context.minTemperatureSteps || 1
             })
             .updateValue(dps[this.dpDesiredTemperature])
-            .on('get', this.getState.bind(this, this.dpDesiredTemperature))
-            .on('set', this.setTargetThresholdTemperature.bind(this));
-
+            .onGet(() => this.getStateAsync(this.dpDesiredTemperature))
+            .onSet(value => this.setTargetThresholdTemperature(value));
 
         let characteristicTemperatureDisplayUnits;
         if (!this.device.context.noTemperatureUnit) {
             characteristicTemperatureDisplayUnits = service.getCharacteristic(Characteristic.TemperatureDisplayUnits)
                 .updateValue(this._getTemperatureDisplayUnits(dps[this.dpTemperatureDisplayUnits]))
-                .on('get', this.getTemperatureDisplayUnits.bind(this))
-                .on('set', this.setTemperatureDisplayUnits.bind(this));
+                .onGet(() => this.getTemperatureDisplayUnits())
+                .onSet(value => this.setTemperatureDisplayUnits(value));
         } else this._removeCharacteristic(service, Characteristic.TemperatureDisplayUnits);
 
         let characteristicLockPhysicalControls;
         if (!this.device.context.noChildLock) {
             characteristicLockPhysicalControls = service.getCharacteristic(Characteristic.LockPhysicalControls)
                 .updateValue(this._getLockPhysicalControls(dps[this.dpChildLock]))
-                .on('get', this.getLockPhysicalControls.bind(this))
-                .on('set', this.setLockPhysicalControls.bind(this));
+                .onGet(() => this.getLockPhysicalControls())
+                .onSet(value => this.setLockPhysicalControls(value));
         } else this._removeCharacteristic(service, Characteristic.LockPhysicalControls);
 
         const characteristicRotationSpeed = service.getCharacteristic(Characteristic.RotationSpeed)
             .updateValue(this._getRotationSpeed(dps))
-            .on('get', this.getRotationSpeed.bind(this))
-            .on('set', this.setRotationSpeed.bind(this));
+            .onGet(() => this.getRotationSpeed())
+            .onSet(value => this.setRotationSpeed(value));
 
         this.characteristicActive = characteristicActive;
         this.characteristicHeatingThresholdTemperature = characteristicHeatingThresholdTemperature;
@@ -108,18 +102,13 @@ class ConvectorAccessory extends BaseAccessory {
                 const newActive = this._getActive(changes[this.dpActive]);
                 if (characteristicActive.value !== newActive) {
                     characteristicActive.updateValue(newActive);
-
-                    if (!changes.hasOwnProperty(this.dpRotationSpeed)) {
-                        characteristicRotationSpeed.updateValue(this._getRotationSpeed(state));
-                    }
+                    if (!changes.hasOwnProperty(this.dpRotationSpeed)) characteristicRotationSpeed.updateValue(this._getRotationSpeed(state));
                 }
             }
 
             if (characteristicLockPhysicalControls && changes.hasOwnProperty(this.dpChildLock)) {
                 const newLockPhysicalControls = this._getLockPhysicalControls(changes[this.dpChildLock]);
-                if (characteristicLockPhysicalControls.value !== newLockPhysicalControls) {
-                    characteristicLockPhysicalControls.updateValue(newLockPhysicalControls);
-                }
+                if (characteristicLockPhysicalControls.value !== newLockPhysicalControls) characteristicLockPhysicalControls.updateValue(newLockPhysicalControls);
             }
 
             if (changes.hasOwnProperty(this.dpDesiredTemperature)) {
@@ -127,7 +116,8 @@ class ConvectorAccessory extends BaseAccessory {
                     characteristicHeatingThresholdTemperature.updateValue(changes[this.dpDesiredTemperature]);
             }
 
-            if (changes.hasOwnProperty(this.dpCurrentTemperature) && characteristicCurrentTemperature.value !== changes[this.dpCurrentTemperature]) characteristicCurrentTemperature.updateValue(changes[this.dpCurrentTemperature]);
+            if (changes.hasOwnProperty(this.dpCurrentTemperature) && characteristicCurrentTemperature.value !== changes[this.dpCurrentTemperature])
+                characteristicCurrentTemperature.updateValue(changes[this.dpCurrentTemperature]);
 
             if (characteristicTemperatureDisplayUnits && changes.hasOwnProperty(this.dpTemperatureDisplayUnits)) {
                 const newTemperatureDisplayUnits = this._getTemperatureDisplayUnits(changes[this.dpTemperatureDisplayUnits]);
@@ -141,68 +131,46 @@ class ConvectorAccessory extends BaseAccessory {
         });
     }
 
-    getActive(callback) {
-        this.getState(this.dpActive, (err, dp) => {
-            if (err) return callback(err);
-
-            callback(null, this._getActive(dp));
-        });
+    getActive() {
+        return this._getActive(this.getStateAsync(this.dpActive));
     }
 
     _getActive(dp) {
         const {Characteristic} = this.hap;
-
         return dp ? Characteristic.Active.ACTIVE : Characteristic.Active.INACTIVE;
     }
 
-    setActive(value, callback) {
+    setActive(value) {
         const {Characteristic} = this.hap;
-
         switch (value) {
             case Characteristic.Active.ACTIVE:
-                return this.setState(this.dpActive, true, callback);
-
+                return this.setStateAsync(this.dpActive, true);
             case Characteristic.Active.INACTIVE:
-                return this.setState(this.dpActive, false, callback);
+                return this.setStateAsync(this.dpActive, false);
         }
-
-        callback();
     }
 
-    getLockPhysicalControls(callback) {
-        this.getState(this.dpChildLock, (err, dp) => {
-            if (err) return callback(err);
-
-            callback(null, this._getLockPhysicalControls(dp));
-        });
+    getLockPhysicalControls() {
+        return this._getLockPhysicalControls(this.getStateAsync(this.dpChildLock));
     }
 
     _getLockPhysicalControls(dp) {
         const {Characteristic} = this.hap;
-
         return dp ? Characteristic.LockPhysicalControls.CONTROL_LOCK_ENABLED : Characteristic.LockPhysicalControls.CONTROL_LOCK_DISABLED;
     }
 
-    setLockPhysicalControls(value, callback) {
+    setLockPhysicalControls(value) {
         const {Characteristic} = this.hap;
-
         switch (value) {
             case Characteristic.LockPhysicalControls.CONTROL_LOCK_ENABLED:
-                return this.setState(this.dpChildLock, true, callback);
-
+                return this.setStateAsync(this.dpChildLock, true);
             case Characteristic.LockPhysicalControls.CONTROL_LOCK_DISABLED:
-                return this.setState(this.dpChildLock, false, callback);
+                return this.setStateAsync(this.dpChildLock, false);
         }
-
-        callback();
     }
 
-    getCurrentHeaterCoolerState(callback) {
-        this.getState([this.dpActive], (err, dps) => {
-            if (err) return callback(err);
-
-            callback(null, this._getCurrentHeaterCoolerState(dps));
-        });
+    getCurrentHeaterCoolerState() {
+        return this._getCurrentHeaterCoolerState(this.getStateAsync([this.dpActive]));
     }
 
     _getCurrentHeaterCoolerState(dps) {
@@ -210,93 +178,62 @@ class ConvectorAccessory extends BaseAccessory {
         return dps[this.dpActive] ? Characteristic.CurrentHeaterCoolerState.HEATING : Characteristic.CurrentHeaterCoolerState.INACTIVE;
     }
 
-    getTargetHeaterCoolerState(callback) {
-        callback(null, this._getTargetHeaterCoolerState());
-    }
-
     _getTargetHeaterCoolerState() {
         const {Characteristic} = this.hap;
         return Characteristic.TargetHeaterCoolerState.HEAT;
     }
 
-    setTargetHeaterCoolerState(value, callback) {
-        this.setState(this.dpActive, true, callback);
+    async setTargetThresholdTemperature(value) {
+        await this.setStateAsync(this.dpDesiredTemperature, value);
+        if (this.characteristicHeatingThresholdTemperature) {
+            this.characteristicHeatingThresholdTemperature.updateValue(value);
+        }
     }
 
-    setTargetThresholdTemperature(value, callback) {
-        this.setState(this.dpDesiredTemperature, value, err => {
-            if (err) return callback(err);
-
-            if (this.characteristicHeatingThresholdTemperature) {
-                this.characteristicHeatingThresholdTemperature.updateValue(value);
-            }
-
-            callback();
-        });
-    }
-
-    getTemperatureDisplayUnits(callback) {
-        this.getState(this.dpTemperatureDisplayUnits, (err, dp) => {
-            if (err) return callback(err);
-
-            callback(null, this._getTemperatureDisplayUnits(dp));
-        });
+    getTemperatureDisplayUnits() {
+        return this._getTemperatureDisplayUnits(this.getStateAsync(this.dpTemperatureDisplayUnits));
     }
 
     _getTemperatureDisplayUnits(dp) {
         const {Characteristic} = this.hap;
-
         return dp === 'F' ? Characteristic.TemperatureDisplayUnits.FAHRENHEIT : Characteristic.TemperatureDisplayUnits.CELSIUS;
     }
 
-    setTemperatureDisplayUnits(value, callback) {
+    setTemperatureDisplayUnits(value) {
         const {Characteristic} = this.hap;
-
-        this.setState(this.dpTemperatureDisplayUnits, value === Characteristic.TemperatureDisplayUnits.FAHRENHEIT ? 'F' : 'C', callback);
+        return this.setStateAsync(this.dpTemperatureDisplayUnits, value === Characteristic.TemperatureDisplayUnits.FAHRENHEIT ? 'F' : 'C');
     }
 
-    getRotationSpeed(callback) {
-        this.getState([this.dpActive, this.dpRotationSpeed], (err, dps) => {
-            if (err) return callback(err);
-
-            callback(null, this._getRotationSpeed(dps));
-        });
+    getRotationSpeed() {
+        return this._getRotationSpeed(this.getStateAsync([this.dpActive, this.dpRotationSpeed]));
     }
 
     _getRotationSpeed(dps) {
         if (!dps[this.dpActive]) return 0;
-
         if (this._hkRotationSpeed) {
             const currntRotationSpeed = this.convertRotationSpeedFromHomeKitToTuya(this._hkRotationSpeed);
-
             return currntRotationSpeed === dps[this.dpRotationSpeed] ? this._hkRotationSpeed : this.convertRotationSpeedFromTuyaToHomeKit(dps[this.dpRotationSpeed]);
         }
-
         return this._hkRotationSpeed = this.convertRotationSpeedFromTuyaToHomeKit(dps[this.dpRotationSpeed]);
     }
 
-    setRotationSpeed(value, callback) {
+    setRotationSpeed(value) {
         const {Characteristic} = this.hap;
-
         if (value === 0) {
-            this.setActive(Characteristic.Active.INACTIVE, callback);
+            return this.setActive(Characteristic.Active.INACTIVE);
         } else {
             this._hkRotationSpeed = value;
-
             const newSpeed = this.convertRotationSpeedFromHomeKitToTuya(value);
             const currentSpeed = this.convertRotationSpeedFromHomeKitToTuya(this.characteristicRotationSpeed.value);
-
             if (this.enableFlipSpeedSlider) this._hkRotationSpeed = this.convertRotationSpeedFromTuyaToHomeKit(newSpeed);
 
             if (newSpeed !== currentSpeed) {
                 this.characteristicRotationSpeed.updateValue(this._hkRotationSpeed);
-                this.setMultiState({[this.dpActive]: true, [this.dpRotationSpeed]: newSpeed}, callback);
+                return this.setMultiStateAsync({[this.dpActive]: true, [this.dpRotationSpeed]: newSpeed});
             } else {
-                callback();
-                if (this.enableFlipSpeedSlider)
-                    process.nextTick(() => {
-                        this.characteristicRotationSpeed.updateValue(this._hkRotationSpeed);
-                    });
+                if (this.enableFlipSpeedSlider) {
+                    process.nextTick(() => { this.characteristicRotationSpeed.updateValue(this._hkRotationSpeed); });
+                }
             }
         }
     }

--- a/lib/CustomMultiOutletAccessory.js
+++ b/lib/CustomMultiOutletAccessory.js
@@ -1,5 +1,4 @@
 const BaseAccessory = require('./BaseAccessory');
-const async = require('async');
 
 class CustomMultiOutletAccessory extends BaseAccessory {
     static getCategory(Categories) {
@@ -31,7 +30,7 @@ class CustomMultiOutletAccessory extends BaseAccessory {
                 throw new Error('The outlet definition #${i} is missing or is malformed: ' + outlet);
 
             const name = ((outlet.name || '').trim() || 'Unnamed') + ' - ' + this.device.context.name;
-            let service = this.accessory.getServiceByUUIDAndSubType(Service.Outlet, 'outlet ' + outlet.dp);
+            let service = this.accessory.getServiceById(Service.Outlet.UUID, 'outlet ' + outlet.dp);
             if (service) this._checkServiceName(service, name);
             else service = this.accessory.addService(Service.Outlet, name, 'outlet ' + outlet.dp);
 
@@ -59,8 +58,8 @@ class CustomMultiOutletAccessory extends BaseAccessory {
 
             characteristics[match[1]] = service.getCharacteristic(Characteristic.On)
                 .updateValue(dps[match[1]])
-                .on('get', this.getPower.bind(this, match[1]))
-                .on('set', this.setPower.bind(this, match[1]));
+                .onGet(() => this.getPower(match[1]))
+                .onSet(value => this.setPower(match[1], value));
         });
 
         this.device.on('change', (changes, state) => {
@@ -70,41 +69,28 @@ class CustomMultiOutletAccessory extends BaseAccessory {
         });
     }
 
-    getPower(dp, callback) {
-        callback(null, this.device.state[dp]);
+    getPower(dp) {
+        return this.getStateAsync(dp);
     }
 
-    setPower(dp, value, callback) {
+    setPower(dp, value) {
         if (!this._pendingPower) {
-            this._pendingPower = {props: {}, callbacks: []};
+            this._pendingPower = {props: {}, resolvers: []};
         }
 
-        if (dp) {
-            if (this._pendingPower.timer) clearTimeout(this._pendingPower.timer);
+        if (this._pendingPower.timer) clearTimeout(this._pendingPower.timer);
+        this._pendingPower.props = {...this._pendingPower.props, ...{[dp]: value}};
 
-            this._pendingPower.props = {...this._pendingPower.props, ...{[dp]: value}};
-            this._pendingPower.callbacks.push(callback);
+        return new Promise(resolve => {
+            this._pendingPower.resolvers.push(resolve);
 
             this._pendingPower.timer = setTimeout(() => {
-                this.setPower();
+                const {props, resolvers} = this._pendingPower;
+                this._pendingPower = null;
+                this.setMultiStateAsync(props);
+                resolvers.forEach(r => r());
             }, 500);
-            return;
-        }
-
-        const callbacks = this._pendingPower.callbacks;
-        const callEachBack = err => {
-            async.eachSeries(callbacks, (callback, next) => {
-                try {
-                    callback(err);
-                } catch (ex) {}
-                next();
-            });
-        };
-
-        const newValue = this._pendingPower.props;
-        this._pendingPower = null;
-
-        this.setMultiState(newValue, callEachBack);
+        });
     }
 }
 

--- a/lib/DehumidifierAccessory.js
+++ b/lib/DehumidifierAccessory.js
@@ -17,17 +17,16 @@ class DehumidifierAccessory extends BaseAccessory {
 
         this.defaultDps = {
             'Active':     1,
-            'Mode':       2, // 0 - normal, 1 - continual, 2 - automatic, 3 - laundry
+            'Mode':       2,
             'Humidity':   4,
             'Cleaning':   5,
-            'FanSpeed':   6, // 1 - slow, 3 - fast
+            'FanSpeed':   6,
             'ChildLock':  7,
-            'TankState': 11, // 0 - not full, 8 - removed, ... - ?
-            // 12, 101, 105 - ?
+            'TankState': 11,
             'Sleep':    102,
             'CurrentTemperature': 103,
             'CurrentHumidity':    104,
-        }
+        };
     }
 
     _registerPlatformAccessory() {
@@ -58,13 +57,12 @@ class DehumidifierAccessory extends BaseAccessory {
         const characteristicTemperature = this.accessory.getService(Service.TemperatureSensor)
             .getCharacteristic(Characteristic.CurrentTemperature)
             .updateValue(this._getCurrentTemperature(dps[this.getDp('CurrentTemperature')]))
-            .on('get', this.getCurrentTemperature.bind(this));
-
+            .onGet(() => this._getCurrentTemperature(this.getStateAsync(this.getDp('CurrentTemperature'))));
 
         const characteristicCurrentHumidity = this.accessory.getService(Service.HumiditySensor)
             .getCharacteristic(Characteristic.CurrentRelativeHumidity)
             .updateValue(this._getCurrentHumidity(dps[this.getDp('CurrentHumidity')]))
-            .on('get', this.getCurrentHumidity.bind(this));
+            .onGet(() => this._getCurrentHumidity(this.getStateAsync(this.getDp('CurrentHumidity'))));
 
         const service = this.accessory.getService(Service.HumidifierDehumidifier);
         this._checkServiceName(service, this.device.context.name);
@@ -79,8 +77,8 @@ class DehumidifierAccessory extends BaseAccessory {
                     minStep: this.device.context.speedSteps || 1,
                 })
                 .updateValue(this._getRotationSpeed(dps))
-                .on('get', this.getRotationSpeed.bind(this))
-                .on('set', this.setRotationSpeed.bind(this));
+                .onGet(() => this.getRotationSpeed())
+                .onSet(value => this.setRotationSpeed(value));
         }
 
         this._removeCharacteristic(service, Characteristic.SwingMode);
@@ -91,196 +89,123 @@ class DehumidifierAccessory extends BaseAccessory {
 
         const characteristicCurrentHumidity2 = service.getCharacteristic(Characteristic.CurrentRelativeHumidity)
             .updateValue(this._getCurrentHumidity(dps[this.getDp('CurrentHumidity')]))
-            .on('get', this.getCurrentHumidity.bind(this));
+            .onGet(() => this._getCurrentHumidity(this.getStateAsync(this.getDp('CurrentHumidity'))));
 
         const characteristicActive = service.getCharacteristic(Characteristic.Active)
             .updateValue(this._getActive(dps[this.getDp('Active')]))
-            .on('get', this.getActive.bind(this))
-            .on('set', this.setActive.bind(this));
+            .onGet(() => this.getActive())
+            .onSet(value => this.setActive(value));
 
         const characteristicWaterTank = service.getCharacteristic(Characteristic.WaterLevel)
             .updateValue(dps[this.getDp('TankState')])
-            .on('get', this.getTankState.bind(this))
+            .onGet(() => this._getTankState(this.getStateAsync(this.getDp('TankState'))));
 
         let characteristicChildLock;
-
         if (!this.device.context.noChildLock) {
             let lockService = this.accessory.getService(Service.LockMechanism);
-            characteristicChildLock = lockService.getCharacteristic(Characteristic.LockCurrentState)
+            lockService.getCharacteristic(Characteristic.LockCurrentState)
                 .updateValue(this._getLockTargetState(dps[this.getDp('ChildLock')]))
-                .on('get', this.getLockTargetState.bind(this));
+                .onGet(() => this._getLockTargetState(this.getStateAsync(this.getDp('ChildLock'))));
             characteristicChildLock = lockService.getCharacteristic(Characteristic.LockTargetState)
                 .updateValue(this._getLockTargetState(dps[this.getDp('ChildLock')]))
-                .on('get', this.getLockTargetState.bind(this))
-                .on('set', this.setLockTargetState.bind(this));
+                .onGet(() => this._getLockTargetState(this.getStateAsync(this.getDp('ChildLock'))))
+                .onSet(value => this.setLockTargetState(value));
         } else this._removeCharacteristic(service, Characteristic.LockTargetState);
 
         this.characteristicHumidity = service.getCharacteristic(Characteristic.RelativeHumidityDehumidifierThreshold);
-        this.characteristicHumidity.setProps({
-                minStep: this.device.context.humiditySteps || 5,
-            })
+        this.characteristicHumidity.setProps({ minStep: this.device.context.humiditySteps || 5 })
             .updateValue(dps[this.getDp('Humidity')])
-            .on('get', this.getState.bind(this, this.getDp('Humidity')))
-            .on('set', this.setTargetHumidity.bind(this));
-
+            .onGet(() => this.getStateAsync(this.getDp('Humidity')))
+            .onSet(value => this.setTargetHumidity(value));
 
         this.device.on('change', (changes, state) => {
             if (changes.hasOwnProperty(this.getDp('Active'))) {
                 const newActive = this._getActive(changes[this.getDp('Active')]);
                 if (characteristicActive.value !== newActive) {
                     characteristicActive.updateValue(newActive);
-
-                    if (!changes.hasOwnProperty(this.getDp('FanSpeed'))) {
+                    if (!changes.hasOwnProperty(this.getDp('FanSpeed')) && characteristicSpeed) {
                         characteristicSpeed.updateValue(this._getRotationSpeed(state));
                     }
                 }
             }
 
-            if (changes.hasOwnProperty('Humidity') && this.characteristicHumidity.value !== changes[this.getDp('Humidity')]) this.characteristicHumidity.updateValue(changes[this.getDp('Humidity')]);
+            if (changes.hasOwnProperty('Humidity') && this.characteristicHumidity.value !== changes[this.getDp('Humidity')])
+                this.characteristicHumidity.updateValue(changes[this.getDp('Humidity')]);
 
             if (characteristicChildLock && changes.hasOwnProperty(this.getDp('ChildLock'))) {
                 const newChildLock = this._getLockTargetState(changes[this.getDp('ChildLock')]);
                 if (characteristicChildLock.value !== newChildLock) characteristicChildLock.updateValue(newChildLock);
             }
 
-            if (changes.hasOwnProperty(this.getDp('FanSpeed'))) {
+            if (changes.hasOwnProperty(this.getDp('FanSpeed')) && characteristicSpeed) {
                 const newSpeed = this._getRotationSpeed(state);
                 if (characteristicSpeed.value !== newSpeed) characteristicSpeed.updateValue(newSpeed);
             }
         });
     }
 
-    getActive(callback) {
-        this.getState(this.getDp('Active'), (err, dp) => {
-            if (err) return callback(err);
-
-            callback(null, this._getActive(dp));
-        });
+    getActive() {
+        return this._getActive(this.getStateAsync(this.getDp('Active')));
     }
 
     _getActive(dp) {
         const {Characteristic} = this.hap;
-
         return dp ? Characteristic.Active.ACTIVE : Characteristic.Active.INACTIVE;
     }
 
-    setActive(value, callback) {
+    setActive(value) {
         const {Characteristic} = this.hap;
-
         switch (value) {
             case Characteristic.Active.ACTIVE:
-                return this.setState(this.getDp('Active'), true, callback);
-
+                return this.setStateAsync(this.getDp('Active'), true);
             case Characteristic.Active.INACTIVE:
-                return this.setState(this.getDp('Active'), false, callback);
+                return this.setStateAsync(this.getDp('Active'), false);
         }
-
-        callback();
-    }
-
-    getTankState(callback) {
-        this.getState(this.getDp('TankState'), (err, dp) => {
-            if (err) return callback(err);
-
-            callback(null, this._getTankState(dp));
-        });
     }
 
     _getTankState(dp) {
-        const {Characteristic} = this.hap;
-
         return dp ? 100 : 50;
-    }
-
-    getLockTargetState(callback) {
-        this.getState(this.getDp('ChildLock'), (err, dp) => {
-            if (err) return callback(err);
-
-            callback(null, this._getLockTargetState(dp));
-        });
     }
 
     _getLockTargetState(dp) {
         const {Characteristic} = this.hap;
-
         return dp ? Characteristic.LockTargetState.SECURED : Characteristic.LockTargetState.UNSECURED;
     }
 
-    setLockTargetState(value, callback) {
-        if (this.device.context.noLock) return callback();
-
+    setLockTargetState(value) {
+        if (this.device.context.noLock) return;
         const {Characteristic} = this.hap;
-
         switch (value) {
             case Characteristic.LockTargetState.SECURED:
-                return this.setState(this.getDp('ChildLock'), true, callback);
-
+                return this.setStateAsync(this.getDp('ChildLock'), true);
             case Characteristic.LockTargetState.UNSECURED:
-                return this.setState(this.getDp('ChildLock'), false, callback);
+                return this.setStateAsync(this.getDp('ChildLock'), false);
         }
-
-        callback();
     }
 
-    getRotationSpeed(callback) {
-        this.getState(this.getDp('FanSpeed'), (err, dp) => {
-            if (err) return callback(err);
-
-            callback(null, this._getRotationSpeed(dp));
-        });
+    getRotationSpeed() {
+        return this._getRotationSpeed(this.getStateAsync(this.getDp('FanSpeed')));
     }
 
     _getRotationSpeed(dp) {
-        const {Characteristic} = this.hap;
-
-        return dp > 1 ? dp-1 : dp;
+        return dp > 1 ? dp - 1 : dp;
     }
 
-    setRotationSpeed(value, callback) {
-        if (this.device.context.noSpeed) return callback();
+    setRotationSpeed(value) {
+        if (this.device.context.noSpeed) return;
         value > 1 ? value++ : null;
-        return this.setState(this.getDp('FanSpeed'), value.toString(), callback);
-    }
-
-    getCurrentHumidity(callback) {
-        this.getState(this.getDp('CurrentHumidity'), (err, dp) => {
-            if (err) return callback(err);
-
-            callback(null, this._getCurrentHumidity(dp));
-        });
+        return this.setStateAsync(this.getDp('FanSpeed'), value.toString());
     }
 
     _getCurrentHumidity(dp) {
         return dp;
     }
 
-    getCurrentTemperature(callback) {
-        this.getState(this.getDp('CurrentTemperature'), (err, dp) => {
-            if (err) return callback(err);
-
-            callback(null, this._getCurrentTemperature(dp));
-        });
-    }
-
     _getCurrentTemperature(dp) {
         return dp;
     }
 
-    getTargetHumidity(callback) {
-        this.getState([this.getDp('Active'), this.getDp('Humidity')], (err, dps) => {
-            if (err) return callback(err);
-
-            callback(null, this._getTargetHumidity(dps));
-        });
-    }
-
-    _getTargetHumidity(dps) {
-        if (!dps[this.getDp('Active')]) return 0;
-
-        return dps[this.getDp('Humidity')];
-    }
-
-    setTargetHumidity(value, callback) {
+    setTargetHumidity(value) {
         const {Characteristic} = this.hap;
 
         let origValue = value;
@@ -290,7 +215,7 @@ class DehumidifierAccessory extends BaseAccessory {
             this.characteristicHumidity.updateValue(value);
         }
 
-        this.setMultiState({[this.getDp('Active')]: true, [this.getDp('Humidity')]: value}, callback);
+        return this.setMultiStateAsync({[this.getDp('Active')]: true, [this.getDp('Humidity')]: value});
     }
 
     getDp(name) {

--- a/lib/EnergyCharacteristics.js
+++ b/lib/EnergyCharacteristics.js
@@ -1,14 +1,14 @@
 // Thanks to homebridge-tplink-smarthome
 
-module.exports = function(Characteristic) {
+module.exports = function({Characteristic, Formats, Perms}) {
     class EnergyCharacteristic extends Characteristic {
         constructor(displayName, UUID, props) {
             super(displayName, UUID);
             this.setProps(Object.assign({
-                format: Characteristic.Formats.FLOAT,
+                format: Formats.FLOAT,
                 minValue: 0,
                 maxValue: 65535,
-                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
+                perms: [Perms.READ, Perms.NOTIFY]
             }, props));
             this.value = this.getDefaultValue();
         }
@@ -39,7 +39,7 @@ module.exports = function(Characteristic) {
     class KilowattVoltAmpereHour extends EnergyCharacteristic {
         constructor() {
             super('Apparent Energy', KilowattVoltAmpereHour.UUID, {
-                format: Characteristic.Formats.UINT32,
+                format: Formats.UINT32,
                 unit: 'kVAh',
                 minStep: 1
             });
@@ -51,7 +51,7 @@ module.exports = function(Characteristic) {
     class VoltAmperes extends EnergyCharacteristic {
         constructor() {
             super('Apparent Power', VoltAmperes.UUID, {
-                format: Characteristic.Formats.UINT16,
+                format: Formats.UINT16,
                 unit: 'VA',
                 minStep: 1
             });

--- a/lib/GarageDoorAccessory.js
+++ b/lib/GarageDoorAccessory.js
@@ -1,30 +1,20 @@
 const BaseAccessory = require('./BaseAccessory');
 
-// define constants for Kogan garage door.
 // Action
 const GARAGE_DOOR_OPEN = 'open';
 const GARAGE_DOOR_CLOSE = 'close';
-const GARAGE_DOOR_FOPEN = 'fopen';
-const GARAGE_DOOR_FCLOSE = 'fclose';
 
 // Status or state
 // yes, 'openning' is not a mistake, that's the text from the Kogan opener
 const GARAGE_DOOR_OPENED = 'opened';
 const GARAGE_DOOR_CLOSED = 'closed';
 const GARAGE_DOOR_OPENNING = 'openning';
-const GARAGE_DOOR_OPENING =
-    'opening'; // 'opening' is not currently a valid value; added in case Kogan
-               // one day decides to correct the spelling
+const GARAGE_DOOR_OPENING = 'opening';
 const GARAGE_DOOR_CLOSING = 'closing';
-// Kogan garage door appears to have no stopped status
 
-// Kogan manufacturer name
 const GARAGE_DOOR_MANUFACTURER_KOGAN = 'Kogan';
-
-// Wofea manufacturer name
 const GARAGE_DOOR_MANUFACTURER_WOFEA = 'Wofea';
 
-// main code
 class GarageDoorAccessory extends BaseAccessory {
     static getCategory(Categories) {
         return Categories.GARAGE_DOOR_OPENER;
@@ -42,77 +32,49 @@ class GarageDoorAccessory extends BaseAccessory {
         super._registerPlatformAccessory();
     }
 
-    // function to return a ID string for log messages
     _logPrefix() {
         return (this.manufacturer ? this.manufacturer + ' ' : '') + 'GarageDoor';
     }
 
-    // function to prefix a string ID and always log to console
     _alwaysLog(...args) { this.log.info(this._logPrefix(), ...args); }
 
-    // function to log to console if debug is on
     _debugLog(...args) {
         this.log.debug(this._logPrefix(), ...args);
     }
 
-    // function to return true if the garage door manufacturer is Kogan and false
-    // otherwise
     _isKogan() {
-        if (this.manufacturer === GARAGE_DOOR_MANUFACTURER_KOGAN.trim()) {
-            return true;
-        } else {
-            return false;
-        }
+        return this.manufacturer === GARAGE_DOOR_MANUFACTURER_KOGAN.trim();
     }
 
-    // function to return true if the garage door manufacturer is Wofea
     _isWofea() {
-      if (this.manufacturer === GARAGE_DOOR_MANUFACTURER_WOFEA.trim()) {
-          return true;
-      } else {
-          return false;
-      }
-  }
+        return this.manufacturer === GARAGE_DOOR_MANUFACTURER_WOFEA.trim();
+    }
 
     _registerCharacteristics(dps) {
         const {Service, Characteristic} = this.hap;
         const service = this.accessory.getService(Service.GarageDoorOpener);
         this._checkServiceName(service, this.device.context.name);
 
-        // Set the manufacturer string
-        // If the manufacturer string matches a known manufacturer, set to that string
-        // Otherwise set the manufacturer to the defined value
-        // Otherwise set the manufacturer to a blank string
-        if (this.device.context.manufacturer.trim().toLowerCase() ===
-            GARAGE_DOOR_MANUFACTURER_KOGAN.trim().toLowerCase()) {
+        if (this.device.context.manufacturer.trim().toLowerCase() === GARAGE_DOOR_MANUFACTURER_KOGAN.trim().toLowerCase()) {
             this.manufacturer = GARAGE_DOOR_MANUFACTURER_KOGAN.trim();
-        } else if (this.device.context.manufacturer.trim().toLowerCase() ===
-            GARAGE_DOOR_MANUFACTURER_WOFEA.trim().toLowerCase()) {
+        } else if (this.device.context.manufacturer.trim().toLowerCase() === GARAGE_DOOR_MANUFACTURER_WOFEA.trim().toLowerCase()) {
             this.manufacturer = this.device.context.manufacturer.trim();
         } else if (this.device.context.manufacturer) {
             this.manufacturer = this.device.context.manufacturer.trim();
         } else {
             this.manufacturer = '';
         }
-        // set the dpAction and dpStatus values based on the manufacturer
+
         if (this._isKogan()) {
-            // Kogan SmarterHome Wireless Garage Door Opener
-            this._debugLog(
-                '_registerCharacteristics setting dpAction and dpStatus for ' +
-                GARAGE_DOOR_MANUFACTURER_KOGAN + ' garage door');
+            this._debugLog('_registerCharacteristics setting dpAction and dpStatus for ' + GARAGE_DOOR_MANUFACTURER_KOGAN + ' garage door');
             this.dpAction = this._getCustomDP(this.device.context.dpAction) || '101';
             this.dpStatus = this._getCustomDP(this.device.context.dpStatus) || '102';
         } else if (this._isWofea()) {
-            // Wofea Wifi Switch Smart Garage Door Opener
-            this._debugLog(
-                '_registerCharacteristics setting dpAction and dpStatus for ' +
-                GARAGE_DOOR_MANUFACTURER_WOFEA + ' garage door');
+            this._debugLog('_registerCharacteristics setting dpAction and dpStatus for ' + GARAGE_DOOR_MANUFACTURER_WOFEA + ' garage door');
             this.dpAction = this._getCustomDP(this.device.context.dpAction) || '1';
             this.dpStatus = this._getCustomDP(this.device.context.dpStatus) || '101';
         } else {
-            // the original garage door opener
-            this._debugLog(
-                '_registerCharacteristics setting dpAction and dpStatus for generic door');
+            this._debugLog('_registerCharacteristics setting dpAction and dpStatus for generic door');
             this.dpAction = this._getCustomDP(this.device.context.dpAction) || '1';
             this.dpStatus = this._getCustomDP(this.device.context.dpStatus) || '2';
         }
@@ -135,31 +97,25 @@ class GarageDoorAccessory extends BaseAccessory {
 
         const characteristicTargetDoorState = service.getCharacteristic(Characteristic.TargetDoorState)
             .updateValue(this._getTargetDoorState(dps[this.dpStatus]))
-            .on('get', this.getTargetDoorState.bind(this))
-            .on('set', this.setTargetDoorState.bind(this));
+            .onGet(() => this.getTargetDoorState())
+            .onSet(value => this.setTargetDoorState(value));
 
         const characteristicCurrentDoorState = service.getCharacteristic(Characteristic.CurrentDoorState)
             .updateValue(this._getCurrentDoorState(dps[this.dpStatus]))
-            .on('get', this.getCurrentDoorState.bind(this));
+            .onGet(() => this.getCurrentDoorState());
 
         this.device.on('change', changes => {
             this._alwaysLog('changed:' + JSON.stringify(changes));
 
             if (changes.hasOwnProperty(this.dpStatus)) {
-                const newCurrentDoorState =
-                    this._getCurrentDoorState(changes[this.dpStatus]);
-                this._debugLog('on change new and old CurrentDoorState ' +
-                    newCurrentDoorState + ' ' +
-                    characteristicCurrentDoorState.value);
-                this._debugLog('on change old characteristicTargetDoorState ' +
-                    characteristicTargetDoorState.value);
+                const newCurrentDoorState = this._getCurrentDoorState(changes[this.dpStatus]);
+                this._debugLog('on change new and old CurrentDoorState ' + newCurrentDoorState + ' ' + characteristicCurrentDoorState.value);
+                this._debugLog('on change old characteristicTargetDoorState ' + characteristicTargetDoorState.value);
 
-                if (newCurrentDoorState == this.currentOpen &&
-                    characteristicTargetDoorState.value !== this.targetOpen)
+                if (newCurrentDoorState == this.currentOpen && characteristicTargetDoorState.value !== this.targetOpen)
                     characteristicTargetDoorState.updateValue(this.targetOpen);
 
-                if (newCurrentDoorState == this.currentClosed &&
-                    characteristicTargetDoorState.value !== this.targetClosed)
+                if (newCurrentDoorState == this.currentClosed && characteristicTargetDoorState.value !== this.targetClosed)
                     characteristicTargetDoorState.updateValue(this.targetClosed);
 
                 if (characteristicCurrentDoorState.value !== newCurrentDoorState) characteristicCurrentDoorState.updateValue(newCurrentDoorState);
@@ -167,21 +123,16 @@ class GarageDoorAccessory extends BaseAccessory {
         });
     }
 
-    getTargetDoorState(callback) {
-        this.getState(this.dpStatus, (err, dp) => {
-            if (err) return callback(err);
-
-            this._debugLog('getTargetDoorState dp ' + JSON.stringify(dp));
-
-            callback(null, this._getTargetDoorState(dp));
-        });
+    getTargetDoorState() {
+        const dp = this.getStateAsync(this.dpStatus);
+        this._debugLog('getTargetDoorState dp ' + JSON.stringify(dp));
+        return this._getTargetDoorState(dp);
     }
 
     _getTargetDoorState(dp) {
         this._debugLog('_getTargetDoorState dp ' + JSON.stringify(dp));
 
         if (this._isKogan()) {
-            // translate the Kogan strings to the enumerated status values
             switch (dp) {
                 case GARAGE_DOOR_OPENED:
                 case GARAGE_DOOR_OPENNING:
@@ -193,112 +144,79 @@ class GarageDoorAccessory extends BaseAccessory {
                     return this.targetClosed;
 
                 default:
-                    this._alwaysLog('_getTargetDoorState UNKNOWN STATE ' +
-                        JSON.stringify(dp));
+                    this._alwaysLog('_getTargetDoorState UNKNOWN STATE ' + JSON.stringify(dp));
             }
         } else {
-            // Generic garage door uses true for the opened status and false for the
-            // closed status
             if (dp === true) {
                 return this.targetOpen;
             } else if (dp === false) {
                 return this.targetClosed;
             } else {
-                this._alwaysLog('_getTargetDoorState UNKNOWN STATE ' +
-                    JSON.stringify(dp));
+                this._alwaysLog('_getTargetDoorState UNKNOWN STATE ' + JSON.stringify(dp));
             }
         }
     }
 
-    setTargetDoorState(value, callback) {
-        var newValue = GARAGE_DOOR_CLOSE;
-        this._debugLog('setTargetDoorState value ' + value + ' targetOpen ' +
-            this.targetOpen + ' targetClosed ' + this.targetClosed);
+    setTargetDoorState(value) {
+        this._debugLog('setTargetDoorState value ' + value + ' targetOpen ' + this.targetOpen + ' targetClosed ' + this.targetClosed);
+        let newValue = GARAGE_DOOR_CLOSE;
 
         if (this._isKogan()) {
-            // translate the the enumerated status values to Kogan strings
             switch (value) {
                 case this.targetOpen:
                     newValue = GARAGE_DOOR_OPEN;
                     break;
-
                 case this.targetClosed:
                     newValue = GARAGE_DOOR_CLOSE;
                     break;
-
                 default:
-                    this._alwaysLog('setTargetDoorState UNKNOWN STATE ' +
-                        JSON.stringify(value));
+                    this._alwaysLog('setTargetDoorState UNKNOWN STATE ' + JSON.stringify(value));
             }
         } else {
-            // Generic garage door uses true for the open action and false for the
-            // close action
             switch (value) {
                 case this.targetOpen:
                     newValue = true;
                     break;
-
                 case this.targetClosed:
                     newValue = false;
                     break;
-
                 default:
-                    this._alwaysLog('setTargetDoorState UNKNOWN STATE ' +
-                        JSON.stringify(value));
+                    this._alwaysLog('setTargetDoorState UNKNOWN STATE ' + JSON.stringify(value));
             }
         }
 
-        this.setState(this.dpAction, newValue, callback);
+        return this.setStateAsync(this.dpAction, newValue);
     }
 
-    getCurrentDoorState(callback) {
-        this.getState(this.dpStatus, (err, dpStatusValue) => {
-            if (err) return callback(err);
-
-            callback(null, this._getCurrentDoorState(dpStatusValue));
-        });
+    getCurrentDoorState() {
+        const dpStatusValue = this.getStateAsync(this.dpStatus);
+        return this._getCurrentDoorState(dpStatusValue);
     }
 
     _getCurrentDoorState(dpStatusValue) {
-        this._debugLog('_getCurrentDoorState dpStatusValue ' +
-            JSON.stringify(dpStatusValue));
+        this._debugLog('_getCurrentDoorState dpStatusValue ' + JSON.stringify(dpStatusValue));
 
         if (this._isKogan()) {
-            // translate the Kogan strings to the enumerated status values
             switch (dpStatusValue) {
                 case GARAGE_DOOR_OPENED:
                     return this.currentOpen;
-
                 case GARAGE_DOOR_OPENNING:
                 case GARAGE_DOOR_OPENING:
                     return this.currentOpening;
-
                 case GARAGE_DOOR_CLOSING:
                     return this.currentClosing;
-
                 case GARAGE_DOOR_CLOSED:
                     return this.currentClosed;
-
                 default:
-                    this._alwaysLog('_getCurrentDoorState UNKNOWN STATUS ' +
-                        JSON.stringify(dpStatusValue));
+                    this._alwaysLog('_getCurrentDoorState UNKNOWN STATUS ' + JSON.stringify(dpStatusValue));
             }
         } else {
-            // Generic garage door uses true for the open status and false for the
-            // close status. It doesn't seem to have other values for opening and
-            // closing. If the getState() function callback in BaseAccessory.js passed
-            // the dps object into this function, we may be able to infer opening and
-            // closing from the combined dpStatus and dpAction values. That would
-            // require mods to every accessory that used that callback. Not worth it.
             if (dpStatusValue === true) {
-                // dpStatus true corresponds to an open door
                 return this.currentOpen;
             } else if (dpStatusValue === false) {
-                // dpStatus false corresponds to a closed door, so assume "not open"
                 return this.currentClosed;
             } else {
-                this._alwaysLog('_getCurrentDoorState UNKNOWN STATUS ' +
-                    JSON.stringify(dpStatusValue));
+                this._alwaysLog('_getCurrentDoorState UNKNOWN STATUS ' + JSON.stringify(dpStatusValue));
             }
         }
     }

--- a/lib/MultiOutletAccessory.js
+++ b/lib/MultiOutletAccessory.js
@@ -1,5 +1,4 @@
 const BaseAccessory = require('./BaseAccessory');
-const async = require('async');
 
 class MultiOutletAccessory extends BaseAccessory {
     static getCategory(Categories) {
@@ -25,7 +24,7 @@ class MultiOutletAccessory extends BaseAccessory {
         const outletCount = parseInt(this.device.context.outletCount) || 1;
         const _validServices = [];
         for (let i = 0; i++ < outletCount;) {
-            let service = this.accessory.getServiceByUUIDAndSubType(Service.Outlet, 'outlet ' + i);
+            let service = this.accessory.getServiceById(Service.Outlet.UUID, 'outlet ' + i);
             if (service) this._checkServiceName(service, this.device.context.name + ' ' + i);
             else service = this.accessory.addService(Service.Outlet, this.device.context.name + ' ' + i, 'outlet ' + i);
 
@@ -54,8 +53,8 @@ class MultiOutletAccessory extends BaseAccessory {
 
             characteristics[match[1]] = service.getCharacteristic(Characteristic.On)
                 .updateValue(dps[match[1]])
-                .on('get', this.getPower.bind(this, match[1]))
-                .on('set', this.setPower.bind(this, match[1]));
+                .onGet(() => this.getPower(match[1]))
+                .onSet(value => this.setPower(match[1], value));
         });
 
         this.device.on('change', (changes, state) => {
@@ -65,41 +64,28 @@ class MultiOutletAccessory extends BaseAccessory {
         });
     }
 
-    getPower(dp, callback) {
-        callback(null, this.device.state[dp]);
+    getPower(dp) {
+        return this.getStateAsync(dp);
     }
 
-    setPower(dp, value, callback) {
+    setPower(dp, value) {
         if (!this._pendingPower) {
-            this._pendingPower = {props: {}, callbacks: []};
+            this._pendingPower = {props: {}, resolvers: []};
         }
 
-        if (dp) {
-            if (this._pendingPower.timer) clearTimeout(this._pendingPower.timer);
+        if (this._pendingPower.timer) clearTimeout(this._pendingPower.timer);
+        this._pendingPower.props = {...this._pendingPower.props, ...{[dp]: value}};
 
-            this._pendingPower.props = {...this._pendingPower.props, ...{[dp]: value}};
-            this._pendingPower.callbacks.push(callback);
+        return new Promise(resolve => {
+            this._pendingPower.resolvers.push(resolve);
 
             this._pendingPower.timer = setTimeout(() => {
-                this.setPower();
+                const {props, resolvers} = this._pendingPower;
+                this._pendingPower = null;
+                this.setMultiStateAsync(props);
+                resolvers.forEach(r => r());
             }, 500);
-            return;
-        }
-
-        const callbacks = this._pendingPower.callbacks;
-        const callEachBack = err => {
-            async.eachSeries(callbacks, (callback, next) => {
-                try {
-                    callback(err);
-                } catch (ex) {}
-                next();
-            });
-        };
-
-        const newValue = this._pendingPower.props;
-        this._pendingPower = null;
-
-        this.setMultiState(newValue, callEachBack);
+        });
     }
 }
 

--- a/lib/OilDiffuserAccessory.js
+++ b/lib/OilDiffuserAccessory.js
@@ -1,5 +1,4 @@
 const BaseAccessory = require('./BaseAccessory');
-const async = require('async');
 
 class OilDiffuserAccessory extends BaseAccessory {
     static getCategory(Categories) {
@@ -11,27 +10,15 @@ class OilDiffuserAccessory extends BaseAccessory {
     }
 
     _isBelleLife() {
-        if (this.device.context.manufacturer.trim().toLowerCase() === 'bellelife') {
-            return true;
-        } else {
-            return false;
-        }
+        return this.device.context.manufacturer.trim().toLowerCase() === 'bellelife';
     }
-    
+
     _isGeeni() {
-        if (this.device.context.manufacturer.trim().toLowerCase() === 'geeni') {
-            return true;
-        } else {
-            return false;
-        }
+        return this.device.context.manufacturer.trim().toLowerCase() === 'geeni';
     }
 
     _isAsakuki() {
-        if (this.device.context.manufacturer.trim().toLowerCase() === 'asakuki') {
-            return true;
-        } else {
-            return false;
-        }
+        return this.device.context.manufacturer.trim().toLowerCase() === 'asakuki';
     }
 
     _registerPlatformAccessory() {
@@ -47,12 +34,12 @@ class OilDiffuserAccessory extends BaseAccessory {
         const {Service} = this.hap;
 
         const humidifierName = this.device.context.name;
-        let humidifierService = this.accessory.getServiceByUUIDAndSubType(Service.HumidifierDehumidifier, 'humidifier');
+        let humidifierService = this.accessory.getServiceById(Service.HumidifierDehumidifier.UUID, 'humidifier');
         if (humidifierService) this._checkServiceName(humidifierService, humidifierName);
         else humidifierService = this.accessory.addService(Service.HumidifierDehumidifier, humidifierName, 'humidifier');
 
         const lightName = this.device.context.name + ' Light';
-        let lightService = this.accessory.getServiceByUUIDAndSubType(Service.Lightbulb, 'lightbulb');
+        let lightService = this.accessory.getServiceById(Service.Lightbulb.UUID, 'lightbulb');
         if (lightService) this._checkServiceName(lightService, lightName);
         else lightService = this.accessory.addService(Service.Lightbulb, lightName, 'lightbulb');
 
@@ -66,10 +53,10 @@ class OilDiffuserAccessory extends BaseAccessory {
     _registerCharacteristics(dps) {
         this._verifyCachedPlatformAccessory();
 
-        const {Service, AdaptiveLightingController, Characteristic, EnergyCharacteristics} = this.hap;
+        const {Service, AdaptiveLightingController, Characteristic} = this.hap;
 
-        const humidifierService = this.accessory.getServiceByUUIDAndSubType(Service.HumidifierDehumidifier, 'humidifier');
-        const lightService = this.accessory.getServiceByUUIDAndSubType(Service.Lightbulb, 'lightbulb');
+        const humidifierService = this.accessory.getServiceById(Service.HumidifierDehumidifier.UUID, 'humidifier');
+        const lightService = this.accessory.getServiceById(Service.Lightbulb.UUID, 'lightbulb');
 
         this.dpLight = this._getCustomDP(this.device.context.dpLight) || '5';
         this.dpMode = this._getCustomDP(this.device.context.dpMode) || '6';
@@ -79,27 +66,24 @@ class OilDiffuserAccessory extends BaseAccessory {
         this.dpWaterLevel = this._getCustomDP(this.device.context.dpWaterLevel) || '9';
         this.maxSpeed = this._getCustomDP(this.device.context.maxSpeed) || 2;
 
-        if(this._isBelleLife()){
+        if (this._isBelleLife()) {
             this.cmdInterval = 'interval';
             this.cmdLow = 'small';
             this.cmdHigh = 'large';
-        }
-        else if(this._isGeeni()){
+        } else if (this._isGeeni()) {
             this.cmdInterval = '2';
             this.cmdContinuous = '1';
-        } 
-        else if(this._isAsakuki()){
+        } else if (this._isAsakuki()) {
             this.cmdLow = 'small';
             this.cmdHigh = 'big';
-        } 
-        else {
+        } else {
             this.cmdInterval = this.device.context.cmdInterval || '2';
             this.cmdContinuous = this.device.context.cmdContinuous || '1';
         }
 
         this._detectColorFunction(dps[this.dpColor]);
-	
-	    this.cmdWhite = 'white';
+
+        this.cmdWhite = 'white';
         if (this.device.context.cmdWhite) {
             if (/^w[a-z]+$/i.test(this.device.context.cmdWhite)) this.cmdWhite = ('' + this.device.context.cmdWhite).trim();
             else throw new Error(`The cmdWhite doesn't appear to be valid: ${this.device.context.cmdWhite}`);
@@ -115,92 +99,76 @@ class OilDiffuserAccessory extends BaseAccessory {
         }
 
         // Led Light
-
         const characteristicLightOn = lightService.getCharacteristic(Characteristic.On)
             .updateValue(dps[this.dpLight])
-            .on('get', this.getState.bind(this, this.dpLight))
-            .on('set', this.setState.bind(this, this.dpLight));
-	
-	    const characteristicBrightness = lightService.getCharacteristic(Characteristic.Brightness)
-            .updateValue(dps[this.dpMode] === this.cmdWhite ? this.convertBrightnessFromTuyaToHomeKit(dps[this.dpColor]).b : this.convertColorFromTuyaToHomeKit(dps[this.dpColor]).b)
-            .on('get', this.getBrightness.bind(this))
-            .on('set', this.setBrightness.bind(this));
+            .onGet(() => this.getStateAsync(this.dpLight))
+            .onSet(value => this.setStateAsync(this.dpLight, value));
 
-	    const characteristicColorTemperature = lightService.getCharacteristic(Characteristic.ColorTemperature)
-            .setProps({
-                minValue: 0,
-                maxValue: 600
-            })
+        const characteristicBrightness = lightService.getCharacteristic(Characteristic.Brightness)
+            .updateValue(dps[this.dpMode] === this.cmdWhite ? this.convertBrightnessFromTuyaToHomeKit(dps[this.dpColor]).b : this.convertColorFromTuyaToHomeKit(dps[this.dpColor]).b)
+            .onGet(() => this.getBrightness())
+            .onSet(value => this.setBrightness(value));
+
+        const characteristicColorTemperature = lightService.getCharacteristic(Characteristic.ColorTemperature)
+            .setProps({ minValue: 0, maxValue: 600 })
             .updateValue(dps[this.dpMode] === this.cmdWhite ? this.convertColorTemperatureFromTuyaToHomeKit(dps[this.dpColorTemperature]) : 0)
-            .on('get', this.getColorTemperature.bind(this))
-            .on('set', this.setColorTemperature.bind(this));
+            .onGet(() => this.getColorTemperature())
+            .onSet(value => this.setColorTemperature(value));
 
         const characteristicHue = lightService.getCharacteristic(Characteristic.Hue)
             .updateValue(this.convertColorFromTuyaToHomeKit(dps[this.dpColor]).h)
-            .on('get', this.getHue.bind(this))
-            .on('set', this.setHue.bind(this));
+            .onGet(() => this.getHue())
+            .onSet(value => this.setHue(value));
 
         const characteristicSaturation = lightService.getCharacteristic(Characteristic.Saturation)
-	    .updateValue(this.convertColorFromTuyaToHomeKit(dps[this.dpColor]).s)            
-            .on('get', this.getSaturation.bind(this))
-            .on('set', this.setSaturation.bind(this)); 
-
+            .updateValue(this.convertColorFromTuyaToHomeKit(dps[this.dpColor]).s)
+            .onGet(() => this.getSaturation())
+            .onSet(value => this.setSaturation(value));
 
         this.characteristicHue = characteristicHue;
         this.characteristicSaturation = characteristicSaturation;
-	    this.characteristicColorTemperature = characteristicColorTemperature;
-	    this.characteristicBrightness = characteristicBrightness;
+        this.characteristicColorTemperature = characteristicColorTemperature;
+        this.characteristicBrightness = characteristicBrightness;
 
-	    if (this.adaptiveLightingSupport()) {
+        if (this.adaptiveLightingSupport()) {
             this.adaptiveLightingController = new AdaptiveLightingController(lightService);
             this.accessory.configureController(this.adaptiveLightingController);
             this.accessory.adaptiveLightingController = this.adaptiveLightingController;
         }
 
         // Humidifier
-        
         const characteristicActive = humidifierService.getCharacteristic(Characteristic.Active)
             .updateValue(this._getActive(dps[this.dpActive]))
-            .on('get', this.getActive.bind(this))
-            .on('set', this.setActive.bind(this));
-            
+            .onGet(() => this.getActive())
+            .onSet(value => this.setActive(value));
+
         humidifierService.getCharacteristic(Characteristic.CurrentHumidifierDehumidifierState)
             .updateValue(this._getCurrentHumidifierDehumidifierState(dps))
-            .on('get', this.getCurrentHumidifierDehumidifierState.bind(this));
+            .onGet(() => this._getCurrentHumidifierDehumidifierState(this.getStateAsync([this.dpActive])));
 
         humidifierService.getCharacteristic(Characteristic.TargetHumidifierDehumidifierState)
-            .setProps({
-                minValue: 1,
-                maxValue: 1,
-                validValues: [1]
-            })
+            .setProps({ minValue: 1, maxValue: 1, validValues: [1] })
             .updateValue(this._getTargetHumidifierDehumidifierState())
-            .on('get', this.getTargetHumidifierDehumidifierState.bind(this))
-            .on('set', this.setTargetHumidifierDehumidifierState.bind(this));
+            .onGet(() => this._getTargetHumidifierDehumidifierState())
+            .onSet(() => this.setStateAsync(this.dpActive, true));
 
-	    const characteristicWaterLevel = humidifierService.getCharacteristic(Characteristic.WaterLevel)
+        const characteristicWaterLevel = humidifierService.getCharacteristic(Characteristic.WaterLevel)
             .updateValue(this._getWaterLevel(dps[this.dpWaterLevel]))
-            .on('get', this.getWaterLevel.bind(this))
-            
+            .onGet(() => this._getWaterLevel(this.getStateAsync(this.dpWaterLevel)));
+
         humidifierService.getCharacteristic(Characteristic.CurrentRelativeHumidity)
             .updateValue(this.dpActive ? 1 : 0)
-            .on('get', this.getRotationSpeed.bind(this));
- 
+            .onGet(() => this.getRotationSpeed());
+
         const characteristicRotationSpeed = humidifierService.getCharacteristic(Characteristic.RotationSpeed)
-        .setProps({
-            minValue: 0,
-            maxValue: this.maxSpeed,
-            minStep: 1
-        })
+            .setProps({ minValue: 0, maxValue: this.maxSpeed, minStep: 1 })
             .updateValue(this._getRotationSpeed(dps))
-            .on('get', this.getRotationSpeed.bind(this))
-            .on('set', this.setRotationSpeed.bind(this));
+            .onGet(() => this.getRotationSpeed())
+            .onSet(value => this.setRotationSpeed(value));
 
         this.characteristicActive = characteristicActive;
         this.characteristicRotationSpeed = characteristicRotationSpeed;
 
-        
-            
         this.device.on('change', (changes, state) => {
             if (changes.hasOwnProperty(this.dpLight) && characteristicLightOn.value !== changes[this.dpLight]) characteristicLightOn.updateValue(changes[this.dpLight]);
 
@@ -215,10 +183,10 @@ class OilDiffuserAccessory extends BaseAccessory {
             }
 
             if (changes.hasOwnProperty(this.dpWaterLevel) && characteristicWaterLevel) {
-                const waterLevel = changes[this.dpWaterLevel]
+                const waterLevel = changes[this.dpWaterLevel];
                 if (characteristicWaterLevel.value !== waterLevel) characteristicWaterLevel.updateValue(waterLevel);
             }
-            
+
             if (changes.hasOwnProperty(this.dpColor)) {
                 const oldColor = this.convertColorFromTuyaToHomeKit(this.convertColorFromHomeKitToTuya({
                     h: characteristicHue.value,
@@ -228,105 +196,85 @@ class OilDiffuserAccessory extends BaseAccessory {
                 const newColor = this.convertColorFromTuyaToHomeKit(changes[this.dpColor]);
 
                 if (oldColor.h !== newColor.h) characteristicHue.updateValue(newColor.h);
-
                 if (oldColor.s !== newColor.s) characteristicSaturation.updateValue(newColor.s);
-		
                 if (oldColor.b !== newColor.b) characteristicBrightness.updateValue(newColor.b);
             }
-
         });
     }
-    
-    getBrightness(callback) {
-        if (this.device.state[this.dpMode] === this.cmdWhite) return callback(null, this.convertBrightnessFromTuyaToHomeKit(this.device.state[this.dpColor]).b);
-        callback(null, this.convertColorFromTuyaToHomeKit(this.device.state[this.dpColor]).b);
+
+    getBrightness() {
+        if (this.device.state[this.dpMode] === this.cmdWhite) return this.convertBrightnessFromTuyaToHomeKit(this.device.state[this.dpColor]).b;
+        return this.convertColorFromTuyaToHomeKit(this.device.state[this.dpColor]).b;
     }
 
-    setBrightness(value, callback) {
-        if(value === 0) {  
-            return this.setState(this.dpLight, false, callback); 
-        }
-        else {
-            if (this.device.state[this.dpMode] === this.cmdWhite) return this.setState((this.dpColor).b, this.convertBrightnessFromHomeKitToTuya({b: value}), callback);
+    setBrightness(value) {
+        if (value === 0) {
+            return this.setStateAsync(this.dpLight, false);
+        } else {
+            if (this.device.state[this.dpMode] === this.cmdWhite) return this.setStateAsync((this.dpColor).b, this.convertBrightnessFromHomeKitToTuya({b: value}));
             this.device.state[this.dpMode] = this.cmdColor;
-            this.setMultiState({[this.dpMode]: this.cmdColor, [this.dpColor]: this.convertColorFromHomeKitToTuya({b: value})}, callback);
+            return this.setMultiStateAsync({[this.dpMode]: this.cmdColor, [this.dpColor]: this.convertColorFromHomeKitToTuya({b: value})});
         }
     }
 
-    getColorTemperature(callback) {
-        if (this.device.state[this.dpMode] !== this.cmdWhite) return callback(null, 0);
-        callback(null, this.convertColorTemperatureFromTuyaToHomeKit(this.device.state[this.dpColorTemperature]));
+    getColorTemperature() {
+        if (this.device.state[this.dpMode] !== this.cmdWhite) return 0;
+        return this.convertColorTemperatureFromTuyaToHomeKit(this.device.state[this.dpColorTemperature]);
     }
-    
-    setColorTemperature(value, callback) {
-        if (value === 0) return callback(null, true);
-	
-        const newColor = this.convertHomeKitColorTemperatureToHomeKitColor(value);
-	    const oldColor = this.convertColorFromTuyaToHomeKit(this.device.state[this.dpColor]);
 
+    setColorTemperature(value) {
+        if (value === 0) return;
+
+        const newColor = this.convertHomeKitColorTemperatureToHomeKitColor(value);
         this.characteristicHue.updateValue(newColor.h);
         this.characteristicSaturation.updateValue(newColor.s);
         this.device.state[this.dpMode] = this.cmdColor;
-	
-	    this.setMultiState({[this.dpMode]: this.cmdColor, [this.dpColor]: this.convertColorFromHomeKitToTuya(newColor)}, callback);
+
+        return this.setMultiStateAsync({[this.dpMode]: this.cmdColor, [this.dpColor]: this.convertColorFromHomeKitToTuya(newColor)});
     }
 
-    getHue(callback) {
-        if (this.device.state[this.dpMode] === this.cmdWhite) return callback(null, 0);
-        callback(null, this.convertColorFromTuyaToHomeKit(this.device.state[this.dpColor]).h);
+    getHue() {
+        if (this.device.state[this.dpMode] === this.cmdWhite) return 0;
+        return this.convertColorFromTuyaToHomeKit(this.device.state[this.dpColor]).h;
     }
 
-    setHue(value, callback) {
-        this._setHueSaturation({h: value}, callback);
+    setHue(value) {
+        return this._setHueSaturation({h: value});
     }
 
-    getSaturation(callback) {
-        callback(null, this.convertColorFromTuyaToHomeKit(this.device.state[this.dpColor]).s);
+    getSaturation() {
+        return this.convertColorFromTuyaToHomeKit(this.device.state[this.dpColor]).s;
     }
 
-    setSaturation(value, callback) {
-        this._setHueSaturation({s: value}, callback);
+    setSaturation(value) {
+        return this._setHueSaturation({s: value});
     }
 
-    _setHueSaturation(prop, callback) {
+    _setHueSaturation(prop) {
         if (!this._pendingHueSaturation) {
-            this._pendingHueSaturation = {props: {}, callbacks: []};
+            this._pendingHueSaturation = {props: {}, resolvers: []};
         }
 
-        if (prop) {
-            if (this._pendingHueSaturation.timer) clearTimeout(this._pendingHueSaturation.timer);
+        if (this._pendingHueSaturation.timer) clearTimeout(this._pendingHueSaturation.timer);
+        this._pendingHueSaturation.props = {...this._pendingHueSaturation.props, ...prop};
 
-            this._pendingHueSaturation.props = {...this._pendingHueSaturation.props, ...prop};
-            this._pendingHueSaturation.callbacks.push(callback);
+        return new Promise(resolve => {
+            this._pendingHueSaturation.resolvers.push(resolve);
 
             this._pendingHueSaturation.timer = setTimeout(() => {
-                this._setHueSaturation();
+                const {props, resolvers} = this._pendingHueSaturation;
+                this._pendingHueSaturation = null;
+
+                const newValue = this.convertColorFromHomeKitToTuya(props);
+                this.setMultiStateAsync({[this.dpMode]: this.cmdColor, [this.dpColor]: newValue});
+
+                resolvers.forEach(r => r());
             }, 500);
-            return;
-        }
-
-        const callbacks = this._pendingHueSaturation.callbacks;
-        const callEachBack = err => {
-            async.eachSeries(callbacks, (callback, next) => {
-                try {
-                    callback(err);
-                } catch (ex) {}
-                next();
-            });
-        };
-
-        const isSham = this._pendingHueSaturation.props.h === 0 && this._pendingHueSaturation.props.s === 0;
-        const newValue = this.convertColorFromHomeKitToTuya(this._pendingHueSaturation.props);
-        this._pendingHueSaturation = null;
-
-        this.setMultiState({[this.dpMode]: this.cmdColor, [this.dpColor]: newValue}, callEachBack);
-    }
-    
-    getActive(callback) {
-        this.getState(this.dpActive, (err, dp) => {
-            if (err) return callback(err);
-            callback(null, this._getActive(dp));
         });
+    }
+
+    getActive() {
+        return this._getActive(this.getStateAsync(this.dpActive));
     }
 
     _getActive(dp) {
@@ -334,25 +282,16 @@ class OilDiffuserAccessory extends BaseAccessory {
         return dp ? Characteristic.Active.ACTIVE : Characteristic.Active.INACTIVE;
     }
 
-    setActive(value, callback) {
-        if (this.characteristicActive.value !== value){
+    setActive(value) {
+        if (this.characteristicActive.value !== value) {
             const {Characteristic} = this.hap;
             switch (value) {
                 case Characteristic.Active.ACTIVE:
-                    return this.setState(this.dpActive, true, callback);
-
+                    return this.setStateAsync(this.dpActive, true);
                 case Characteristic.Active.INACTIVE:
-                    return this.setState(this.dpActive, false, callback);
+                    return this.setStateAsync(this.dpActive, false);
             }
-            callback();
         }
-    }
-    
-    getCurrentHumidifierDehumidifierState(callback) {
-        this.getState([this.dpActive], (err, dps) => {
-            if (err) return callback(err);
-            callback(null, this._getCurrentHumidifierDehumidifierState(dps));
-        });
     }
 
     _getCurrentHumidifierDehumidifierState(dps) {
@@ -360,59 +299,34 @@ class OilDiffuserAccessory extends BaseAccessory {
         return dps[this.dpActive] ? Characteristic.CurrentHumidifierDehumidifierState.HUMIDIFYING : Characteristic.CurrentHumidifierDehumidifierState.INACTIVE;
     }
 
-    getTargetHumidifierDehumidifierState(callback) {
-        this.getState([this.dpActive], (err, dps) => {
-            if (err) return callback(err);
-            callback(null, this._getTargetHumidifierDehumidifierState(dps));
-        });
-        //callback(null, this._getTargetHumidifierDehumidifierState());
-    }
-
     _getTargetHumidifierDehumidifierState() {
         const {Characteristic} = this.hap;
         return Characteristic.TargetHumidifierDehumidifierState.HUMIDIFIER;
     }
-    
-    setTargetHumidifierDehumidifierState(value, callback) {
-        this.setState(this.dpActive, true, callback);
-    }
 
-    getWaterLevel(callback) {
-        this.getState(this.dpWaterLevel, (err, dp) => {
-            if (err) return callback(err);
-            callback(null, this._getWaterLevel(dp));
-        });
-    }
-    
-    // Will hardcode water levels until its needed -Ed, mine only shows empty or not.
     _getWaterLevel(value) {
-	if(parseFloat(value) == 0) {return 69;}
-	else {return 0;}
+        if (parseFloat(value) == 0) { return 69; }
+        else { return 0; }
     }
 
-    getRotationSpeed(callback) {
-        this.getState([this.dpActive, this.dpRotationSpeed], (err, dps) => {
-            if (err) return callback(err);
-            callback(null, this._getRotationSpeed(dps));
-        });
+    getRotationSpeed() {
+        return this._getRotationSpeed(this.getStateAsync([this.dpActive, this.dpRotationSpeed]));
     }
 
     _getRotationSpeed(dps) {
         if (!dps[this.dpActive]) return 0;
         if (this._hkRotationSpeed) {
             const currentRotationSpeed = this.convertRotationSpeedFromHomeKitToTuya(this._hkRotationSpeed);
-
             return currentRotationSpeed === dps[this.dpRotationSpeed] ? this._hkRotationSpeed : this.convertRotationSpeedFromTuyaToHomeKit(dps[this.dpRotationSpeed]);
         }
-
         return this._hkRotationSpeed = this.convertRotationSpeedFromTuyaToHomeKit(dps[this.dpRotationSpeed]);
     }
 
-    setRotationSpeed(value, callback) {
+    setRotationSpeed(value) {
         const {Characteristic} = this.hap;
 
         if (value === 0) {
-            this.setState(this.dpActive, false, callback);
+            return this.setStateAsync(this.dpActive, false);
         } else {
             this._hkRotationSpeed = value;
             const newSpeed = this.convertRotationSpeedFromHomeKitToTuya(value);
@@ -421,13 +335,13 @@ class OilDiffuserAccessory extends BaseAccessory {
 
             if (newSpeed !== currentSpeed) {
                 this.characteristicRotationSpeed.updateValue(this._hkRotationSpeed);
-                this.setMultiState({[this.dpActive]: true, [this.dpRotationSpeed]: newSpeed}, callback);
+                return this.setMultiStateAsync({[this.dpActive]: true, [this.dpRotationSpeed]: newSpeed});
             } else {
-                callback();
-                if (this.enableFlipSpeedSlider)
+                if (this.enableFlipSpeedSlider) {
                     process.nextTick(() => {
                         this.characteristicRotationSpeed.updateValue(this._hkRotationSpeed);
                     });
+                }
             }
         }
     }
@@ -435,45 +349,30 @@ class OilDiffuserAccessory extends BaseAccessory {
     convertRotationSpeedFromTuyaToHomeKit(value) {
         if (this._isBelleLife()) {
             return {[this.cmdInterval]: 1, [this.cmdLow]: 2, [this.cmdHigh]: 3}[value];
-        }
-        else if (this._isGeeni()){
+        } else if (this._isGeeni()) {
             return {[this.cmdInterval]: 1, [this.cmdContinuous]: 2}[value];
-        }
-        else if (this._isAsakuki()){
+        } else if (this._isAsakuki()) {
             return {[this.cmdLow]: 1, [this.cmdHigh]: 2}[value];
-        }
-        else{
+        } else {
             return {[this.cmdInterval]: 1, [this.cmdContinuous]: 2}[value];
         }
     }
 
     convertRotationSpeedFromHomeKitToTuya(value) {
-            if (this._isBelleLife()) {
-                if (value < 2)
-                    return this.cmdLow;
-                else if (value < 3)
-                    return this.cmdMiddle
-                else
-                    return this.cmdHigh;
-            }
-            else if (this._isGeeni()) {
-                if (value < 2)
-                    return this.cmdInterval;
-                else
-                    return this.cmdContinuous;
-            }
-            else if (this._isAsakuki()) {
-                if (value < 2)
-                    return this.cmdLow;
-                else
-                    return this.cmdHigh;
-            }
-            else {
-                if (value < 2)
-                    return this.cmdLow;
-                else
-                    return this.cmdHigh;
-            }
+        if (this._isBelleLife()) {
+            if (value < 2) return this.cmdLow;
+            else if (value < 3) return this.cmdMiddle;
+            else return this.cmdHigh;
+        } else if (this._isGeeni()) {
+            if (value < 2) return this.cmdInterval;
+            else return this.cmdContinuous;
+        } else if (this._isAsakuki()) {
+            if (value < 2) return this.cmdLow;
+            else return this.cmdHigh;
+        } else {
+            if (value < 2) return this.cmdLow;
+            else return this.cmdHigh;
+        }
     }
 }
 

--- a/lib/OutletAccessory.js
+++ b/lib/OutletAccessory.js
@@ -37,31 +37,31 @@ class OutletAccessory extends BaseAccessory {
         if (energyKeys.volts) {
             characteristicVolts = service.getCharacteristic(EnergyCharacteristics.Volts)
                 .updateValue(this._getDividedState(dps[energyKeys.volts], energyKeys.voltsDivisor))
-                .on('get', this.getDividedState.bind(this, energyKeys.volts, energyKeys.voltsDivisor));
+                .onGet(() => this.getDividedStateAsync(energyKeys.volts, energyKeys.voltsDivisor));
         } else this._removeCharacteristic(service, EnergyCharacteristics.Volts);
 
         let characteristicAmps;
         if (energyKeys.amps) {
             characteristicAmps = service.getCharacteristic(EnergyCharacteristics.Amperes)
                 .updateValue(this._getDividedState(dps[energyKeys.amps], energyKeys.ampsDivisor))
-                .on('get', this.getDividedState.bind(this, energyKeys.amps, energyKeys.ampsDivisor));
+                .onGet(() => this.getDividedStateAsync(energyKeys.amps, energyKeys.ampsDivisor));
         } else this._removeCharacteristic(service, EnergyCharacteristics.Amperes);
 
         let characteristicWatts;
         if (energyKeys.watts) {
             characteristicWatts = service.getCharacteristic(EnergyCharacteristics.Watts)
                 .updateValue(this._getDividedState(dps[energyKeys.watts], energyKeys.wattsDivisor))
-                .on('get', this.getDividedState.bind(this, energyKeys.watts, energyKeys.wattsDivisor));
+                .onGet(() => this.getDividedStateAsync(energyKeys.watts, energyKeys.wattsDivisor));
         } else this._removeCharacteristic(service, EnergyCharacteristics.Watts);
-        
+
         const characteristicOn = service.getCharacteristic(Characteristic.On)
             .updateValue(dps[this.dpPower])
-            .on('get', this.getState.bind(this, this.dpPower))
-            .on('set', this.setState.bind(this, this.dpPower));
+            .onGet(() => this.getStateAsync(this.dpPower))
+            .onSet(value => this.setStateAsync(this.dpPower, value));
 
         this.device.on('change', changes => {
             if (changes.hasOwnProperty(this.dpPower) && characteristicOn.value !== changes[this.dpPower]) characteristicOn.updateValue(changes[this.dpPower]);
-            
+
             if (changes.hasOwnProperty(energyKeys.volts) && characteristicVolts) {
                 const newVolts = this._getDividedState(changes[energyKeys.volts], energyKeys.voltsDivisor);
                 if (characteristicVolts.value !== newVolts) characteristicVolts.updateValue(newVolts);

--- a/lib/RGBTWLightAccessory.js
+++ b/lib/RGBTWLightAccessory.js
@@ -1,5 +1,4 @@
 const BaseAccessory = require('./BaseAccessory');
-const async = require('async');
 
 class RGBTWLightAccessory extends BaseAccessory {
     static getCategory(Categories) {
@@ -48,13 +47,13 @@ class RGBTWLightAccessory extends BaseAccessory {
 
         const characteristicOn = service.getCharacteristic(Characteristic.On)
             .updateValue(dps[this.dpPower])
-            .on('get', this.getState.bind(this, this.dpPower))
-            .on('set', this.setState.bind(this, this.dpPower));
+            .onGet(() => this.getStateAsync(this.dpPower))
+            .onSet(value => this.setStateAsync(this.dpPower, value));
 
         const characteristicBrightness = service.getCharacteristic(Characteristic.Brightness)
             .updateValue(dps[this.dpMode] === this.cmdWhite ? this.convertBrightnessFromTuyaToHomeKit(dps[this.dpBrightness]) : this.convertColorFromTuyaToHomeKit(dps[this.dpColor]).b)
-            .on('get', this.getBrightness.bind(this))
-            .on('set', this.setBrightness.bind(this));
+            .onGet(() => this.getBrightness())
+            .onSet(value => this.setBrightness(value));
 
         const characteristicColorTemperature = service.getCharacteristic(Characteristic.ColorTemperature)
             .setProps({
@@ -62,18 +61,18 @@ class RGBTWLightAccessory extends BaseAccessory {
                 maxValue: this.device.context.maxWhiteColor
             })
             .updateValue(dps[this.dpMode] === this.cmdWhite ? this.convertColorTemperatureFromTuyaToHomeKit(dps[this.dpColorTemperature]) : this.device.context.minWhiteColor)
-            .on('get', this.getColorTemperature.bind(this))
-            .on('set', this.setColorTemperature.bind(this));
+            .onGet(() => this.getColorTemperature())
+            .onSet(value => this.setColorTemperature(value));
 
         const characteristicHue = service.getCharacteristic(Characteristic.Hue)
             .updateValue(dps[this.dpMode] === this.cmdWhite ? 0 : this.convertColorFromTuyaToHomeKit(dps[this.dpColor]).h)
-            .on('get', this.getHue.bind(this))
-            .on('set', this.setHue.bind(this));
+            .onGet(() => this.getHue())
+            .onSet(value => this.setHue(value));
 
         const characteristicSaturation = service.getCharacteristic(Characteristic.Saturation)
             .updateValue(dps[this.dpMode] === this.cmdWhite ? 0 : this.convertColorFromTuyaToHomeKit(dps[this.dpColor]).s)
-            .on('get', this.getSaturation.bind(this))
-            .on('set', this.setSaturation.bind(this));
+            .onGet(() => this.getSaturation())
+            .onSet(value => this.setSaturation(value));
 
         this.characteristicHue = characteristicHue;
         this.characteristicSaturation = characteristicSaturation;
@@ -94,24 +93,18 @@ class RGBTWLightAccessory extends BaseAccessory {
                         characteristicBrightness.updateValue(this.convertBrightnessFromTuyaToHomeKit(changes[this.dpBrightness]));
 
                     if (changes.hasOwnProperty(this.dpColorTemperature) && this.convertColorTemperatureFromHomeKitToTuya(characteristicColorTemperature.value) !== changes[this.dpColorTemperature]) {
-
                         const newColorTemperature = this.convertColorTemperatureFromTuyaToHomeKit(changes[this.dpColorTemperature]);
                         const newColor = this.convertHomeKitColorTemperatureToHomeKitColor(newColorTemperature);
-
                         characteristicHue.updateValue(newColor.h);
                         characteristicSaturation.updateValue(newColor.s);
                         characteristicColorTemperature.updateValue(newColorTemperature);
-
                     } else if (changes[this.dpMode] && !changes.hasOwnProperty(this.dpColorTemperature)) {
-
                         const newColorTemperature = this.convertColorTemperatureFromTuyaToHomeKit(state[this.dpColorTemperature]);
                         const newColor = this.convertHomeKitColorTemperatureToHomeKitColor(newColorTemperature);
-
                         characteristicHue.updateValue(newColor.h);
                         characteristicSaturation.updateValue(newColor.s);
                         characteristicColorTemperature.updateValue(newColorTemperature);
                     }
-
                     break;
 
                 default:
@@ -125,11 +118,8 @@ class RGBTWLightAccessory extends BaseAccessory {
 
                         if (oldColor.b !== newColor.b) characteristicBrightness.updateValue(newColor.b);
                         if (oldColor.h !== newColor.h) characteristicHue.updateValue(newColor.h);
-
                         if (oldColor.s !== newColor.s) characteristicSaturation.updateValue(newColor.s);
-
                         if (characteristicColorTemperature.value !== this.device.context.minWhiteColor) characteristicColorTemperature.updateValue(this.device.context.minWhiteColor);
-
                     } else if (changes[this.dpMode]) {
                         if (characteristicColorTemperature.value !== this.device.context.minWhiteColor) characteristicColorTemperature.updateValue(this.device.context.minWhiteColor);
                     }
@@ -137,113 +127,93 @@ class RGBTWLightAccessory extends BaseAccessory {
         });
     }
 
-    getBrightness(callback) {
-        if (this.device.state[this.dpMode] === this.cmdWhite) return callback(null, this.convertBrightnessFromTuyaToHomeKit(this.device.state[this.dpBrightness]));
-        callback(null, this.convertColorFromTuyaToHomeKit(this.device.state[this.dpColor]).b);
+    getBrightness() {
+        if (this.device.state[this.dpMode] === this.cmdWhite) return this.convertBrightnessFromTuyaToHomeKit(this.device.state[this.dpBrightness]);
+        return this.convertColorFromTuyaToHomeKit(this.device.state[this.dpColor]).b;
     }
 
-    setBrightness(value, callback) {
-        if (this.device.state[this.dpMode] === this.cmdWhite) return this.setState(this.dpBrightness, this.convertBrightnessFromHomeKitToTuya(value), callback);
-        this.setState(this.dpColor, this.convertColorFromHomeKitToTuya({b: value}), callback);
+    setBrightness(value) {
+        if (this.device.state[this.dpMode] === this.cmdWhite) return this.setStateAsync(this.dpBrightness, this.convertBrightnessFromHomeKitToTuya(value));
+        return this.setStateAsync(this.dpColor, this.convertColorFromHomeKitToTuya({b: value}));
     }
 
-    getColorTemperature(callback) {
-        if (this.device.state[this.dpMode] !== this.cmdWhite) return callback(null, this.device.context.minWhiteColor);
-        callback(null, this.convertColorTemperatureFromTuyaToHomeKit(this.device.state[this.dpColorTemperature]));
+    getColorTemperature() {
+        this.log.debug(`getColorTemperature`);
+        if (this.device.state[this.dpMode] !== this.cmdWhite) return this.device.context.minWhiteColor;
+        return this.convertColorTemperatureFromTuyaToHomeKit(this.device.state[this.dpColorTemperature]);
     }
 
-    setColorTemperature(value, callback) {
+    setColorTemperature(value) {
         this.log.debug(`setColorTemperature: ${value}`);
-        if (value === 0) return callback(null, true);
+        if (value === 0) return;
 
         const newColor = this.convertHomeKitColorTemperatureToHomeKitColor(value);
         this.characteristicHue.updateValue(newColor.h);
         this.characteristicSaturation.updateValue(newColor.s);
 
         if (this.device.state[this.dpMode] !== this.cmdWhite) {
-            this.setMultiState({[this.dpMode]: this.cmdWhite, [this.dpColorTemperature]: this.convertColorTemperatureFromHomeKitToTuya(value), [this.dpBrightness]: this.convertBrightnessFromHomeKitToTuya(this.convertColorFromTuyaToHomeKit(this.device.state[this.dpColor]).b)}, callback);
+            return this.setMultiStateAsync({[this.dpMode]: this.cmdWhite, [this.dpColorTemperature]: this.convertColorTemperatureFromHomeKitToTuya(value), [this.dpBrightness]: this.convertBrightnessFromHomeKitToTuya(this.convertColorFromTuyaToHomeKit(this.device.state[this.dpColor]).b)});
         } else {
-            this.setMultiState({[this.dpMode]: this.cmdWhite, [this.dpColorTemperature]: this.convertColorTemperatureFromHomeKitToTuya(value)}, callback);
+            return this.setMultiStateAsync({[this.dpMode]: this.cmdWhite, [this.dpColorTemperature]: this.convertColorTemperatureFromHomeKitToTuya(value)});
         }
     }
 
-    getHue(callback) {
+    getHue() {
         if (this.device.state[this.dpMode] === this.cmdWhite) {
-            const prepareHue = this.convertHomeKitColorTemperatureToHomeKitColor(this.convertColorTemperatureFromTuyaToHomeKit(this.device.state[this.dpColorTemperature]));
-            callback(null, prepareHue.h);
-        } else {
-            callback(null, this.convertColorFromTuyaToHomeKit(this.device.state[this.dpColor]).h);
+            return this.convertHomeKitColorTemperatureToHomeKitColor(this.convertColorTemperatureFromTuyaToHomeKit(this.device.state[this.dpColorTemperature])).h;
         }
+        return this.convertColorFromTuyaToHomeKit(this.device.state[this.dpColor]).h;
     }
 
-    setHue(value, callback) {
-        this._setHueSaturation({h: value}, callback);
+    setHue(value) {
+        return this._setHueSaturation({h: value});
     }
 
-    getSaturation(callback) {
+    getSaturation() {
         if (this.device.state[this.dpMode] === this.cmdWhite) {
-            const prepareSaturation = this.convertHomeKitColorTemperatureToHomeKitColor(this.convertColorTemperatureFromTuyaToHomeKit(this.device.state[this.dpColorTemperature]));
-            callback(null, prepareSaturation.s);
-        } else {
-            callback(null, this.convertColorFromTuyaToHomeKit(this.device.state[this.dpColor]).s);
+            return this.convertHomeKitColorTemperatureToHomeKitColor(this.convertColorTemperatureFromTuyaToHomeKit(this.device.state[this.dpColorTemperature])).s;
         }
+        return this.convertColorFromTuyaToHomeKit(this.device.state[this.dpColor]).s;
     }
 
-    setSaturation(value, callback) {
-        this._setHueSaturation({s: value}, callback);
+    setSaturation(value) {
+        return this._setHueSaturation({s: value});
     }
 
-    _setHueSaturation(prop, callback) {
+    _setHueSaturation(prop) {
         if (!this._pendingHueSaturation) {
-            this._pendingHueSaturation = {props: {}, callbacks: []};
+            this._pendingHueSaturation = {props: {}, resolvers: []};
         }
 
-        if (prop) {
-            if (this._pendingHueSaturation.timer) clearTimeout(this._pendingHueSaturation.timer);
+        if (this._pendingHueSaturation.timer) clearTimeout(this._pendingHueSaturation.timer);
+        this._pendingHueSaturation.props = {...this._pendingHueSaturation.props, ...prop};
 
-            this._pendingHueSaturation.props = {...this._pendingHueSaturation.props, ...prop};
-            this._pendingHueSaturation.callbacks.push(callback);
+        return new Promise(resolve => {
+            this._pendingHueSaturation.resolvers.push(resolve);
 
             this._pendingHueSaturation.timer = setTimeout(() => {
-                this._setHueSaturation();
-            }, 500);
-            return;
-        }
+                const {props, resolvers} = this._pendingHueSaturation;
+                this._pendingHueSaturation = null;
 
-        //this.characteristicColorTemperature.updateValue(0);
+                if (this.device.state[this.dpMode] !== this.cmdColor)
+                    props.b = this.convertBrightnessFromTuyaToHomeKit(this.device.state[this.dpBrightness]);
 
-        const callbacks = this._pendingHueSaturation.callbacks;
-        const callEachBack = err => {
-            async.eachSeries(callbacks, (callback, next) => {
-                try {
-                    callback(err);
-                } catch (ex) {}
-                next();
-            }, () => {
+                const isSham = props.h === 0 && props.s === 0;
+                const newValue = this.convertColorFromHomeKitToTuya(props);
+
+                if (!(this.device.state[this.dpMode] === this.cmdWhite && isSham)) {
+                    this.setMultiStateAsync({[this.dpMode]: this.cmdColor, [this.dpColor]: newValue});
+                }
                 this.characteristicColorTemperature.updateValue(this.device.context.minWhiteColor);
-            });
-        };
 
-        if (this.device.state[this.dpMode] !== this.cmdColor)
-            this._pendingHueSaturation.props.b = this.convertBrightnessFromTuyaToHomeKit(this.device.state[this.dpBrightness]);
-
-        const isSham = this._pendingHueSaturation.props.h === 0 && this._pendingHueSaturation.props.s === 0;
-        const newValue = this.convertColorFromHomeKitToTuya(this._pendingHueSaturation.props);
-        this._pendingHueSaturation = null;
-
-
-        if (this.device.state[this.dpMode] === this.cmdWhite && isSham) return callEachBack();
-
-        this.setMultiState({[this.dpMode]: this.cmdColor, [this.dpColor]: newValue}, callEachBack);
+                resolvers.forEach(r => r());
+            }, 500);
+        });
     }
 
     getControllers() {
-        if (!this.adaptiveLightingController) {
-            return [];
-        } else {
-            return [this.adaptiveLightingController];
-        }
-      }
+        return this.adaptiveLightingController ? [this.adaptiveLightingController] : [];
+    }
 }
 
 module.exports = RGBTWLightAccessory;

--- a/lib/RGBTWOutletAccessory.js
+++ b/lib/RGBTWOutletAccessory.js
@@ -1,5 +1,4 @@
 const BaseAccessory = require('./BaseAccessory');
-const async = require('async');
 
 class RGBTWOutletAccessory extends BaseAccessory {
     static getCategory(Categories) {
@@ -23,12 +22,12 @@ class RGBTWOutletAccessory extends BaseAccessory {
         const {Service} = this.hap;
 
         const outletName = 'Outlet - ' + this.device.context.name;
-        let outletService = this.accessory.getServiceByUUIDAndSubType(Service.Outlet, 'outlet');
+        let outletService = this.accessory.getServiceById(Service.Outlet.UUID, 'outlet');
         if (outletService) this._checkServiceName(outletService, outletName);
         else outletService = this.accessory.addService(Service.Outlet, outletName, 'outlet');
 
         const lightName = 'RGBTWLight - ' + this.device.context.name;
-        let lightService = this.accessory.getServiceByUUIDAndSubType(Service.Lightbulb, 'lightbulb');
+        let lightService = this.accessory.getServiceById(Service.Lightbulb.UUID, 'lightbulb');
         if (lightService) this._checkServiceName(lightService, lightName);
         else lightService = this.accessory.addService(Service.Lightbulb, lightName, 'lightbulb');
 
@@ -44,15 +43,14 @@ class RGBTWOutletAccessory extends BaseAccessory {
 
         const {Service, Characteristic, EnergyCharacteristics} = this.hap;
 
-        const outletService = this.accessory.getServiceByUUIDAndSubType(Service.Outlet, 'outlet');
-        const lightService = this.accessory.getServiceByUUIDAndSubType(Service.Lightbulb, 'lightbulb');
+        const outletService = this.accessory.getServiceById(Service.Outlet.UUID, 'outlet');
+        const lightService = this.accessory.getServiceById(Service.Lightbulb.UUID, 'lightbulb');
 
         this.dpLight = this._getCustomDP(this.device.context.dpLight) || '1';
         this.dpMode = this._getCustomDP(this.device.context.dpMode) || '2';
         this.dpBrightness = this._getCustomDP(this.device.context.dpBrightness) || '3';
         this.dpColorTemperature = this._getCustomDP(this.device.context.dpColorTemperature) || '4';
         this.dpColor = this._getCustomDP(this.device.context.dpColor) || '5';
-
         this.dpPower = this._getCustomDP(this.device.context.dpPower) || '101';
 
         this._detectColorFunction(dps[this.dpColor]);
@@ -80,65 +78,62 @@ class RGBTWOutletAccessory extends BaseAccessory {
             watts: this._getCustomDP(this.device.context.wattsId),
             wattsDivisor: parseInt(this.device.context.wattsDivisor) || 10
         };
-        
+
         const characteristicLightOn = lightService.getCharacteristic(Characteristic.On)
             .updateValue(dps[this.dpLight])
-            .on('get', this.getState.bind(this, this.dpLight))
-            .on('set', this.setState.bind(this, this.dpLight));
+            .onGet(() => this.getStateAsync(this.dpLight))
+            .onSet(value => this.setStateAsync(this.dpLight, value));
 
         const characteristicBrightness = lightService.getCharacteristic(Characteristic.Brightness)
             .updateValue(dps[this.dpMode] === this.cmdWhite ? this.convertBrightnessFromTuyaToHomeKit(dps[this.dpBrightness]) : this.convertColorFromTuyaToHomeKit(dps[this.dpColor]).b)
-            .on('get', this.getBrightness.bind(this))
-            .on('set', this.setBrightness.bind(this));
+            .onGet(() => this.getBrightness())
+            .onSet(value => this.setBrightness(value));
 
         const characteristicColorTemperature = lightService.getCharacteristic(Characteristic.ColorTemperature)
-            .setProps({
-                minValue: 0,
-                maxValue: 600
-            })
+            .setProps({ minValue: 0, maxValue: 600 })
             .updateValue(dps[this.dpMode] === this.cmdWhite ? this.convertColorTemperatureFromTuyaToHomeKit(dps[this.dpColorTemperature]) : 0)
-            .on('get', this.getColorTemperature.bind(this))
-            .on('set', this.setColorTemperature.bind(this));
+            .onGet(() => this.getColorTemperature())
+            .onSet(value => this.setColorTemperature(value));
 
         const characteristicHue = lightService.getCharacteristic(Characteristic.Hue)
             .updateValue(dps[this.dpMode] === this.cmdWhite ? 0 : this.convertColorFromTuyaToHomeKit(dps[this.dpColor]).h)
-            .on('get', this.getHue.bind(this))
-            .on('set', this.setHue.bind(this));
+            .onGet(() => this.getHue())
+            .onSet(value => this.setHue(value));
 
         const characteristicSaturation = lightService.getCharacteristic(Characteristic.Saturation)
             .updateValue(dps[this.dpMode] === this.cmdWhite ? 0 : this.convertColorFromTuyaToHomeKit(dps[this.dpColor]).s)
-            .on('get', this.getSaturation.bind(this))
-            .on('set', this.setSaturation.bind(this));
+            .onGet(() => this.getSaturation())
+            .onSet(value => this.setSaturation(value));
 
         this.characteristicHue = characteristicHue;
         this.characteristicSaturation = characteristicSaturation;
         this.characteristicColorTemperature = characteristicColorTemperature;
-        
+
         let characteristicVolts;
         if (energyKeys.volts) {
             characteristicVolts = outletService.getCharacteristic(EnergyCharacteristics.Volts)
                 .updateValue(this._getDividedState(dps[energyKeys.volts], energyKeys.voltsDivisor))
-                .on('get', this.getDividedState.bind(this, energyKeys.volts, energyKeys.voltsDivisor));
+                .onGet(() => this.getDividedStateAsync(energyKeys.volts, energyKeys.voltsDivisor));
         } else this._removeCharacteristic(outletService, EnergyCharacteristics.Volts);
 
         let characteristicAmps;
         if (energyKeys.amps) {
             characteristicAmps = outletService.getCharacteristic(EnergyCharacteristics.Amperes)
                 .updateValue(this._getDividedState(dps[energyKeys.amps], energyKeys.ampsDivisor))
-                .on('get', this.getDividedState.bind(this, energyKeys.amps, energyKeys.ampsDivisor));
+                .onGet(() => this.getDividedStateAsync(energyKeys.amps, energyKeys.ampsDivisor));
         } else this._removeCharacteristic(outletService, EnergyCharacteristics.Amperes);
 
         let characteristicWatts;
         if (energyKeys.watts) {
             characteristicWatts = outletService.getCharacteristic(EnergyCharacteristics.Watts)
                 .updateValue(this._getDividedState(dps[energyKeys.watts], energyKeys.wattsDivisor))
-                .on('get', this.getDividedState.bind(this, energyKeys.watts, energyKeys.wattsDivisor));
+                .onGet(() => this.getDividedStateAsync(energyKeys.watts, energyKeys.wattsDivisor));
         } else this._removeCharacteristic(outletService, EnergyCharacteristics.Watts);
 
         const characteristicOutletOn = outletService.getCharacteristic(Characteristic.On)
             .updateValue(dps[this.dpPower])
-            .on('get', this.getState.bind(this, this.dpPower))
-            .on('set', this.setState.bind(this, this.dpPower));
+            .onGet(() => this.getStateAsync(this.dpPower))
+            .onSet(value => this.setStateAsync(this.dpPower, value));
 
         this.device.on('change', (changes, state) => {
             if (changes.hasOwnProperty(this.dpLight) && characteristicLightOn.value !== changes[this.dpLight]) characteristicLightOn.updateValue(changes[this.dpLight]);
@@ -149,24 +144,18 @@ class RGBTWOutletAccessory extends BaseAccessory {
                         characteristicBrightness.updateValue(this.convertBrightnessFromTuyaToHomeKit(changes[this.dpBrightness]));
 
                     if (changes.hasOwnProperty(this.dpColorTemperature) && this.convertColorTemperatureFromHomeKitToTuya(characteristicColorTemperature.value) !== changes[this.dpColorTemperature]) {
-
                         const newColorTemperature = this.convertColorTemperatureFromTuyaToHomeKit(changes[this.dpColorTemperature]);
                         const newColor = this.convertHomeKitColorTemperatureToHomeKitColor(newColorTemperature);
-
                         characteristicHue.updateValue(newColor.h);
                         characteristicSaturation.updateValue(newColor.s);
                         characteristicColorTemperature.updateValue(newColorTemperature);
-
                     } else if (changes[this.dpMode] && !changes.hasOwnProperty(this.dpColorTemperature)) {
-
                         const newColorTemperature = this.convertColorTemperatureFromTuyaToHomeKit(state[this.dpColorTemperature]);
                         const newColor = this.convertHomeKitColorTemperatureToHomeKitColor(newColorTemperature);
-
                         characteristicHue.updateValue(newColor.h);
                         characteristicSaturation.updateValue(newColor.s);
                         characteristicColorTemperature.updateValue(newColorTemperature);
                     }
-
                     break;
 
                 default:
@@ -180,11 +169,8 @@ class RGBTWOutletAccessory extends BaseAccessory {
 
                         if (oldColor.b !== newColor.b) characteristicBrightness.updateValue(newColor.b);
                         if (oldColor.h !== newColor.h) characteristicHue.updateValue(newColor.h);
-
                         if (oldColor.s !== newColor.s) characteristicSaturation.updateValue(newColor.h);
-
                         if (characteristicColorTemperature.value !== 0) characteristicColorTemperature.updateValue(0);
-
                     } else if (changes[this.dpMode]) {
                         if (characteristicColorTemperature.value !== 0) characteristicColorTemperature.updateValue(0);
                     }
@@ -209,87 +195,75 @@ class RGBTWOutletAccessory extends BaseAccessory {
         });
     }
 
-    getBrightness(callback) {
-        if (this.device.state[this.dpMode] === this.cmdWhite) return callback(null, this.convertBrightnessFromTuyaToHomeKit(this.device.state[this.dpBrightness]));
-        callback(null, this.convertColorFromTuyaToHomeKit(this.device.state[this.dpColor]).b);
+    getBrightness() {
+        if (this.device.state[this.dpMode] === this.cmdWhite) return this.convertBrightnessFromTuyaToHomeKit(this.device.state[this.dpBrightness]);
+        return this.convertColorFromTuyaToHomeKit(this.device.state[this.dpColor]).b;
     }
 
-    setBrightness(value, callback) {
-        if (this.device.state[this.dpMode] === this.cmdWhite) return this.setState(this.dpBrightness, this.convertBrightnessFromHomeKitToTuya(value), callback);
-        this.setState(this.dpColor, this.convertColorFromHomeKitToTuya({b: value}), callback);
+    setBrightness(value) {
+        if (this.device.state[this.dpMode] === this.cmdWhite) return this.setStateAsync(this.dpBrightness, this.convertBrightnessFromHomeKitToTuya(value));
+        return this.setStateAsync(this.dpColor, this.convertColorFromHomeKitToTuya({b: value}));
     }
 
-    getColorTemperature(callback) {
-        if (this.device.state[this.dpMode] !== this.cmdWhite) return callback(null, 0);
-        callback(null, this.convertColorTemperatureFromTuyaToHomeKit(this.device.state[this.dpColorTemperature]));
+    getColorTemperature() {
+        if (this.device.state[this.dpMode] !== this.cmdWhite) return 0;
+        return this.convertColorTemperatureFromTuyaToHomeKit(this.device.state[this.dpColorTemperature]);
     }
 
-    setColorTemperature(value, callback) {
-        if (value === 0) return callback(null, true);
+    setColorTemperature(value) {
+        if (value === 0) return;
 
         const newColor = this.convertHomeKitColorTemperatureToHomeKitColor(value);
         this.characteristicHue.updateValue(newColor.h);
         this.characteristicSaturation.updateValue(newColor.s);
 
-        this.setMultiState({[this.dpMode]: this.cmdWhite, [this.dpColorTemperature]: this.convertColorTemperatureFromHomeKitToTuya(value)}, callback);
+        return this.setMultiStateAsync({[this.dpMode]: this.cmdWhite, [this.dpColorTemperature]: this.convertColorTemperatureFromHomeKitToTuya(value)});
     }
 
-    getHue(callback) {
-        if (this.device.state[this.dpMode] === this.cmdWhite) return callback(null, 0);
-        callback(null, this.convertColorFromTuyaToHomeKit(this.device.state[this.dpColor]).h);
+    getHue() {
+        if (this.device.state[this.dpMode] === this.cmdWhite) return 0;
+        return this.convertColorFromTuyaToHomeKit(this.device.state[this.dpColor]).h;
     }
 
-    setHue(value, callback) {
-        this._setHueSaturation({h: value}, callback);
+    setHue(value) {
+        return this._setHueSaturation({h: value});
     }
 
-    getSaturation(callback) {
-        if (this.device.state[this.dpMode] === this.cmdWhite) return callback(null, 0);
-        callback(null, this.convertColorFromTuyaToHomeKit(this.device.state[this.dpColor]).s);
+    getSaturation() {
+        if (this.device.state[this.dpMode] === this.cmdWhite) return 0;
+        return this.convertColorFromTuyaToHomeKit(this.device.state[this.dpColor]).s;
     }
 
-    setSaturation(value, callback) {
-        this._setHueSaturation({s: value}, callback);
+    setSaturation(value) {
+        return this._setHueSaturation({s: value});
     }
 
-    _setHueSaturation(prop, callback) {
+    _setHueSaturation(prop) {
         if (!this._pendingHueSaturation) {
-            this._pendingHueSaturation = {props: {}, callbacks: []};
+            this._pendingHueSaturation = {props: {}, resolvers: []};
         }
 
-        if (prop) {
-            if (this._pendingHueSaturation.timer) clearTimeout(this._pendingHueSaturation.timer);
+        if (this._pendingHueSaturation.timer) clearTimeout(this._pendingHueSaturation.timer);
+        this._pendingHueSaturation.props = {...this._pendingHueSaturation.props, ...prop};
 
-            this._pendingHueSaturation.props = {...this._pendingHueSaturation.props, ...prop};
-            this._pendingHueSaturation.callbacks.push(callback);
+        return new Promise(resolve => {
+            this._pendingHueSaturation.resolvers.push(resolve);
 
             this._pendingHueSaturation.timer = setTimeout(() => {
-                this._setHueSaturation();
-            }, 500);
-            return;
-        }
+                const {props, resolvers} = this._pendingHueSaturation;
+                this._pendingHueSaturation = null;
 
-        //this.characteristicColorTemperature.updateValue(0);
+                const isSham = props.h === 0 && props.s === 0;
+                const newValue = this.convertColorFromHomeKitToTuya(props);
 
-        const callbacks = this._pendingHueSaturation.callbacks;
-        const callEachBack = err => {
-            async.eachSeries(callbacks, (callback, next) => {
-                try {
-                    callback(err);
-                } catch (ex) {}
-                next();
-            }, () => {
+                if (!(this.device.state[this.dpMode] === this.cmdWhite && isSham)) {
+                    this.setMultiStateAsync({[this.dpMode]: this.cmdColor, [this.dpColor]: newValue});
+                }
                 this.characteristicColorTemperature.updateValue(0);
-            });
-        };
 
-        const isSham = this._pendingHueSaturation.props.h === 0 && this._pendingHueSaturation.props.s === 0;
-        const newValue = this.convertColorFromHomeKitToTuya(this._pendingHueSaturation.props);
-        this._pendingHueSaturation = null;
-
-        if (this.device.state[this.dpMode] === this.cmdWhite && isSham) return callEachBack();
-
-        this.setMultiState({[this.dpMode]: this.cmdColor, [this.dpColor]: newValue}, callEachBack);
+                resolvers.forEach(r => r());
+            }, 500);
+        });
     }
 }
 

--- a/lib/SimpleBlindsAccessory.js
+++ b/lib/SimpleBlindsAccessory.js
@@ -31,30 +31,25 @@ class SimpleBlindsAccessory extends BaseAccessory {
         this.dpBlindType = parseInt(this.device.context.dpBlindType) || 1;
         this.dpAction = this._getCustomDP(this.device.context.dpAction) || '1';
 
-        //setting the defaults if no one declares anything.
         this.OPEN_COMMAND = '';
         this.CLOSE_COMMAND = '';
         this.STOP_COMMAND = '';
 
-        if(this.dpBlindType === 1)
-        {
-          this.log.debug("Blinds Type 1 Selected");
-          this.OPEN_COMMAND = 'open';
-          this.CLOSE_COMMAND = 'close';
-          this.STOP_COMMAND = 'stop';
-        } else if (this.dpBlindType === 2)
-        {
-          this.log.debug("Blinds Type 2 Detected");
-          this.OPEN_COMMAND = 'on';
-          this.CLOSE_COMMAND = 'off';
-          this.STOP_COMMAND = 'stop';
-
+        if (this.dpBlindType === 1) {
+            this.log.debug('Blinds Type 1 Selected');
+            this.OPEN_COMMAND = 'open';
+            this.CLOSE_COMMAND = 'close';
+            this.STOP_COMMAND = 'stop';
+        } else if (this.dpBlindType === 2) {
+            this.log.debug('Blinds Type 2 Detected');
+            this.OPEN_COMMAND = 'on';
+            this.CLOSE_COMMAND = 'off';
+            this.STOP_COMMAND = 'stop';
         } else if (this.dpBlindType === 3) {
-          this.log.debug("Blinds Type 3 Selected");
-          //this one here should fix https://github.com/iRayanKhan/homebridge-tuya/issues/444 when the type is set to 0
-          this.OPEN_COMMAND = '1';
-          this.CLOSE_COMMAND = '2';
-          this.STOP_COMMAND = '3';
+            this.log.debug('Blinds Type 3 Selected');
+            this.OPEN_COMMAND = '1';
+            this.CLOSE_COMMAND = '2';
+            this.STOP_COMMAND = '3';
         }
 
         let _cmdOpen = this.OPEN_COMMAND;
@@ -62,11 +57,9 @@ class SimpleBlindsAccessory extends BaseAccessory {
             _cmdOpen = ('' + this.device.context.cmdOpen).trim();
         }
         let _cmdClose = this.CLOSE_COMMAND;
-
         if (this.device.context.cmdClose) {
             _cmdClose = ('' + this.device.context.cmdClose).trim();
         }
-
         let _cmdStop = this.STOP_COMMAND;
         if (this.device.context.cmdStop) {
             _cmdStop = ('' + this.device.context.cmdStop).trim();
@@ -84,40 +77,38 @@ class SimpleBlindsAccessory extends BaseAccessory {
         const endingDuration = parseInt(this.device.context.timeToTighten) || 0;
         this.minPosition = endingDuration ? Math.round(endingDuration * -100 / (this.duration - endingDuration)) : BLINDS_CLOSED;
 
-        // If the blinds are closed, note it; if not, assume open because there is no way to know where it is
         this.assumedPosition = dps[this.dpAction] === this.cmdClose ? this.minPosition : BLINDS_OPEN;
         this.assumedState = BLINDS_STOPPED;
         this.changeTime = this.targetPosition = false;
 
         const characteristicCurrentPosition = service.getCharacteristic(Characteristic.CurrentPosition)
             .updateValue(this._getCurrentPosition(dps[this.dpAction]))
-            .on('get', this.getCurrentPosition.bind(this));
+            .onGet(() => this.getCurrentPosition());
 
         const characteristicTargetPosition = service.getCharacteristic(Characteristic.TargetPosition)
             .updateValue(this._getTargetPosition(dps[this.dpAction]))
-            .on('get', this.getTargetPosition.bind(this))
-            .on('set', this.setTargetPosition.bind(this));
+            .onGet(() => this.getTargetPosition())
+            .onSet(value => this.setTargetPosition(value));
 
         const characteristicPositionState = service.getCharacteristic(Characteristic.PositionState)
             .updateValue(this._getPositionState())
-            .on('get', this.getPositionState.bind(this));
+            .onGet(() => this._getPositionState());
 
         this.device.on('change', changes => {
-            this.log.debug("[TuyaAccessory] Blinds saw change to " + changes[this.dpAction]);
+            this.log.debug('[TuyaAccessory] Blinds saw change to ' + changes[this.dpAction]);
             if (changes.hasOwnProperty(this.dpAction)) {
                 switch (changes[this.dpAction]) {
-                    case this.cmdOpen:  // Starting to open
+                    case this.cmdOpen:
                         this.assumedState = BLINDS_OPENING;
                         characteristicPositionState.updateValue(Characteristic.PositionState.INCREASING);
 
-                        // Only if change was external or someone internally asked for open
                         if (this.targetPosition === false || this.targetPosition === BLINDS_OPEN) {
                             this.targetPosition = false;
 
                             const durationToOpen = Math.abs(this.assumedPosition - BLINDS_OPEN) * this.duration * 10;
                             this.changeTime = Date.now() - durationToOpen;
 
-                            this.log.debug("[TuyaAccessory] Blinds will be marked open in " + durationToOpen + "ms");
+                            this.log.debug('[TuyaAccessory] Blinds will be marked open in ' + durationToOpen + 'ms');
 
                             if (this.changeTimeout) clearTimeout(this.changeTimeout);
                             this.changeTimeout = setTimeout(() => {
@@ -126,23 +117,22 @@ class SimpleBlindsAccessory extends BaseAccessory {
                                 this.changeTime = false;
                                 this.assumedPosition = BLINDS_OPEN;
                                 this.assumedState = BLINDS_STOPPED;
-                                this.log.debug("[TuyaAccessory] Blinds marked open");
+                                this.log.debug('[TuyaAccessory] Blinds marked open');
                             }, durationToOpen);
                         }
                         break;
 
-                    case this.cmdClose:  // Starting to close
+                    case this.cmdClose:
                         this.assumedState = BLINDS_CLOSING;
                         characteristicPositionState.updateValue(Characteristic.PositionState.DECREASING);
 
-                        // Only if change was external or someone internally asked for close
                         if (this.targetPosition === false || this.targetPosition === BLINDS_CLOSED) {
                             this.targetPosition = false;
 
                             const durationToClose = Math.abs(this.assumedPosition - BLINDS_CLOSED) * this.duration * 10;
                             this.changeTime = Date.now() - durationToClose;
 
-                            this.log.debug("[TuyaAccessory] Blinds will be marked closed in " + durationToClose + "ms");
+                            this.log.debug('[TuyaAccessory] Blinds will be marked closed in ' + durationToClose + 'ms');
 
                             if (this.changeTimeout) clearTimeout(this.changeTimeout);
                             this.changeTimeout = setTimeout(() => {
@@ -151,22 +141,17 @@ class SimpleBlindsAccessory extends BaseAccessory {
                                 this.changeTime = false;
                                 this.assumedPosition = this.minPosition;
                                 this.assumedState = BLINDS_STOPPED;
-                                this.log.debug("[TuyaAccessory] Blinds marked closed");
+                                this.log.debug('[TuyaAccessory] Blinds marked closed');
                             }, durationToClose);
                         }
                         break;
 
-                    case this.cmdStop: {  // Stopped in middle
+                    case this.cmdStop: {
                         if (this.changeTimeout) clearTimeout(this.changeTimeout);
 
-                        this.log.debug("[TuyaAccessory] Blinds last change was " + this.changeTime + "; " + (Date.now() - this.changeTime) + 'ms ago');
+                        this.log.debug('[TuyaAccessory] Blinds last change was ' + this.changeTime + '; ' + (Date.now() - this.changeTime) + 'ms ago');
 
                         if (this.changeTime) {
-                            /*
-                            this.assumedPosition = Math.min(100 - this.minPosition, Math.max(0, Math.round((Date.now() - this.changeTime) / (10 * this.duration))));
-                            if (this.assumedState === BLINDS_CLOSING) this.assumedPosition = 100 - this.assumedPosition;
-                            else this.assumedPosition += this.minPosition;
-                             */
                             const disposition = ((Date.now() - this.changeTime) / (10 * this.duration));
                             if (this.assumedState === BLINDS_CLOSING) {
                                 this.assumedPosition = BLINDS_OPEN - disposition;
@@ -179,7 +164,7 @@ class SimpleBlindsAccessory extends BaseAccessory {
                         characteristicCurrentPosition.updateValue(adjustedPosition);
                         characteristicTargetPosition.updateValue(adjustedPosition);
                         characteristicPositionState.updateValue(Characteristic.PositionState.STOPPED);
-                        this.log.debug("[TuyaAccessory] Blinds marked stopped at " + adjustedPosition + "; assumed to be at " + this.assumedPosition);
+                        this.log.debug('[TuyaAccessory] Blinds marked stopped at ' + adjustedPosition + '; assumed to be at ' + this.assumedPosition);
 
                         this.changeTime = this.targetPosition = false;
                         this.assumedState = BLINDS_STOPPED;
@@ -190,94 +175,82 @@ class SimpleBlindsAccessory extends BaseAccessory {
         });
     }
 
-    getCurrentPosition(callback) {
-        this.getState(this.dpAction, (err, dp) => {
-            if (err) return callback(err);
-
-            callback(null, this._getCurrentPosition(dp));
-        });
+    getCurrentPosition() {
+        return this._getCurrentPosition(this.device.state[this.dpAction]);
     }
 
     _getCurrentPosition(dp) {
         switch (dp) {
             case this.cmdOpen:
                 return BLINDS_OPEN;
-
             case this.cmdClose:
                 return BLINDS_CLOSED;
-
             default:
                 return Math.max(BLINDS_CLOSED, Math.round(this.assumedPosition));
         }
     }
 
-    getTargetPosition(callback) {
-        this.getState(this.dpAction, (err, dp) => {
-            if (err) return callback(err);
-
-            callback(null, this._getTargetPosition(dp));
-        });
+    getTargetPosition() {
+        return this._getTargetPosition(this.device.state[this.dpAction]);
     }
 
     _getTargetPosition(dp) {
         switch (dp) {
             case this.cmdOpen:
                 return BLINDS_OPEN;
-
             case this.cmdClose:
                 return BLINDS_CLOSED;
-
             default:
                 return Math.max(BLINDS_CLOSED, Math.round(this.assumedPosition));
         }
     }
 
-    setTargetPosition(value, callback) {
+    setTargetPosition(value) {
         this.log.debug('[TuyaAccessory] Blinds asked to move from ' + this.assumedPosition + ' to ' + value);
 
         if (this.changeTimeout) clearTimeout(this.changeTimeout);
         this.targetPosition = value;
 
         if (this.changeTime !== false) {
-            this.log.debug("[TuyaAccessory] Blinds " + (this.assumedState === BLINDS_CLOSING ? 'closing' : 'opening') + " had started " + this.changeTime + "; " + (Date.now() - this.changeTime) + 'ms ago');
+            this.log.debug('[TuyaAccessory] Blinds ' + (this.assumedState === BLINDS_CLOSING ? 'closing' : 'opening') + ' had started ' + this.changeTime + '; ' + (Date.now() - this.changeTime) + 'ms ago');
             const disposition = ((Date.now() - this.changeTime) / (10 * this.duration));
             if (this.assumedState === BLINDS_CLOSING) {
                 this.assumedPosition = BLINDS_OPEN - disposition;
             } else {
                 this.assumedPosition = this.minPosition + disposition;
             }
-            this.log.debug("[TuyaAccessory] Blinds' adjusted assumedPosition is " + this.assumedPosition);
+            this.log.debug('[TuyaAccessory] Blinds\' adjusted assumedPosition is ' + this.assumedPosition);
         }
 
         const duration = Math.abs(this.assumedPosition - value) * this.duration * 10;
 
         if (Math.abs(value - this.assumedPosition) < 1) {
-            return this.setState(this.dpAction, this.cmdStop, callback);
+            return this.setStateAsync(this.dpAction, this.cmdStop);
         } else if (value > this.assumedPosition) {
             this.assumedState = BLINDS_OPENING;
-            this.setState(this.dpAction, this.cmdOpen, callback);
-            this.changeTime = Date.now() -  Math.abs(this.assumedPosition - this.minPosition) * this.duration * 10;
+            this.changeTime = Date.now() - Math.abs(this.assumedPosition - this.minPosition) * this.duration * 10;
+            const result = this.setStateAsync(this.dpAction, this.cmdOpen);
+            if (value !== BLINDS_OPEN && value !== BLINDS_CLOSED) {
+                this.log.debug('[TuyaAccessory] Blinds will stop in ' + duration + 'ms');
+                this.changeTimeout = setTimeout(() => {
+                    this.log.debug('[TuyaAccessory] Blinds asked to stop');
+                    this.setStateAsync(this.dpAction, this.cmdStop);
+                }, duration);
+            }
+            return result;
         } else {
             this.assumedState = BLINDS_CLOSING;
-            this.setState(this.dpAction, this.cmdClose, callback);
-            this.changeTime = Date.now() -  Math.abs(this.assumedPosition - BLINDS_OPEN) * this.duration * 10;
+            this.changeTime = Date.now() - Math.abs(this.assumedPosition - BLINDS_OPEN) * this.duration * 10;
+            const result = this.setStateAsync(this.dpAction, this.cmdClose);
+            if (value !== BLINDS_OPEN && value !== BLINDS_CLOSED) {
+                this.log.debug('[TuyaAccessory] Blinds will stop in ' + duration + 'ms');
+                this.changeTimeout = setTimeout(() => {
+                    this.log.debug('[TuyaAccessory] Blinds asked to stop');
+                    this.setStateAsync(this.dpAction, this.cmdStop);
+                }, duration);
+            }
+            return result;
         }
-
-        if (value !== BLINDS_OPEN && value !== BLINDS_CLOSED) {
-            this.log.debug("[TuyaAccessory] Blinds will stop in " + duration + "ms");
-            this.log.debug("[TuyaAccessory] Blinds assumed started " + this.changeTime + "; " + (Date.now() - this.changeTime) + 'ms ago');
-            this.changeTimeout = setTimeout(() => {
-                this.log.debug("[TuyaAccessory] Blinds asked to stop");
-                this.setState(this.dpAction, this.cmdStop);
-            }, duration);
-        }
-    }
-
-    getPositionState(callback) {
-        const state = this._getPositionState();
-        process.nextTick(() => {
-            callback(null, state);
-        });
     }
 
     _getPositionState() {
@@ -286,10 +259,8 @@ class SimpleBlindsAccessory extends BaseAccessory {
         switch (this.assumedState) {
             case BLINDS_OPENING:
                 return Characteristic.PositionState.INCREASING;
-
             case BLINDS_CLOSING:
                 return Characteristic.PositionState.DECREASING;
-
             default:
                 return Characteristic.PositionState.STOPPED;
         }

--- a/lib/SimpleDimmer2Accessory.js
+++ b/lib/SimpleDimmer2Accessory.js
@@ -27,13 +27,13 @@ class SimpleDimmer2Accessory extends BaseAccessory {
 
         const characteristicOn = service.getCharacteristic(Characteristic.On)
             .updateValue(dps[this.dpPower])
-            .on('get', this.getState.bind(this, this.dpPower))
-            .on('set', this.setState.bind(this, this.dpPower));
+            .onGet(() => this.getStateAsync(this.dpPower))
+            .onSet(value => this.setStateAsync(this.dpPower, value));
 
         const characteristicBrightness = service.getCharacteristic(Characteristic.Brightness)
             .updateValue(this.convertBrightnessFromTuyaToHomeKit(dps[this.dpBrightness]))
-            .on('get', this.getBrightness.bind(this))
-            .on('set', this.setBrightness.bind(this));
+            .onGet(() => this.getBrightness())
+            .onSet(value => this.setBrightness(value));
 
         this.device.on('change', changes => {
             if (changes.hasOwnProperty(this.dpPower) && characteristicOn.value !== changes[this.dpPower]) characteristicOn.updateValue(changes[this.dpPower]);
@@ -42,12 +42,12 @@ class SimpleDimmer2Accessory extends BaseAccessory {
         });
     }
 
-    getBrightness(callback) {
-        callback(null, this.convertBrightnessFromTuyaToHomeKit(this.device.state[this.dpBrightness]));
+    getBrightness() {
+        return this.convertBrightnessFromTuyaToHomeKit(this.device.state[this.dpBrightness]);
     }
 
-    setBrightness(value, callback) {
-        this.setState(this.dpBrightness, this.convertBrightnessFromHomeKitToTuya(value), callback);
+    setBrightness(value) {
+        return this.setStateAsync(this.dpBrightness, this.convertBrightnessFromHomeKitToTuya(value));
     }
 }
 

--- a/lib/SimpleDimmerAccessory.js
+++ b/lib/SimpleDimmerAccessory.js
@@ -27,13 +27,13 @@ class SimpleDimmerAccessory extends BaseAccessory {
 
         const characteristicOn = service.getCharacteristic(Characteristic.On)
             .updateValue(dps[this.dpPower])
-            .on('get', this.getState.bind(this, this.dpPower))
-            .on('set', this.setState.bind(this, this.dpPower));
+            .onGet(() => this.getStateAsync(this.dpPower))
+            .onSet(value => this.setStateAsync(this.dpPower, value));
 
         const characteristicBrightness = service.getCharacteristic(Characteristic.Brightness)
             .updateValue(this.convertBrightnessFromTuyaToHomeKit(dps[this.dpBrightness]))
-            .on('get', this.getBrightness.bind(this))
-            .on('set', this.setBrightness.bind(this));
+            .onGet(() => this.getBrightness())
+            .onSet(value => this.setBrightness(value));
 
         this.device.on('change', changes => {
             if (changes.hasOwnProperty(this.dpPower) && characteristicOn.value !== changes[this.dpPower]) characteristicOn.updateValue(changes[this.dpPower]);
@@ -42,12 +42,12 @@ class SimpleDimmerAccessory extends BaseAccessory {
         });
     }
 
-    getBrightness(callback) {
-        callback(null, this.convertBrightnessFromTuyaToHomeKit(this.device.state[this.dpBrightness]));
+    getBrightness() {
+        return this.convertBrightnessFromTuyaToHomeKit(this.device.state[this.dpBrightness]);
     }
 
-    setBrightness(value, callback) {
-        this.setState(this.dpBrightness, this.convertBrightnessFromHomeKitToTuya(value), callback);
+    setBrightness(value) {
+        return this.setStateAsync(this.dpBrightness, this.convertBrightnessFromHomeKitToTuya(value));
     }
 }
 

--- a/lib/SimpleFanAccessory.js
+++ b/lib/SimpleFanAccessory.js
@@ -21,23 +21,18 @@ class SimpleFanAccessory extends BaseAccessory {
         this._checkServiceName(serviceFan, this.device.context.name);
         this.dpFanOn = this._getCustomDP(this.device.context.dpFanOn) || '1';
         this.dpRotationSpeed = this._getCustomDP(this.device.context.dpRotationSpeed) || '3';
-        // Add fan direction DP to the accessory
         this.dpFanDirection = this._getCustomDP(this.device.context.dpFanDirection) || '2';
 
         this.maxSpeed = parseInt(this.device.context.maxSpeed) || 3;
-        // This variable is here so that we can set the fans to turn onto speed one instead of 3 on start.
         this.fanDefaultSpeed = parseInt(this.device.context.fanDefaultSpeed) || 1;
-        // This variable is here as a workaround to allow for the on/off function to work.
         this.fanCurrentSpeed = 0;
-        // Add setting to use .toString() on return values or not.
         this.useStrings = this._coerceBoolean(this.device.context.useStrings, true);
-        // Whether multiple state requests should be sent to device
         this.useMultiState = this._coerceBoolean(this.device.context.useMultiState, true);
 
         const characteristicFanOn = serviceFan.getCharacteristic(Characteristic.On)
             .updateValue(this._getFanOn(dps[this.dpFanOn]))
-            .on('get', this.getFanOn.bind(this))
-            .on('set', this.setFanOn.bind(this));
+            .onGet(() => this.getFanOn())
+            .onSet(value => this.setFanOn(value));
 
         const characteristicRotationSpeed = serviceFan.getCharacteristic(Characteristic.RotationSpeed)
             .setProps({
@@ -46,24 +41,21 @@ class SimpleFanAccessory extends BaseAccessory {
                 minStep: Math.max(100 / this.maxSpeed)
             })
             .updateValue(this.convertRotationSpeedFromTuyaToHomeKit(dps[this.dpRotationSpeed]))
-            .on('get', this.getSpeed.bind(this))
-            .on('set', this.setSpeed.bind(this));
+            .onGet(() => this.getSpeed())
+            .onSet(value => this.setSpeed(value));
 
-        // Add RotationDirection characteristic
         const characteristicFanDirection = serviceFan.getCharacteristic(Characteristic.RotationDirection)
             .updateValue(this._getFanDirection(dps[this.dpFanDirection]))
-            .on('get', this.getFanDirection.bind(this))
-            .on('set', this.setFanDirection.bind(this));
+            .onGet(() => this.getFanDirection())
+            .onSet(value => this.setFanDirection(value));
 
         this.device.on('change', (changes, state) => {
-
             if (changes.hasOwnProperty(this.dpFanOn) && characteristicFanOn.value !== changes[this.dpFanOn])
                 characteristicFanOn.updateValue(changes[this.dpFanOn]);
 
             if (changes.hasOwnProperty(this.dpRotationSpeed) && this.convertRotationSpeedFromHomeKitToTuya(characteristicRotationSpeed.value) !== changes[this.dpRotationSpeed])
                 characteristicRotationSpeed.updateValue(this.convertRotationSpeedFromTuyaToHomeKit(changes[this.dpRotationSpeed]));
 
-            // Update RotationDirection on device change
             if (changes.hasOwnProperty(this.dpFanDirection) && characteristicFanDirection) {
                 const dir = this._getFanDirection(changes[this.dpFanDirection]);
                 if (characteristicFanDirection.value !== dir) characteristicFanDirection.updateValue(dir);
@@ -73,103 +65,75 @@ class SimpleFanAccessory extends BaseAccessory {
         });
     }
 
-    /*************************** FAN ***************************/
-    // Get the Current Fan State
-    getFanOn(callback) {
-        this.getState(this.dpFanOn, (err, dp) => {
-            if (err) return callback(err);
-            callback(null, this._getFanOn(dp));
-        });
+    getFanOn() {
+        return this._getFanOn(this.getStateAsync(this.dpFanOn));
     }
 
     _getFanOn(dp) {
-        const {Characteristic} = this.hap;
         return dp;
     }
 
-    setFanOn(value, callback) {
-        const {Characteristic} = this.hap;
-        // This uses the multistate set command to send the fan on and speed request in one call.
-
+    setFanOn(value) {
         if (!this.useMultiState) {
-            return this.setState(this.dpFanOn, value, callback);
-        } else if (value == false ) {
+            return this.setStateAsync(this.dpFanOn, value);
+        } else if (value == false) {
             this.fanCurrentSpeed = 0;
-            // This will turn off the fan speed if it is set to be 0.
-            return this.setState(this.dpFanOn, false, callback);
+            return this.setStateAsync(this.dpFanOn, false);
         } else {
             if (this.fanCurrentSpeed === 0) {
-                // The current fanDefaultSpeed Variable is there to have the fan set to a sensible default if turned on.
                 if (this.useStrings) {
-                    return this.setMultiStateLegacy({[this.dpFanOn]: value, [this.dpRotationSpeed]: this.fanDefaultSpeed.toString()}, callback);
+                    return this.setMultiStateLegacyAsync({[this.dpFanOn]: value, [this.dpRotationSpeed]: this.fanDefaultSpeed.toString()});
                 } else {
-                    return this.setMultiStateLegacy({[this.dpFanOn]: value, [this.dpRotationSpeed]: this.fanDefaultSpeed}, callback);
+                    return this.setMultiStateLegacyAsync({[this.dpFanOn]: value, [this.dpRotationSpeed]: this.fanDefaultSpeed});
                 }
             } else {
-                // The current fanCurrentSpeed Variable is there to ensure the fan speed doesn't change if the fan is already on.
                 if (this.useStrings) {
-                    return this.setMultiStateLegacy({[this.dpFanOn]: value, [this.dpRotationSpeed]: this.fanCurrentSpeed.toString()}, callback);
+                    return this.setMultiStateLegacyAsync({[this.dpFanOn]: value, [this.dpRotationSpeed]: this.fanCurrentSpeed.toString()});
                 } else {
-                    return this.setMultiStateLegacy({[this.dpFanOn]: value, [this.dpRotationSpeed]: this.fanCurrentSpeed}, callback);
+                    return this.setMultiStateLegacyAsync({[this.dpFanOn]: value, [this.dpRotationSpeed]: this.fanCurrentSpeed});
                 }
             }
         }
     }
 
-    // Get the Current Fan Speed
-    getSpeed(callback) {
-        this.getState(this.dpRotationSpeed, (err, dp) => {
-            if (err) return callback(err);
-            callback(null, this.convertRotationSpeedFromTuyaToHomeKit(dp));
-        });
+    getSpeed() {
+        return this.convertRotationSpeedFromTuyaToHomeKit(this.getStateAsync(this.dpRotationSpeed));
     }
 
-    // Set the new fan speed
-    setSpeed(value, callback) {
-        const { Characteristic } = this.hap;
+    setSpeed(value) {
         if (!this.useMultiState) {
-            return this.setState(this.dpRotationSpeed, this.convertRotationSpeedFromHomeKitToTuya(value), callback);
+            return this.setStateAsync(this.dpRotationSpeed, this.convertRotationSpeedFromHomeKitToTuya(value));
         } else if (value === 0) {
-            // This is to set the fan speed variable to be 1 when the fan is off.
             if (this.useStrings) {
-                return this.setMultiStateLegacy({[this.dpFanOn]: false, [this.dpRotationSpeed]: this.fanDefaultSpeed.toString()}, callback);
+                return this.setMultiStateLegacyAsync({[this.dpFanOn]: false, [this.dpRotationSpeed]: this.fanDefaultSpeed.toString()});
             } else {
-                return this.setMultiStateLegacy({[this.dpFanOn]: false, [this.dpRotationSpeed]: this.fanDefaultSpeed}, callback);
+                return this.setMultiStateLegacyAsync({[this.dpFanOn]: false, [this.dpRotationSpeed]: this.fanDefaultSpeed});
             }
         } else {
-            // This is to set the fan speed variable to match the current speed.
             this.fanCurrentSpeed = this.convertRotationSpeedFromHomeKitToTuya(value);
-            // This uses the multistatelegacy set command to send the fan on and speed request in one call.
             if (this.useStrings) {
-                return this.setMultiStateLegacy({[this.dpFanOn]: true, [this.dpRotationSpeed]: this.convertRotationSpeedFromHomeKitToTuya(value).toString()}, callback);
+                return this.setMultiStateLegacyAsync({[this.dpFanOn]: true, [this.dpRotationSpeed]: this.convertRotationSpeedFromHomeKitToTuya(value).toString()});
             } else {
-                return this.setMultiStateLegacy({[this.dpFanOn]: true, [this.dpRotationSpeed]: this.convertRotationSpeedFromHomeKitToTuya(value)}, callback);
+                return this.setMultiStateLegacyAsync({[this.dpFanOn]: true, [this.dpRotationSpeed]: this.convertRotationSpeedFromHomeKitToTuya(value)});
             }
         }
     }
 
-    // Get the Current Fan Direction
-    getFanDirection(callback) {
-        this.getState(this.dpFanDirection, (err, dp) => {
-            if (err) return callback(err);
-            callback(null, this._getFanDirection(dp));
-        });
+    getFanDirection() {
+        return this._getFanDirection(this.getStateAsync(this.dpFanDirection));
     }
 
     _getFanDirection(dp) {
-        const { Characteristic } = this.hap;
-        // forward -> CLOCKWISE, reverse -> COUNTER_CLOCKWISE
+        const {Characteristic} = this.hap;
         return (dp === 'reverse') ? Characteristic.RotationDirection.COUNTER_CLOCKWISE : Characteristic.RotationDirection.CLOCKWISE;
     }
 
-    setFanDirection(value, callback) {
-        const { Characteristic } = this.hap;
-        // HomeKit: 0 = CLOCKWISE, 1 = COUNTER_CLOCKWISE
+    setFanDirection(value) {
+        const {Characteristic} = this.hap;
         const tuyaVal = (value === Characteristic.RotationDirection.COUNTER_CLOCKWISE) ? 'reverse' : 'forward';
-        return this.setState(this.dpFanDirection, tuyaVal, callback);
+        return this.setStateAsync(this.dpFanDirection, tuyaVal);
     }
 
-    // Helpers for speed conversion (HomeKit 0..100 ↔ Tuya 1..maxSpeed)
     convertRotationSpeedFromTuyaToHomeKit(value) {
         const v = parseInt(value) || 0;
         if (v <= 0) return 0;

--- a/lib/SimpleFanLightAccessory.js
+++ b/lib/SimpleFanLightAccessory.js
@@ -24,7 +24,6 @@ class SimpleFanLightAccessory extends BaseAccessory {
         this._checkServiceName(serviceFan, this.device.context.name);
         this._checkServiceName(serviceLightbulb, this.device.context.name + ' Light');
 
-        // DP mapping examples
         this.dpFanOn = this._getCustomDP(this.device.context.dpFanOn) || '60';
         this.dpRotationSpeed = this._getCustomDP(this.device.context.dpRotationSpeed) || '62';
         this.dpFanDirection = this._getCustomDP(this.device.context.dpFanDirection) || '63';
@@ -32,43 +31,34 @@ class SimpleFanLightAccessory extends BaseAccessory {
         this.dpBrightness = this._getCustomDP(this.device.context.dpBrightness) || '22';
         this.dpColorTemp = this._getCustomDP(this.device.context.dpColorTemp) || '23';
 
-        // Feature toggles and ranges
         this.useLight = this._coerceBoolean(this.device.context.useLight, true);
         this.useBrightness = this._coerceBoolean(this.device.context.useBrightness, true);
         this.useColorTemp = this._coerceBoolean(this.device.context.useColorTemp, true);
         this.maxSpeed = parseInt(this.device.context.maxSpeed) || 6;
-
-        // This variable is here so that we can set the fans to turn onto speed one instead of a higher value on start.
         this.fanDefaultSpeed = parseInt(this.device.context.fanDefaultSpeed) || 1;
-        // This variable is here as a workaround to allow for the on/off function to work.
         this.fanCurrentSpeed = 0;
-        // Add setting to use .toString() on return values or not.
         this.useStrings = this._coerceBoolean(this.device.context.useStrings, true);
 
-        // FAN - On/Off
         const characteristicFanOn = serviceFan.getCharacteristic(Characteristic.On)
             .updateValue(this._getFanOn(dps[this.dpFanOn]))
-            .on('get', this.getFanOn.bind(this))
-            .on('set', this.setFanOn.bind(this));
+            .onGet(() => this.getFanOn())
+            .onSet(value => this.setFanOn(value));
 
-        // FAN - Speed (HomeKit 0-100 → Tuya 1..maxSpeed)
         const characteristicRotationSpeed = serviceFan.getCharacteristic(Characteristic.RotationSpeed)
             .setProps({
                 minValue: 0,
                 maxValue: 100,
-                minStep: Math.max(1, 100 / this.maxSpeed) // ensure a sensible step
+                minStep: Math.max(1, 100 / this.maxSpeed)
             })
             .updateValue(this.convertRotationSpeedFromTuyaToHomeKit(dps[this.dpRotationSpeed]))
-            .on('get', this.getSpeed.bind(this))
-            .on('set', this.setSpeed.bind(this));
+            .onGet(() => this.getSpeed())
+            .onSet(value => this.setSpeed(value));
 
-        // FAN - Direction (forward/reverse)
-        let characteristicFanDirection = serviceFan.getCharacteristic(Characteristic.RotationDirection)
+        const characteristicFanDirection = serviceFan.getCharacteristic(Characteristic.RotationDirection)
             .updateValue(this._getFanDirection(dps[this.dpFanDirection]))
-            .on('get', this.getFanDirection.bind(this))
-            .on('set', this.setFanDirection.bind(this));
+            .onGet(() => this.getFanDirection())
+            .onSet(value => this.setFanDirection(value));
 
-        // LIGHT
         let characteristicLightOn;
         let characteristicBrightness;
         let characteristicColorTemp;
@@ -76,40 +66,29 @@ class SimpleFanLightAccessory extends BaseAccessory {
         if (this.useLight) {
             characteristicLightOn = serviceLightbulb.getCharacteristic(Characteristic.On)
                 .updateValue(this._getLightOn(dps[this.dpLightOn]))
-                .on('get', this.getLightOn.bind(this))
-                .on('set', this.setLightOn.bind(this));
+                .onGet(() => this.getLightOn())
+                .onSet(value => this.setLightOn(value));
 
             if (this.useBrightness) {
-                // HomeKit brightness is 0..100; device uses 10..1000
                 characteristicBrightness = serviceLightbulb.getCharacteristic(Characteristic.Brightness)
-                    .setProps({
-                        minValue: 0,
-                        maxValue: 100,
-                        minStep: 1
-                    })
+                    .setProps({ minValue: 0, maxValue: 100, minStep: 1 })
                     .updateValue(this.convertBrightnessFromTuyaToHomeKit(dps[this.dpBrightness]))
-                    .on('get', this.getBrightness.bind(this))
-                    .on('set', this.setBrightness.bind(this));
+                    .onGet(() => this.getBrightness())
+                    .onSet(value => this.setBrightness(value));
             }
 
             if (this.useColorTemp) {
-                // HomeKit ColorTemperature is in mireds (approx 140 cool .. 500 warm); device uses 0..1000
                 characteristicColorTemp = serviceLightbulb.getCharacteristic(Characteristic.ColorTemperature)
-                    .setProps({
-                        minValue: 140,
-                        maxValue: 500
-                    })
+                    .setProps({ minValue: 140, maxValue: 500 })
                     .updateValue(this.convertColorTempFromTuyaToHomeKit(dps[this.dpColorTemp]))
-                    .on('get', this.getColorTemp.bind(this))
-                    .on('set', this.setColorTemp.bind(this));
+                    .onGet(() => this.getColorTemp())
+                    .onSet(value => this.setColorTemp(value));
             }
         }
 
-        // Device event bridge
         this.device.on('change', (changes, state) => {
-            if (changes.hasOwnProperty(this.dpFanOn) && characteristicFanOn.value !== changes[this.dpFanOn]) {
+            if (changes.hasOwnProperty(this.dpFanOn) && characteristicFanOn.value !== changes[this.dpFanOn])
                 characteristicFanOn.updateValue(this._getFanOn(changes[this.dpFanOn]));
-            }
 
             if (changes.hasOwnProperty(this.dpRotationSpeed)) {
                 const hk = this.convertRotationSpeedFromTuyaToHomeKit(changes[this.dpRotationSpeed]);
@@ -139,87 +118,96 @@ class SimpleFanLightAccessory extends BaseAccessory {
         });
     }
 
-    /*************************** FAN ***************************/
-    // Get the Current Fan State
-    getFanOn(callback) {
-        this.getState(this.dpFanOn, (err, dp) => {
-            if (err) return callback(err);
-            callback(null, this._getFanOn(dp));
-        });
+    getFanOn() {
+        return this._getFanOn(this.getStateAsync(this.dpFanOn));
     }
 
     _getFanOn(dp) {
         return !!dp;
     }
 
-    setFanOn(value, callback) {
-        // This uses the multistatelegacy set command to send the fan on and speed request in one call.
+    setFanOn(value) {
         if (value === false) {
             this.fanCurrentSpeed = 0;
-            // This will turn off the fan speed if it is set to be 0.
-            return this.setState(this.dpFanOn, false, callback);
+            return this.setStateAsync(this.dpFanOn, false);
         } else {
             const target = this.fanCurrentSpeed === 0 ? this.fanDefaultSpeed : this.fanCurrentSpeed;
             const payload = {
                 [this.dpFanOn]: true,
                 [this.dpRotationSpeed]: this.useStrings ? target.toString() : target
             };
-            return this.setMultiStateLegacy(payload, callback);
+            return this.setMultiStateLegacyAsync(payload);
         }
     }
 
-    // Get the Current Fan Speed
-    getSpeed(callback) {
-        this.getState(this.dpRotationSpeed, (err, dp) => {
-            if (err) return callback(err);
-            callback(null, this.convertRotationSpeedFromTuyaToHomeKit(dp));
-        });
+    getSpeed() {
+        return this.convertRotationSpeedFromTuyaToHomeKit(this.getStateAsync(this.dpRotationSpeed));
     }
 
-    // Set the new fan speed
-    setSpeed(value, callback) {
+    setSpeed(value) {
         if (value === 0) {
-            // This is to set the fan speed variable to be the default when the fan is off.
             const payload = {
                 [this.dpFanOn]: false,
                 [this.dpRotationSpeed]: this.useStrings ? this.fanDefaultSpeed.toString() : this.fanDefaultSpeed
             };
-            return this.setMultiStateLegacy(payload, callback);
+            return this.setMultiStateLegacyAsync(payload);
         } else {
-            // This is to set the fan speed variable to match the current speed.
             const tuya = this.convertRotationSpeedFromHomeKitToTuya(value);
             this.fanCurrentSpeed = tuya;
             const payload = {
                 [this.dpFanOn]: true,
                 [this.dpRotationSpeed]: this.useStrings ? tuya.toString() : tuya
             };
-            return this.setMultiStateLegacy(payload, callback);
+            return this.setMultiStateLegacyAsync(payload);
         }
     }
 
-    // Fan direction
-    getFanDirection(callback) {
-        this.getState(this.dpFanDirection, (err, dp) => {
-            if (err) return callback(err);
-            callback(null, this._getFanDirection(dp));
-        });
+    getFanDirection() {
+        return this._getFanDirection(this.getStateAsync(this.dpFanDirection));
     }
 
     _getFanDirection(dp) {
-        const { Characteristic } = this.hap;
-        // forward → CLOCKWISE, reverse → COUNTER_CLOCKWISE
+        const {Characteristic} = this.hap;
         return dp === 'reverse'
             ? Characteristic.RotationDirection.COUNTER_CLOCKWISE
             : Characteristic.RotationDirection.CLOCKWISE;
     }
 
-    setFanDirection(value, callback) {
-        // HomeKit: 0 = CLOCKWISE, 1 = COUNTER_CLOCKWISE
+    setFanDirection(value) {
         const tuyaVal = (value === 1) ? 'reverse' : 'forward';
-        return this.setState(this.dpFanDirection, tuyaVal, callback);
+        return this.setStateAsync(this.dpFanDirection, tuyaVal);
     }
 
-    // Helpers for speed conversion (HomeKit 0..100 ↔ Tuya 1..maxSpeed)
+    getLightOn() {
+        return this._getLightOn(this.getStateAsync(this.dpLightOn));
+    }
+
+    _getLightOn(dp) {
+        return !!dp;
+    }
+
+    setLightOn(value) {
+        return this.setStateAsync(this.dpLightOn, value);
+    }
+
+    getBrightness() {
+        return this.convertBrightnessFromTuyaToHomeKit(this.getStateAsync(this.dpBrightness));
+    }
+
+    setBrightness(value) {
+        const tuya = this.convertBrightnessFromHomeKitToTuya(value);
+        return this.setStateAsync(this.dpBrightness, this.useStrings ? tuya.toString() : tuya);
+    }
+
+    getColorTemp() {
+        return this.convertColorTempFromTuyaToHomeKit(this.getStateAsync(this.dpColorTemp));
+    }
+
+    setColorTemp(value) {
+        const tuya = this.convertColorTempFromHomeKitToTuya(value);
+        return this.setStateAsync(this.dpColorTemp, this.useStrings ? tuya.toString() : tuya);
+    }
+
     convertRotationSpeedFromTuyaToHomeKit(value) {
         const v = parseInt(value) || 0;
         if (v <= 0) return 0;
@@ -233,55 +221,10 @@ class SimpleFanLightAccessory extends BaseAccessory {
         return Math.min(this.maxSpeed, Math.max(1, tuya));
     }
 
-    /*************************** LIGHT ***************************/
-    //Lightbulb State
-    getLightOn(callback) {
-        this.getState(this.dpLightOn, (err, dp) => {
-            if (err) return callback(err);
-            callback(null, this._getLightOn(dp));
-        });
-    }
-
-    _getLightOn(dp) {
-        return !!dp;
-    }
-
-    setLightOn(value, callback) {
-        return this.setState(this.dpLightOn, value, callback);
-    }
-
-    //Lightbulb Brightness
-    getBrightness(callback) {
-        this.getState(this.dpBrightness, (err, dp) => {
-            if (err) return callback(err);
-            callback(null, this.convertBrightnessFromTuyaToHomeKit(dp));
-        });
-    }
-
-    setBrightness(value, callback) {
-        const tuya = this.convertBrightnessFromHomeKitToTuya(value);
-        return this.setState(this.dpBrightness, this.useStrings ? tuya.toString() : tuya, callback);
-    }
-
-    // Lightbulb Color Temperature
-    getColorTemp(callback) {
-        this.getState(this.dpColorTemp, (err, dp) => {
-            if (err) return callback(err);
-            callback(null, this.convertColorTempFromTuyaToHomeKit(dp));
-        });
-    }
-
-    setColorTemp(value, callback) {
-        const tuya = this.convertColorTempFromHomeKitToTuya(value);
-        return this.setState(this.dpColorTemp, this.useStrings ? tuya.toString() : tuya, callback);
-    }
-
-    // Helpers for brightness conversion (Tuya 10..1000 ↔ HK 0..100)
     convertBrightnessFromTuyaToHomeKit(value) {
         let v = parseInt(value);
         if (isNaN(v)) v = 0;
         v = Math.max(0, Math.min(1000, v));
-        // device min is 10; map linearly 10..1000 → 0..100
         const pct = Math.round(((v - 10) * 100) / (1000 - 10));
         return Math.max(0, Math.min(100, pct));
     }
@@ -294,12 +237,10 @@ class SimpleFanLightAccessory extends BaseAccessory {
         return Math.max(10, Math.min(1000, tuya));
     }
 
-    // Helpers for color temperature conversion (Tuya 0..1000 ↔ HK 140..500 mireds)
     convertColorTempFromTuyaToHomeKit(value) {
         let v = parseInt(value);
         if (isNaN(v)) v = 0;
         v = Math.max(0, Math.min(1000, v));
-        // 0 → cool (≈140), 1000 → warm (≈500)
         const hk = Math.round(140 + (v * (500 - 140)) / 1000);
         return Math.max(140, Math.min(500, hk));
     }

--- a/lib/SimpleHeaterAccessory.js
+++ b/lib/SimpleHeaterAccessory.js
@@ -32,12 +32,12 @@ class SimpleHeaterAccessory extends BaseAccessory {
 
         const characteristicActive = service.getCharacteristic(Characteristic.Active)
             .updateValue(this._getActive(dps[this.dpActive]))
-            .on('get', this.getActive.bind(this))
-            .on('set', this.setActive.bind(this));
+            .onGet(() => this.getActive())
+            .onSet(value => this.setActive(value));
 
         const characteristicCurrentHeaterCoolerState = service.getCharacteristic(Characteristic.CurrentHeaterCoolerState)
             .updateValue(this._getCurrentHeaterCoolerState(dps))
-            .on('get', this.getCurrentHeaterCoolerState.bind(this));
+            .onGet(() => this.currentHeaterCoolerState);
 
         service.getCharacteristic(Characteristic.TargetHeaterCoolerState)
             .setProps({
@@ -46,13 +46,12 @@ class SimpleHeaterAccessory extends BaseAccessory {
                 validValues: [Characteristic.TargetHeaterCoolerState.HEAT]
             })
             .updateValue(this._getTargetHeaterCoolerState())
-            .on('get', this.getTargetHeaterCoolerState.bind(this))
-            .on('set', this.setTargetHeaterCoolerState.bind(this));
+            .onGet(() => this._getTargetHeaterCoolerState())
+            .onSet(() => this.setStateAsync(this.dpActive, true));
 
         const characteristicCurrentTemperature = service.getCharacteristic(Characteristic.CurrentTemperature)
             .updateValue(this._getDividedState(dps[this.dpCurrentTemperature], this.temperatureDivisor))
-            .on('get', this.getDividedState.bind(this, this.dpCurrentTemperature, this.temperatureDivisor));
-
+            .onGet(() => this.getDividedStateAsync(this.dpCurrentTemperature, this.temperatureDivisor));
 
         const characteristicHeatingThresholdTemperature = service.getCharacteristic(Characteristic.HeatingThresholdTemperature)
             .setProps({
@@ -61,8 +60,8 @@ class SimpleHeaterAccessory extends BaseAccessory {
                 minStep: this.device.context.minTemperatureSteps || 1
             })
             .updateValue(this._getDividedState(dps[this.dpDesiredTemperature], this.thresholdTemperatureDivisor))
-            .on('get', this.getDividedState.bind(this, this.dpDesiredTemperature, this.thresholdTemperatureDivisor))
-            .on('set', this.setTargetThresholdTemperature.bind(this));
+            .onGet(() => this.getDividedStateAsync(this.dpDesiredTemperature, this.thresholdTemperatureDivisor))
+            .onSet(value => this.setTargetThresholdTemperature(value));
 
         this.characteristicHeatingThresholdTemperature = characteristicHeatingThresholdTemperature;
 
@@ -79,62 +78,46 @@ class SimpleHeaterAccessory extends BaseAccessory {
                     characteristicHeatingThresholdTemperature.updateValue(this._getDividedState(changes[this.dpDesiredTemperature], this.thresholdTemperatureDivisor));
             }
 
-            if (changes.hasOwnProperty(this.dpCurrentTemperature) && characteristicCurrentTemperature.value !== changes[this.dpCurrentTemperature]) characteristicCurrentTemperature.updateValue(this._getDividedState(changes[this.dpCurrentTemperature], this.temperatureDivisor));
+            if (changes.hasOwnProperty(this.dpCurrentTemperature) && characteristicCurrentTemperature.value !== changes[this.dpCurrentTemperature])
+                characteristicCurrentTemperature.updateValue(this._getDividedState(changes[this.dpCurrentTemperature], this.temperatureDivisor));
 
             characteristicCurrentHeaterCoolerState.updateValue(this._getCurrentHeaterCoolerState(state));
             this.log.info('SimpleHeater changed: ' + JSON.stringify(state));
         });
     }
 
-    getActive(callback) {
-        this.getState(this.dpActive, (err, dp) => {
-            if (err) return callback(err);
-
-            callback(null, this._getActive(dp));
-        });
+    getActive() {
+        return this._getActive(this.getStateAsync(this.dpActive));
     }
 
     _getActive(dp) {
         const {Characteristic} = this.hap;
-
         return dp ? Characteristic.Active.ACTIVE : Characteristic.Active.INACTIVE;
     }
 
-    setActive(value, callback) {
+    setActive(value) {
         const {Characteristic} = this.hap;
-
         switch (value) {
             case Characteristic.Active.ACTIVE:
-                return this.setState(this.dpActive, true, callback);
-
+                return this.setStateAsync(this.dpActive, true);
             case Characteristic.Active.INACTIVE:
-                return this.setState(this.dpActive, false, callback);
+                return this.setStateAsync(this.dpActive, false);
         }
-
-        callback();
-    }
-
-    getCurrentHeaterCoolerState(callback) {
-        callback(null, this.currentHeaterCoolerState);
     }
 
     _getCurrentHeaterCoolerState(dps) {
         const {Characteristic} = this.hap;
         if (dps[this.dpActive]) {
-            if (dps[this.dpCurrentTemperature] <  dps[this.dpDesiredTemperature]) {
+            if (dps[this.dpCurrentTemperature] < dps[this.dpDesiredTemperature]) {
                 this.currentHeaterCoolerState = Characteristic.CurrentHeaterCoolerState.HEATING;
             }
-            if (dps[this.dpCurrentTemperature] >  dps[this.dpDesiredTemperature]) {
+            if (dps[this.dpCurrentTemperature] > dps[this.dpDesiredTemperature]) {
                 this.currentHeaterCoolerState = Characteristic.CurrentHeaterCoolerState.IDLE;
             }
-         } else {
-             this.currentHeaterCoolerState = Characteristic.CurrentHeaterCoolerState.INACTIVE;
-         };
+        } else {
+            this.currentHeaterCoolerState = Characteristic.CurrentHeaterCoolerState.INACTIVE;
+        }
         return this.currentHeaterCoolerState;
-    }
-
-    getTargetHeaterCoolerState(callback) {
-        callback(null, this._getTargetHeaterCoolerState());
     }
 
     _getTargetHeaterCoolerState() {
@@ -142,20 +125,11 @@ class SimpleHeaterAccessory extends BaseAccessory {
         return Characteristic.TargetHeaterCoolerState.HEAT;
     }
 
-    setTargetHeaterCoolerState(value, callback) {
-        this.setState(this.dpActive, true, callback);
-    }
-
-    setTargetThresholdTemperature(value, callback) {
-        this.setState(this.dpDesiredTemperature, (value - this.temperatureOffset) * this.thresholdTemperatureDivisor, err => {
-            if (err) return callback(err);
-
-            if (this.characteristicHeatingThresholdTemperature) {
-                this.characteristicHeatingThresholdTemperature.updateValue(value);
-            }
-
-            callback();
-        });
+    async setTargetThresholdTemperature(value) {
+        await this.setStateAsync(this.dpDesiredTemperature, (value - this.temperatureOffset) * this.thresholdTemperatureDivisor);
+        if (this.characteristicHeatingThresholdTemperature) {
+            this.characteristicHeatingThresholdTemperature.updateValue(value);
+        }
     }
 
     _getDividedState(dp, divisor) {

--- a/lib/SimpleLightAccessory.js
+++ b/lib/SimpleLightAccessory.js
@@ -26,8 +26,8 @@ class SimpleLightAccessory extends BaseAccessory {
 
         const characteristicOn = service.getCharacteristic(Characteristic.On)
             .updateValue(dps[this.dpPower])
-            .on('get', this.getState.bind(this, this.dpPower))
-            .on('set', this.setState.bind(this, this.dpPower));
+            .onGet(() => this.getStateAsync(this.dpPower))
+            .onSet(value => this.setStateAsync(this.dpPower, value));
 
         this.device.on('change', (changes, state) => {
             if (changes.hasOwnProperty(this.dpPower) && characteristicOn.value !== changes[this.dpPower]) characteristicOn.updateValue(changes[this.dpPower]);

--- a/lib/SwitchAccessory.js
+++ b/lib/SwitchAccessory.js
@@ -1,5 +1,4 @@
 const BaseAccessory = require('./BaseAccessory');
-const async = require('async');
 
 class SwitchAccessory extends BaseAccessory {
     static getCategory(Categories) {
@@ -25,7 +24,7 @@ class SwitchAccessory extends BaseAccessory {
         const switchCount = parseInt(this.device.context.switchCount) || 1;
         const _validServices = [];
         for (let i = 0; i++ < switchCount;) {
-            let service = this.accessory.getServiceByUUIDAndSubType(Service.Switch, 'switch ' + i);
+            let service = this.accessory.getServiceById(Service.Switch.UUID, 'switch ' + i);
             if (service) this._checkServiceName(service, this.device.context.name + ' ' + i);
             else service = this.accessory.addService(Service.Switch, this.device.context.name + ' ' + i, 'switch ' + i);
 
@@ -54,8 +53,8 @@ class SwitchAccessory extends BaseAccessory {
 
             characteristics[match[1]] = service.getCharacteristic(Characteristic.On)
                 .updateValue(dps[match[1]])
-                .on('get', this.getPower.bind(this, match[1]))
-                .on('set', this.setPower.bind(this, match[1]));
+                .onGet(() => this.getPower(match[1]))
+                .onSet(value => this.setPower(match[1], value));
         });
 
         this.device.on('change', (changes, state) => {
@@ -65,41 +64,28 @@ class SwitchAccessory extends BaseAccessory {
         });
     }
 
-    getPower(dp, callback) {
-        callback(null, this.device.state[dp]);
+    getPower(dp) {
+        return this.getStateAsync(dp);
     }
 
-    setPower(dp, value, callback) {
+    setPower(dp, value) {
         if (!this._pendingPower) {
-            this._pendingPower = {props: {}, callbacks: []};
+            this._pendingPower = {props: {}, resolvers: []};
         }
 
-        if (dp) {
-            if (this._pendingPower.timer) clearTimeout(this._pendingPower.timer);
+        if (this._pendingPower.timer) clearTimeout(this._pendingPower.timer);
+        this._pendingPower.props = {...this._pendingPower.props, ...{[dp]: value}};
 
-            this._pendingPower.props = {...this._pendingPower.props, ...{[dp]: value}};
-            this._pendingPower.callbacks.push(callback);
+        return new Promise(resolve => {
+            this._pendingPower.resolvers.push(resolve);
 
             this._pendingPower.timer = setTimeout(() => {
-                this.setPower();
+                const {props, resolvers} = this._pendingPower;
+                this._pendingPower = null;
+                this.setMultiStateAsync(props);
+                resolvers.forEach(r => r());
             }, 500);
-            return;
-        }
-
-        const callbacks = this._pendingPower.callbacks;
-        const callEachBack = err => {
-            async.eachSeries(callbacks, (callback, next) => {
-                try {
-                    callback(err);
-                } catch (ex) {}
-                next();
-            });
-        };
-
-        const newValue = this._pendingPower.props;
-        this._pendingPower = null;
-
-        this.setMultiState(newValue, callEachBack);
+        });
     }
 }
 

--- a/lib/TWLightAccessory.js
+++ b/lib/TWLightAccessory.js
@@ -1,5 +1,4 @@
 const BaseAccessory = require('./BaseAccessory');
-const async = require('async');
 
 const DEFAULT_MIN_WHITE_COLOR = 0;
 const DEFAULT_MAX_WHITE_COLOR = 600;
@@ -32,13 +31,13 @@ class TWLightAccessory extends BaseAccessory {
 
         const characteristicOn = service.getCharacteristic(Characteristic.On)
             .updateValue(dps[this.dpPower])
-            .on('get', this.getState.bind(this, this.dpPower))
-            .on('set', this.setState.bind(this, this.dpPower));
+            .onGet(() => this.getStateAsync(this.dpPower))
+            .onSet(value => this.setStateAsync(this.dpPower, value));
 
         const characteristicBrightness = service.getCharacteristic(Characteristic.Brightness)
             .updateValue(this.convertBrightnessFromTuyaToHomeKit(dps[this.dpBrightness]))
-            .on('get', this.getBrightness.bind(this))
-            .on('set', this.setBrightness.bind(this));
+            .onGet(() => this.getBrightness())
+            .onSet(value => this.setBrightness(value));
 
         const characteristicColorTemperature = service.getCharacteristic(Characteristic.ColorTemperature)
             .setProps({
@@ -46,8 +45,8 @@ class TWLightAccessory extends BaseAccessory {
                 maxValue: this.device.context.maxWhiteColor ?? DEFAULT_MAX_WHITE_COLOR
             })
             .updateValue(this.convertColorTemperatureFromTuyaToHomeKit(dps[this.dpColorTemperature]))
-            .on('get', this.getColorTemperature.bind(this))
-            .on('set', this.setColorTemperature.bind(this));
+            .onGet(() => this.getColorTemperature())
+            .onSet(value => this.setColorTemperature(value));
 
         this.characteristicColorTemperature = characteristicColorTemperature;
 
@@ -72,22 +71,21 @@ class TWLightAccessory extends BaseAccessory {
         });
     }
 
-    getBrightness(callback) {
-        return callback(null, this.convertBrightnessFromTuyaToHomeKit(this.device.state[this.dpBrightness]));
+    getBrightness() {
+        return this.convertBrightnessFromTuyaToHomeKit(this.device.state[this.dpBrightness]);
     }
 
-    setBrightness(value, callback) {
-        return this.setState(this.dpBrightness, this.convertBrightnessFromHomeKitToTuya(value), callback);
+    setBrightness(value) {
+        return this.setStateAsync(this.dpBrightness, this.convertBrightnessFromHomeKitToTuya(value));
     }
 
-    getColorTemperature(callback) {
-        callback(null, this.convertColorTemperatureFromTuyaToHomeKit(this.device.state[this.dpColorTemperature]));
+    getColorTemperature() {
+        return this.convertColorTemperatureFromTuyaToHomeKit(this.device.state[this.dpColorTemperature]);
     }
 
-    setColorTemperature(value, callback) {
-        if (value === 0) return callback(null, true);
-
-        this.setState(this.dpColorTemperature, this.convertColorTemperatureFromHomeKitToTuya(value), callback);
+    setColorTemperature(value) {
+        if (value === 0) return;
+        return this.setStateAsync(this.dpColorTemperature, this.convertColorTemperatureFromHomeKitToTuya(value));
     }
 }
 

--- a/lib/ValveAccessory.js
+++ b/lib/ValveAccessory.js
@@ -23,9 +23,9 @@ class ValveAccessory extends BaseAccessory {
         this._checkServiceName(service, this.device.context.name);
         this.setDuration = this.device.context.defaultDuration || 600;
         this.noTimer = this.device.context.noTimer;
-        this.lastActivationTime = null
+        this.lastActivationTime = null;
         this.timer = null;
-        
+
         switch (this.device.context.valveType) {
             case 'IRRIGATION':
                 service.getCharacteristic(Characteristic.ValveType).updateValue(1);
@@ -42,102 +42,90 @@ class ValveAccessory extends BaseAccessory {
         }
 
         this.dpPower = this._getCustomDP(this.device.context.dpPower) || '1';
-            
+
         const characteristicActive = service.getCharacteristic(Characteristic.Active)
             .updateValue(dps[this.dpPower])
-            .on('get', this.getState.bind(this, this.dpPower))
-            .on('set', this.setState.bind(this, this.dpPower));
+            .onGet(() => this.getStateAsync(this.dpPower))
+            .onSet(value => this.setStateAsync(this.dpPower, value));
 
         const characteristicInUse = service.getCharacteristic(Characteristic.InUse)
-            .on('get', (next) => {
-                next(null, characteristicActive.value)
-            })
-
+            .onGet(() => characteristicActive.value);
 
         if (!this.noTimer) {
             service.getCharacteristic(Characteristic.SetDuration)
-                .on('get', (next) => {
-                    next(null, this.setDuration)
-                })
-                .on('change', (data)=> {
-                    this.log.info("Water Valve Time Duration Set to: " + data.newValue/60 + " Minutes")
-                    this.setDuration = data.newValue
+                .onGet(() => this.setDuration)
+                .on('change', (data) => {
+                    this.log.info('Water Valve Time Duration Set to: ' + data.newValue / 60 + ' Minutes');
+                    this.setDuration = data.newValue;
 
-                    if(service.getCharacteristic(Characteristic.InUse).value) {
+                    if (service.getCharacteristic(Characteristic.InUse).value) {
                         this.lastActivationTime = (new Date()).getTime();
                         service.getCharacteristic(Characteristic.RemainingDuration)
                             .updateValue(data.newValue);
-                            
-                        clearTimeout(this.timer); // clear any existing timer
-                        this.timer = setTimeout( ()=> {
-                            this.log.info("Water Valve Timer Expired. Shutting OFF Valve");
-                            service.getCharacteristic(Characteristic.Active).setValue(0); 
-                            service.getCharacteristic(Characteristic.InUse).updateValue(0); 
+
+                        clearTimeout(this.timer);
+                        this.timer = setTimeout(() => {
+                            this.log.info('Water Valve Timer Expired. Shutting OFF Valve');
+                            service.getCharacteristic(Characteristic.Active).setValue(0);
+                            service.getCharacteristic(Characteristic.InUse).updateValue(0);
                             this.lastActivationTime = null;
-                        }, (data.newValue *1000));	
+                        }, (data.newValue * 1000));
                     }
-                }); // end .on('change' ...
+                });
 
             service.getCharacteristic(Characteristic.RemainingDuration)
-                .on('get', (next) => {
-                    var remainingTime = this.setDuration - Math.floor(((new Date()).getTime() - this.lastActivationTime) / 1000)
-                    if (!remainingTime || remainingTime < 0) 
-                        remainingTime = 0
-                    next(null, remainingTime)
-                })
+                .onGet(() => {
+                    let remainingTime = this.setDuration - Math.floor(((new Date()).getTime() - this.lastActivationTime) / 1000);
+                    return (remainingTime && remainingTime > 0) ? remainingTime : 0;
+                });
 
             service.getCharacteristic(Characteristic.InUse)
                 .on('change', (data) => {
-                        switch(data.newValue) {
-                            case 0:
-                                this.lastActivationTime = null
-                                service.getCharacteristic(Characteristic.RemainingDuration).updateValue(0);
-                                service.getCharacteristic(Characteristic.Active).updateValue(0);
-                                clearTimeout(this.timer); // clear the timer if it was used!
-                                this.log.info("Water Valve is OFF!");
-                                break;
-                            case 1:
-                                this.lastActivationTime = (new Date()).getTime();                               
-                                service.getCharacteristic(Characteristic.RemainingDuration).updateValue(this.setDuration);
-                                service.getCharacteristic(Characteristic.Active).updateValue(1);
-                                this.log.info("Water Valve Turning ON with Timer Set to: "+  this.setDuration/60 + " Minutes");
-                                clearTimeout(this.timer); // clear any existing timer
-                                this.timer = setTimeout(()=> {
-                                    this.log.info("Water Valve Timer Expired. Shutting OFF Valve");
-                                    // use 'setvalue' when the timer ends so it triggers the .on('set'...) event
-                                    service.getCharacteristic(Characteristic.Active).setValue(0);
-                                    service.getCharacteristic(Characteristic.InUse).updateValue(0); 
-                                    this.lastActivationTime = null;
-                                }, (this.setDuration *1000));
-                                break;
-                        }
-                    }); // end .on('change' ...
-                    
-            // If Homebridge crash when valve is on the timer reset
+                    switch (data.newValue) {
+                        case 0:
+                            this.lastActivationTime = null;
+                            service.getCharacteristic(Characteristic.RemainingDuration).updateValue(0);
+                            service.getCharacteristic(Characteristic.Active).updateValue(0);
+                            clearTimeout(this.timer);
+                            this.log.info('Water Valve is OFF!');
+                            break;
+                        case 1:
+                            this.lastActivationTime = (new Date()).getTime();
+                            service.getCharacteristic(Characteristic.RemainingDuration).updateValue(this.setDuration);
+                            service.getCharacteristic(Characteristic.Active).updateValue(1);
+                            this.log.info('Water Valve Turning ON with Timer Set to: ' + this.setDuration / 60 + ' Minutes');
+                            clearTimeout(this.timer);
+                            this.timer = setTimeout(() => {
+                                this.log.info('Water Valve Timer Expired. Shutting OFF Valve');
+                                service.getCharacteristic(Characteristic.Active).setValue(0);
+                                service.getCharacteristic(Characteristic.InUse).updateValue(0);
+                                this.lastActivationTime = null;
+                            }, (this.setDuration * 1000));
+                            break;
+                    }
+                });
+
             if (dps[this.dpPower]) {
-                this.lastActivationTime = (new Date()).getTime();                               
+                this.lastActivationTime = (new Date()).getTime();
                 service.getCharacteristic(Characteristic.RemainingDuration).updateValue(this.setDuration);
                 service.getCharacteristic(Characteristic.Active).updateValue(1);
-                service.getCharacteristic(Characteristic.InUse).updateValue(1); 
-                this.log.info("Water Valve is ON After Restart. Setting Timer to: "+  this.setDuration/60 + " Minutes");	
-                clearTimeout(this.timer); // clear any existing timer								
-                this.timer = setTimeout(()=> {
-                        this.log.info("Water Valve Timer Expired. Shutting OFF Valve");
-                        // use 'setvalue' when the timer ends so it triggers the .on('set'...) event
-                        service.getCharacteristic(Characteristic.Active).setValue(0); 
-                        this.lastActivationTime = null;
-                }, (this.setDuration *1000));
+                service.getCharacteristic(Characteristic.InUse).updateValue(1);
+                this.log.info('Water Valve is ON After Restart. Setting Timer to: ' + this.setDuration / 60 + ' Minutes');
+                clearTimeout(this.timer);
+                this.timer = setTimeout(() => {
+                    this.log.info('Water Valve Timer Expired. Shutting OFF Valve');
+                    service.getCharacteristic(Characteristic.Active).setValue(0);
+                    this.lastActivationTime = null;
+                }, (this.setDuration * 1000));
             }
-
-        } // end if(!this.noTimer)
-
+        }
 
         this.device.on('change', changes => {
             if (changes.hasOwnProperty(this.dpPower) && characteristicActive.value !== changes[this.dpPower]) characteristicActive.updateValue(changes[this.dpPower]);
             if (changes.hasOwnProperty(this.dpPower) && characteristicInUse.value !== changes[this.dpPower]) characteristicInUse.setValue(changes[this.dpPower]);
-            
+
             if (!this.noTimer) {
-                if (changes.hasOwnProperty(this.dpPower) && !changes[this.dpPower]){
+                if (changes.hasOwnProperty(this.dpPower) && !changes[this.dpPower]) {
                     this.lastActivationTime = null;
                     service.getCharacteristic(Characteristic.RemainingDuration).updateValue(0);
                     clearTimeout(this.timer);

--- a/lib/VerticalBlindsWithTilt.js
+++ b/lib/VerticalBlindsWithTilt.js
@@ -12,8 +12,8 @@ class VerticalBlindsWithTilt extends BaseAccessory {
         this.lastTiltCommand = null;
         this.tiltBufferTimeout = null;
         this.tiltDelayTimeout = null;
-        this.positionStateTimeout = null; // For tracking when movement completes
-        this.isMoving = false; // Track if blinds are currently moving
+        this.positionStateTimeout = null;
+        this.isMoving = false;
     }
 
     _registerPlatformAccessory() {
@@ -29,41 +29,34 @@ class VerticalBlindsWithTilt extends BaseAccessory {
         const service = this.accessory.getService(Service.WindowCovering);
         this._checkServiceName(service, this.device.context.name);
 
-        // dp_id 1: control (open/close/stop) - for vertical position
-        // dp_id 2: percent_control - for rotation/tilt control
-        // dp_id 3: percent_state - read-only tilt status
         this.dpAction = this._getCustomDP(this.device.context.dpAction) || '1';
         this.dpTilt = this._getCustomDP(this.device.context.dpTilt) || '2';
         this.dpTiltState = this._getCustomDP(this.device.context.dpTiltState) || '3';
-        
-        // Time in seconds for blinds to fully close/extend (default: 30 seconds)
         this.timeToClose = this.device.context.timeToClose || 30;
-        
-        // Initialize position based on device state
+
         this.currentPosition = this._getInitialPosition(dps);
-        
+
         const characteristicCurrentPosition = service.getCharacteristic(Characteristic.CurrentPosition)
             .updateValue(this.currentPosition)
-            .on('get', this.getPosition.bind(this));
+            .onGet(() => this.currentPosition);
 
         const characteristicTargetPosition = service.getCharacteristic(Characteristic.TargetPosition)
             .updateValue(this.currentPosition)
-            .on('get', this.getPosition.bind(this))
-            .on('set', this.setPosition.bind(this));
+            .onGet(() => this.currentPosition)
+            .onSet(value => this.setPosition(value));
 
         const characteristicPositionState = service.getCharacteristic(Characteristic.PositionState)
             .updateValue(Characteristic.PositionState.STOPPED)
-            .on('get', this.getPositionState.bind(this));
+            .onGet(() => Characteristic.PositionState.STOPPED);
 
-        // Add tilt angle support - use percent_state for reading, percent_control for writing
         const characteristicCurrentHorizontalTilt = service.getCharacteristic(Characteristic.CurrentHorizontalTiltAngle)
             .updateValue(this._getTiltAngle(dps[this.dpTiltState] || dps[this.dpTilt]))
-            .on('get', this.getTiltAngle.bind(this));
+            .onGet(() => this._getTiltAngle(this.getStateAsync([this.dpTiltState])[this.dpTiltState]));
 
         const characteristicTargetHorizontalTilt = service.getCharacteristic(Characteristic.TargetHorizontalTiltAngle)
             .updateValue(this._getTiltAngle(dps[this.dpTiltState] || dps[this.dpTilt]))
-            .on('get', this.getTiltAngle.bind(this))
-            .on('set', this.setTiltAngle.bind(this));
+            .onGet(() => this._getTiltAngle(this.getStateAsync([this.dpTiltState])[this.dpTiltState]))
+            .onSet(value => this.setTiltAngle(value));
 
         this.characteristicCurrentPosition = characteristicCurrentPosition;
         this.characteristicTargetPosition = characteristicTargetPosition;
@@ -72,57 +65,32 @@ class VerticalBlindsWithTilt extends BaseAccessory {
         this.characteristicTargetHorizontalTilt = characteristicTargetHorizontalTilt;
     }
 
-    // Position methods
     _getInitialPosition(dps) {
-        // Try to restore last known position from persistent cache
-        // This survives Homebridge restarts
         if (this.accessory.context.cachedPosition !== undefined) {
             this.log('[TuyaAccessory] Restored position from cache:', this.accessory.context.cachedPosition + '%');
             return this.accessory.context.cachedPosition;
         }
-        
-        // First time setup - default to open
         this.log('[TuyaAccessory] Initial position unknown (first time setup), defaulting to open (100%)');
         return 100;
     }
 
-    getPosition(callback) {
-        // Since there's no position percentage, return tracked position
-        callback(null, this.currentPosition);
-    }
-
-    setPosition(value, callback) {
+    setPosition(value) {
         const {Characteristic} = this.hap;
-        
+
         if (value === 0) {
-            // Close blinds - but skip if already closed
             if (this.currentPosition === 0) {
                 this.log('[TuyaAccessory] Blinds already closed, skipping close command');
-                // Still allow tilt commands to proceed without delay
-                return callback && callback(null);
+                return;
             }
-            
-            // Actually need to close - track the time and set moving state
+
             this.log('[TuyaAccessory] Closing blinds');
             this.lastCloseTime = Date.now();
             this.isMoving = true;
-            
-            // Check if a tilt command was sent during previous movement
+
             if (this.lastTiltCommand && (Date.now() - this.lastTiltCommand.time < this.timeToClose * 1000)) {
                 this.log('[TuyaAccessory] Close command received while tilt was pending - rescheduling tilt delay');
-                
-                // Cancel the buffer timeout if it exists
-                if (this.tiltBufferTimeout) {
-                    clearTimeout(this.tiltBufferTimeout);
-                    this.tiltBufferTimeout = null;
-                }
-                
-                // Cancel any existing delay
-                if (this.tiltDelayTimeout) {
-                    clearTimeout(this.tiltDelayTimeout);
-                }
-                
-                // Schedule the tilt for after close completes
+                if (this.tiltBufferTimeout) { clearTimeout(this.tiltBufferTimeout); this.tiltBufferTimeout = null; }
+                if (this.tiltDelayTimeout) clearTimeout(this.tiltDelayTimeout);
                 const delayMs = this.timeToClose * 1000;
                 this.tiltDelayTimeout = setTimeout(() => {
                     this.log('[TuyaAccessory] Executing delayed tilt angle:', this.lastTiltCommand.angle, '-> Tuya percent_control:', this.lastTiltCommand.value);
@@ -131,54 +99,36 @@ class VerticalBlindsWithTilt extends BaseAccessory {
                     this.lastTiltCommand = null;
                 }, delayMs);
             }
-            
-            // Set target position to 0, but don't update current position yet
+
             this.characteristicTargetPosition.updateValue(0);
             this.characteristicPositionState.updateValue(Characteristic.PositionState.DECREASING);
-            
-            // Set timeout to mark as stopped after closing completes
-            if (this.positionStateTimeout) {
-                clearTimeout(this.positionStateTimeout);
-            }
+
+            if (this.positionStateTimeout) clearTimeout(this.positionStateTimeout);
             this.positionStateTimeout = setTimeout(() => {
                 this.log('[TuyaAccessory] Blinds finished closing');
                 this.currentPosition = 0;
-                this.accessory.context.cachedPosition = 0; // Persist across restarts
+                this.accessory.context.cachedPosition = 0;
                 this.characteristicCurrentPosition.updateValue(0);
                 this.characteristicPositionState.updateValue(Characteristic.PositionState.STOPPED);
                 this.isMoving = false;
                 this.lastCloseTime = 0;
                 this.positionStateTimeout = null;
             }, this.timeToClose * 1000);
-            
-            return this.setState(this.dpAction, 'close', callback);
-            
+
+            return this.setStateAsync(this.dpAction, 'close');
+
         } else if (value === 100) {
-            // Open blinds - but skip if already open
             if (this.currentPosition === 100) {
                 this.log('[TuyaAccessory] Blinds already open, skipping open command');
-                return callback && callback(null);
+                return;
             }
-            
-            // Actually need to open - reset close time and cancel any pending tilts
+
             this.log('[TuyaAccessory] Opening blinds');
-            
-            // Check if a tilt command was sent during previous movement
+
             if (this.lastTiltCommand && (Date.now() - this.lastTiltCommand.time < this.timeToClose * 1000)) {
                 this.log('[TuyaAccessory] Open command received while tilt was pending - rescheduling tilt delay');
-                
-                // Cancel the buffer timeout if it exists
-                if (this.tiltBufferTimeout) {
-                    clearTimeout(this.tiltBufferTimeout);
-                    this.tiltBufferTimeout = null;
-                }
-                
-                // Cancel any existing delay
-                if (this.tiltDelayTimeout) {
-                    clearTimeout(this.tiltDelayTimeout);
-                }
-                
-                // Schedule the tilt for after open completes
+                if (this.tiltBufferTimeout) { clearTimeout(this.tiltBufferTimeout); this.tiltBufferTimeout = null; }
+                if (this.tiltDelayTimeout) clearTimeout(this.tiltDelayTimeout);
                 const delayMs = this.timeToClose * 1000;
                 this.tiltDelayTimeout = setTimeout(() => {
                     this.log('[TuyaAccessory] Executing delayed tilt angle:', this.lastTiltCommand.angle, '-> Tuya percent_control:', this.lastTiltCommand.value);
@@ -190,50 +140,32 @@ class VerticalBlindsWithTilt extends BaseAccessory {
                 this._cancelPendingTilts();
                 this.lastTiltCommand = null;
             }
-            
+
             this.lastCloseTime = 0;
             this.lastOpenTime = Date.now();
-            
-            // Set target position to 100, but don't update current position yet
             this.characteristicTargetPosition.updateValue(100);
             this.characteristicPositionState.updateValue(Characteristic.PositionState.INCREASING);
-            
-            // Set timeout to mark as stopped after opening completes
-            if (this.positionStateTimeout) {
-                clearTimeout(this.positionStateTimeout);
-            }
+
+            if (this.positionStateTimeout) clearTimeout(this.positionStateTimeout);
             this.positionStateTimeout = setTimeout(() => {
                 this.log('[TuyaAccessory] Blinds finished opening');
                 this.currentPosition = 100;
-                this.accessory.context.cachedPosition = 100; // Persist across restarts
+                this.accessory.context.cachedPosition = 100;
                 this.characteristicCurrentPosition.updateValue(100);
                 this.characteristicPositionState.updateValue(Characteristic.PositionState.STOPPED);
                 this.lastOpenTime = 0;
                 this.positionStateTimeout = null;
             }, this.timeToClose * 1000);
-            
-            return this.setState(this.dpAction, 'open', callback);
-            
+
+            return this.setStateAsync(this.dpAction, 'open');
+
         } else {
-            // For partial positions, open fully then user can adjust manually
             this.log('[TuyaAccessory] Partial position requested, opening fully');
-            
-            // Check if a tilt command was sent during previous movement
+
             if (this.lastTiltCommand && (Date.now() - this.lastTiltCommand.time < this.timeToClose * 1000)) {
                 this.log('[TuyaAccessory] Partial open command received while tilt was pending - rescheduling tilt delay');
-                
-                // Cancel the buffer timeout if it exists
-                if (this.tiltBufferTimeout) {
-                    clearTimeout(this.tiltBufferTimeout);
-                    this.tiltBufferTimeout = null;
-                }
-                
-                // Cancel any existing delay
-                if (this.tiltDelayTimeout) {
-                    clearTimeout(this.tiltDelayTimeout);
-                }
-                
-                // Schedule the tilt for after open completes
+                if (this.tiltBufferTimeout) { clearTimeout(this.tiltBufferTimeout); this.tiltBufferTimeout = null; }
+                if (this.tiltDelayTimeout) clearTimeout(this.tiltDelayTimeout);
                 const delayMs = this.timeToClose * 1000;
                 this.tiltDelayTimeout = setTimeout(() => {
                     this.log('[TuyaAccessory] Executing delayed tilt angle:', this.lastTiltCommand.angle, '-> Tuya percent_control:', this.lastTiltCommand.value);
@@ -245,86 +177,54 @@ class VerticalBlindsWithTilt extends BaseAccessory {
                 this._cancelPendingTilts();
                 this.lastTiltCommand = null;
             }
-            
+
             this.lastCloseTime = 0;
             this.lastOpenTime = Date.now();
-            
-            // Set target position to 100, but don't update current position yet
             this.characteristicTargetPosition.updateValue(100);
             this.characteristicPositionState.updateValue(Characteristic.PositionState.INCREASING);
-            
-            // Set timeout to mark as stopped after opening completes
-            if (this.positionStateTimeout) {
-                clearTimeout(this.positionStateTimeout);
-            }
+
+            if (this.positionStateTimeout) clearTimeout(this.positionStateTimeout);
             this.positionStateTimeout = setTimeout(() => {
                 this.log('[TuyaAccessory] Blinds finished opening');
                 this.currentPosition = 100;
-                this.accessory.context.cachedPosition = 100; // Persist across restarts
+                this.accessory.context.cachedPosition = 100;
                 this.characteristicCurrentPosition.updateValue(100);
                 this.characteristicPositionState.updateValue(Characteristic.PositionState.STOPPED);
                 this.lastOpenTime = 0;
                 this.positionStateTimeout = null;
             }, this.timeToClose * 1000);
-            
-            return this.setState(this.dpAction, 'open', callback);
+
+            return this.setStateAsync(this.dpAction, 'open');
         }
     }
 
-    getPositionState(callback) {
-        const {Characteristic} = this.hap;
-        return callback(null, Characteristic.PositionState.STOPPED);
-    }
-
-    // Tilt angle methods
-    getTiltAngle(callback) {
-        // Read from percent_state (dp_id 3)
-        this.getState([this.dpTiltState], (err, dps) => {
-            if (err) return callback(err);
-            callback(null, this._getTiltAngle(dps[this.dpTiltState]));
-        });
-    }
-
     _getTiltAngle(value) {
-        // Convert Tuya percentage (0-100) to HomeKit tilt angle (-90 to 90)
-        // Tuya: 0 = fully closed, 50 = most open, 100 = fully closed other direction
-        // HomeKit: -90 = fully closed, 0 = most open, 90 = fully closed other direction
         const tuyaValue = parseInt(value);
         if (isNaN(tuyaValue)) return 0;
-        return (tuyaValue - 50) * 1.8; // Maps 0-100 to -90 to 90
+        return (tuyaValue - 50) * 1.8;
     }
 
-    setTiltAngle(value, callback) {
-        // Convert HomeKit tilt angle (-90 to 90) to Tuya percentage (0-100)
+    setTiltAngle(value) {
         const tuyaValue = Math.round((value / 1.8) + 50);
         const clampedValue = Math.max(0, Math.min(100, tuyaValue));
-        
-        // Store this command with timestamp
-        this.lastTiltCommand = {
-            angle: value,
-            value: clampedValue,
-            time: Date.now()
-        };
-        
-        // Check if a close OR open command was sent during the movement duration
+
+        this.lastTiltCommand = { angle: value, value: clampedValue, time: Date.now() };
+
         const timeSinceClose = Date.now() - this.lastCloseTime;
         const timeSinceOpen = Date.now() - this.lastOpenTime;
         const shouldDelayForClose = this.lastCloseTime > 0 && timeSinceClose < (this.timeToClose * 1000);
         const shouldDelayForOpen = this.lastOpenTime > 0 && timeSinceOpen < (this.timeToClose * 1000);
         const shouldDelay = shouldDelayForClose || shouldDelayForOpen;
-        
+
         if (shouldDelay) {
-            // Delay the tilt command until after blinds finish closing/opening
-            const delayMs = shouldDelayForClose 
+            const delayMs = shouldDelayForClose
                 ? (this.timeToClose * 1000) - timeSinceClose
                 : (this.timeToClose * 1000) - timeSinceOpen;
             const action = shouldDelayForClose ? 'close' : 'open';
             this.log('[TuyaAccessory] Tilt command received during', action, '- delaying by', Math.round(delayMs / 1000), 'seconds');
-            
-            // Cancel any existing delayed tilt
+
             this._cancelPendingTilts();
-            
-            // Schedule the tilt command
+
             this.tiltDelayTimeout = setTimeout(() => {
                 this.log('[TuyaAccessory] Executing delayed tilt angle:', value, '-> Tuya percent_control:', clampedValue);
                 this._executeTilt(clampedValue);
@@ -333,50 +233,32 @@ class VerticalBlindsWithTilt extends BaseAccessory {
                 this.lastOpenTime = 0;
                 this.lastTiltCommand = null;
             }, delayMs);
-            
-            // Call callback immediately so HomeKit doesn't wait
-            return callback && callback(null);
-            
+
         } else {
-            // Add a small buffer (200ms) to wait for a potential close command
-            // This handles the case where tilt arrives just before close
             this.log('[TuyaAccessory] Setting tilt angle:', value, '-> Tuya percent_control:', clampedValue);
-            
-            // Cancel any existing buffer
-            if (this.tiltBufferTimeout) {
-                clearTimeout(this.tiltBufferTimeout);
-            }
-            
+
+            if (this.tiltBufferTimeout) clearTimeout(this.tiltBufferTimeout);
+
             this.tiltBufferTimeout = setTimeout(() => {
-                // Check again if close or open command arrived during the buffer
                 const currentTimeSinceClose = Date.now() - this.lastCloseTime;
                 const currentTimeSinceOpen = Date.now() - this.lastOpenTime;
                 const closeInProgress = this.lastCloseTime > 0 && currentTimeSinceClose < (this.timeToClose * 1000);
                 const openInProgress = this.lastOpenTime > 0 && currentTimeSinceOpen < (this.timeToClose * 1000);
-                
-                if (closeInProgress || openInProgress) {
-                    this.log('[TuyaAccessory] Movement command arrived during tilt buffer - extending delay');
-                    // The setPosition method will handle rescheduling
-                } else {
-                    // No movement command, execute tilt normally
+
+                if (!closeInProgress && !openInProgress) {
                     this._executeTilt(clampedValue);
                     this.lastTiltCommand = null;
                 }
                 this.tiltBufferTimeout = null;
             }, 200);
-            
-            return callback && callback(null);
         }
     }
 
     _executeTilt(value) {
-        // Force update: Bypass setState caching and call device.update directly
-        // This is needed because percent_control (dp 2) is not reported in device state
         if (!this.device.connected) {
             this.log('[TuyaAccessory] Cannot execute tilt - device not connected');
             return;
         }
-        
         this.device.update({[this.dpTilt]: value});
     }
 
@@ -395,8 +277,7 @@ class VerticalBlindsWithTilt extends BaseAccessory {
 
     updateState(data) {
         const {Characteristic} = this.hap;
-        
-        // Update tilt based on percent_state (dp_id 3)
+
         if (data[this.dpTiltState] !== undefined) {
             const tiltAngle = this._getTiltAngle(data[this.dpTiltState]);
             this.log.debug('[TuyaAccessory] Tilt state updated to:', data[this.dpTiltState], '-> angle:', tiltAngle);
@@ -404,20 +285,19 @@ class VerticalBlindsWithTilt extends BaseAccessory {
             this.characteristicTargetHorizontalTilt.updateValue(tiltAngle);
         }
 
-        // Update position state based on control actions
         if (data[this.dpAction] !== undefined) {
             const action = data[this.dpAction];
             this.log.debug('[TuyaAccessory] Control action:', action);
-            
+
             if (action === 'open') {
                 this.currentPosition = 100;
-                this.accessory.context.cachedPosition = 100; // Persist across restarts
+                this.accessory.context.cachedPosition = 100;
                 this.characteristicCurrentPosition.updateValue(100);
                 this.characteristicTargetPosition.updateValue(100);
                 this.characteristicPositionState.updateValue(Characteristic.PositionState.INCREASING);
             } else if (action === 'close') {
                 this.currentPosition = 0;
-                this.accessory.context.cachedPosition = 0; // Persist across restarts
+                this.accessory.context.cachedPosition = 0;
                 this.characteristicCurrentPosition.updateValue(0);
                 this.characteristicTargetPosition.updateValue(0);
                 this.characteristicPositionState.updateValue(Characteristic.PositionState.DECREASING);

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,25 +25,548 @@
       "devDependencies": {
         "@eslint/js": "^9.30.1",
         "eslint": "^9.30.1",
-        "globals": "^16.3.0"
+        "globals": "^16.3.0",
+        "jest": "^30.3.0"
       },
       "engines": {
-        "homebridge": ">=0.4.0",
-        "node": ">=8.6.0"
+        "homebridge": "^1.8.0 || ^2.0.0-beta.0",
+        "node": "^20.18.0 || ^22.10.0 || ^24.0.0"
       }
     },
-    "node_modules/@babel/runtime": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.0.tgz",
-      "integrity": "sha512-89eSBLJsxNxOERC0Op4vd+0Bqm6wRMqMbFtV3i0/fbaWw/mJ8Q3eBvgX0G4SyrOOLCtbu98HspF8o09MRT+KzQ==",
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "regenerator-runtime": "^0.13.2"
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
+      "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
+      "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
-      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -73,9 +596,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -83,34 +606,37 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
-      "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.6",
+        "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
+        "minimatch": "^3.1.5"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.0.tgz",
-      "integrity": "sha512-ViuymvFmcJi04qdZeDc2whTHryouGcDlaxPqarTD0ZE10ISpxGUVZGZDx4w01upyIynL3iu6IXH2bS1NhclQMw==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
-      "integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -121,20 +647,20 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
-      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "debug": "^4.3.2",
         "espree": "^10.0.1",
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -158,9 +684,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.30.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.30.1.tgz",
-      "integrity": "sha512-zXhuECFlyep42KZUhWjfvsmXGX39W8K8LFb8AWXM9gSV9dQB+MrJGLKvW6Zw0Ggnbpw0VHTtrhFXYe3Gym18jg==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -171,9 +697,9 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
-      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -181,68 +707,55 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
-      "integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.15.1",
+        "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
-      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/json-schema": "^7.0.15"
+        "@humanfs/types": "^0.15.0"
       },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
-      "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
-      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
-        "@humanwhocodes/retry": "^0.3.0"
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
       },
       "engines": {
         "node": ">=18.18.0"
       }
     },
-    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
-      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=18.18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/nzakas"
+        "node": ">=18.18.0"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -273,12 +786,684 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.3.0.tgz",
+      "integrity": "sha512-PAwCvFJ4696XP2qZj+LAn1BWjZaJ6RjG6c7/lkMaUJnkyMS34ucuIsfqYvfskVNvUI27R/u4P1HMYFnlVXG/Ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "jest-message-util": "30.3.0",
+        "jest-util": "30.3.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.3.0.tgz",
+      "integrity": "sha512-U5mVPsBxLSO6xYbf+tgkymLx+iAhvZX43/xI1+ej2ZOPnPdkdO1CzDmFKh2mZBn2s4XZixszHeQnzp1gm/DIxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "30.3.0",
+        "@jest/pattern": "30.0.1",
+        "@jest/reporters": "30.3.0",
+        "@jest/test-result": "30.3.0",
+        "@jest/transform": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "exit-x": "^0.2.2",
+        "graceful-fs": "^4.2.11",
+        "jest-changed-files": "30.3.0",
+        "jest-config": "30.3.0",
+        "jest-haste-map": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-regex-util": "30.0.1",
+        "jest-resolve": "30.3.0",
+        "jest-resolve-dependencies": "30.3.0",
+        "jest-runner": "30.3.0",
+        "jest-runtime": "30.3.0",
+        "jest-snapshot": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-validate": "30.3.0",
+        "jest-watcher": "30.3.0",
+        "pretty-format": "30.3.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz",
+      "integrity": "sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
+      "integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-mock": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.3.0.tgz",
+      "integrity": "sha512-76Nlh4xJxk2D/9URCn3wFi98d2hb19uWE1idLsTt2ywhvdOldbw3S570hBgn25P4ICUZ/cBjybrBex2g17IDbg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "30.3.0",
+        "jest-snapshot": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.3.0.tgz",
+      "integrity": "sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
+      "integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@sinonjs/fake-timers": "^15.0.0",
+        "@types/node": "*",
+        "jest-message-util": "30.3.0",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.3.0.tgz",
+      "integrity": "sha512-+owLCBBdfpgL3HU+BD5etr1SvbXpSitJK0is1kiYjJxAAJggYMRQz5hSdd5pq1sSggfxPbw2ld71pt4x5wwViA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/expect": "30.3.0",
+        "@jest/types": "30.3.0",
+        "jest-mock": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+      "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.3.0.tgz",
+      "integrity": "sha512-a09z89S+PkQnL055bVj8+pe2Caed2PBOaczHcXCykW5ngxX9EWx/1uAwncxc/HiU0oZqfwseMjyhxgRjS49qPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "30.3.0",
+        "@jest/test-result": "30.3.0",
+        "@jest/transform": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "collect-v8-coverage": "^1.0.2",
+        "exit-x": "^0.2.2",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^5.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-worker": "30.3.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.2",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/snapshot-utils": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.3.0.tgz",
+      "integrity": "sha512-ORbRN9sf5PP82v3FXNSwmO1OTDR2vzR2YTaR+E3VkSBZ8zadQE6IqYdYEeFH1NIkeB2HIGdF02dapb6K0Mj05g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "natural-compare": "^1.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-30.0.1.tgz",
+      "integrity": "sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "callsites": "^3.1.0",
+        "graceful-fs": "^4.2.11"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.3.0.tgz",
+      "integrity": "sha512-e/52nJGuD74AKTSe0P4y5wFRlaXP0qmrS17rqOMHeSwm278VyNyXE3gFO/4DTGF9w+65ra3lo3VKj0LBrzmgdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "collect-v8-coverage": "^1.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.3.0.tgz",
+      "integrity": "sha512-dgbWy9b8QDlQeRZcv7LNF+/jFiiYHTKho1xirauZ7kVwY7avjFF6uTT0RqlgudB5OuIPagFdVtfFMosjVbk1eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "30.3.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.3.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz",
+      "integrity": "sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@jest/types": "30.3.0",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "babel-plugin-istanbul": "^7.0.1",
+        "chalk": "^4.1.2",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.3.0",
+        "jest-regex-util": "30.0.1",
+        "jest-util": "30.3.0",
+        "pirates": "^4.0.7",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^5.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
+      "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
+      "integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -287,10 +1472,344 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -311,9 +1830,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -327,23 +1846,75 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/ansi-regex": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
       "dependencies": {
-        "color-convert": "^1.9.0"
+        "color-convert": "^2.0.1"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/argparse": {
@@ -354,9 +1925,109 @@
       "license": "Python-2.0"
     },
     "node_modules/async": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.2.tgz",
-      "integrity": "sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g=="
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
+    "node_modules/babel-jest": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz",
+      "integrity": "sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "30.3.0",
+        "@types/babel__core": "^7.20.5",
+        "babel-plugin-istanbul": "^7.0.1",
+        "babel-preset-jest": "30.3.0",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
+      "integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "workspaces": [
+        "test/babel-8"
+      ],
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-instrument": "^6.0.2",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.3.0.tgz",
+      "integrity": "sha512-+TRkByhsws6sfPjVaitzadk1I0F5sPvOVUH5tyTSzhePpsGIVrdeunHSw/C36QeocS95OOk8lunc4rlu5Anwsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/babel__core": "^7.20.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.3.0.tgz",
+      "integrity": "sha512-6ZcUbWHC+dMz2vfzdNwi87Z1gQsLNK2uLuK1Q89R11xdvejcivlYYwDlEv0FHX3VwEXpbBQ9uufB/MUNpZGfhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "30.3.0",
+        "babel-preset-current-node-syntax": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -365,16 +2036,80 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.25",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.25.tgz",
+      "integrity": "sha512-QO/VHsXCQdnzADMfmkeOPvHdIAkoB7i0/rGjINPJEetLx75hNttVWGQ/jycHUDP9zZ9rupbm60WRxcwViB0MiA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -390,9 +2125,31 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001791",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -411,27 +2168,133 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/chalk/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
       "dependencies": {
-        "color-convert": "^2.0.1"
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/chalk/node_modules/color-convert": {
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -440,45 +2303,29 @@
         "node": ">=7.0.0"
       }
     },
-    "node_modules/chalk/node_modules/color-name": {
+    "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
-    "node_modules/cliui": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-      "dependencies": {
-        "string-width": "^3.1.0",
-        "strip-ansi": "^5.2.0",
-        "wrap-ansi": "^5.1.0"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-    },
     "node_modules/commander": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.1.tgz",
-      "integrity": "sha512-UNgvDd+csKdc9GD4zjtkHKQbT8Aspt2jCBqNSPp53vAS0L1tS9sXB2TCEOPHJ7kt9bN/niWkYj8T3RQSoMXdSQ=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+      "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
+      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
@@ -498,11 +2345,12 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -516,9 +2364,25 @@
     "node_modules/decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dedent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
       }
     },
     "node_modules/deep-is": {
@@ -528,20 +2392,81 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dijkstrajs": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.1.tgz",
-      "integrity": "sha1-082BIh4+pAdCz83lVtTpnpjdxxs="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.349",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.349.tgz",
+      "integrity": "sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
     },
     "node_modules/emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
     },
     "node_modules/escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -560,26 +2485,25 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.30.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.30.1.tgz",
-      "integrity": "sha512-zmxXPNMOXmwm9E0yQLi5uqXHs7uq2UIiqEKo3Gq+3fwo1XrJ+hijAZImyF7hclW3E6oHz43Yk3RP8at6OTKflQ==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.0",
-        "@eslint/config-helpers": "^0.3.0",
-        "@eslint/core": "^0.14.0",
-        "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.30.1",
-        "@eslint/plugin-kit": "^0.3.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "@types/json-schema": "^7.0.15",
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
@@ -598,7 +2522,7 @@
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "minimatch": "^3.1.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -650,81 +2574,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint/node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint/node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint/node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/espree": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
@@ -743,10 +2592,24 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -789,6 +2652,65 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/exit-x": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz",
+      "integrity": "sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz",
+      "integrity": "sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "30.3.0",
+        "@jest/get-type": "30.1.0",
+        "jest-matcher-utils": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -810,6 +2732,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bser": "2.1.1"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -824,14 +2756,20 @@
       }
     },
     "node_modules/find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "locate-path": "^3.0.0"
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/flat-cache": {
@@ -849,16 +2787,34 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/fs-extra": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
       "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^4.0.0",
@@ -868,12 +2824,90 @@
         "node": ">=6 <7 || >=8"
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -889,10 +2923,36 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/globals": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.3.0.tgz",
-      "integrity": "sha512-bqWEnJ1Nt3neqx2q5SFfGS8r/ahumIakg3HcwtNlrVlwXIeNumWn/c7Pn/wKzGhf6SaW6H6uWXLqC30STCMchQ==",
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -903,9 +2963,10 @@
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
-      "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q=="
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -917,10 +2978,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-mitm-proxy": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/http-mitm-proxy/-/http-mitm-proxy-1.1.0.tgz",
       "integrity": "sha512-GyjWXiukopLzp6Yg4Dk1M+6Yfp5c/rPtqXDGaRopeJH1bd9F6k2cyJrB98kKmJaMU2P7kA5LLHbtuFc8HcNvrA==",
+      "license": "MIT",
       "dependencies": {
         "async": "^3.2.5",
         "debug": "^4.3.4",
@@ -938,146 +3007,14 @@
         "node": ">=16"
       }
     },
-    "node_modules/http-mitm-proxy/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/http-mitm-proxy/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/http-mitm-proxy/node_modules/async": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
-      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
-    },
-    "node_modules/http-mitm-proxy/node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/http-mitm-proxy/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/http-mitm-proxy/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/http-mitm-proxy/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-    },
-    "node_modules/http-mitm-proxy/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/http-mitm-proxy/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/http-mitm-proxy/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/http-mitm-proxy/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/http-mitm-proxy/node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/http-mitm-proxy/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/http-mitm-proxy/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "engines": {
-        "node": ">=12"
+        "node": ">=10.17.0"
       }
     },
     "node_modules/ignore": {
@@ -1107,6 +3044,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -1116,6 +3073,32 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -1128,11 +3111,22 @@
       }
     },
     "node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/is-glob": {
@@ -1148,10 +3142,18 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -1160,10 +3162,709 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jest": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-30.3.0.tgz",
+      "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "30.3.0",
+        "@jest/types": "30.3.0",
+        "import-local": "^3.2.0",
+        "jest-cli": "30.3.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.3.0.tgz",
+      "integrity": "sha512-B/7Cny6cV5At6M25EWDgf9S617lHivamL8vl6KEpJqkStauzcG4e+WPfDgMMF+H4FVH4A2PLRyvgDJan4441QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.1.1",
+        "jest-util": "30.3.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.3.0.tgz",
+      "integrity": "sha512-PyXq5szeSfR/4f1lYqCmmQjh0vqDkURUYi9N6whnHjlRz4IUQfMcXkGLeEoiJtxtyPqgUaUUfyQlApXWBSN1RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/expect": "30.3.0",
+        "@jest/test-result": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "co": "^4.6.0",
+        "dedent": "^1.6.0",
+        "is-generator-fn": "^2.1.0",
+        "jest-each": "30.3.0",
+        "jest-matcher-utils": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-runtime": "30.3.0",
+        "jest-snapshot": "30.3.0",
+        "jest-util": "30.3.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "30.3.0",
+        "pure-rand": "^7.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.3.0.tgz",
+      "integrity": "sha512-l6Tqx+j1fDXJEW5bqYykDQQ7mQg+9mhWXtnj+tQZrTWYHyHoi6Be8HPumDSA+UiX2/2buEgjA58iJzdj146uCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "30.3.0",
+        "@jest/test-result": "30.3.0",
+        "@jest/types": "30.3.0",
+        "chalk": "^4.1.2",
+        "exit-x": "^0.2.2",
+        "import-local": "^3.2.0",
+        "jest-config": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-validate": "30.3.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.3.0.tgz",
+      "integrity": "sha512-WPMAkMAtNDY9P/oKObtsRG/6KTrhtgPJoBTmk20uDn4Uy6/3EJnnaZJre/FMT1KVRx8cve1r7/FlMIOfRVWL4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@jest/get-type": "30.1.0",
+        "@jest/pattern": "30.0.1",
+        "@jest/test-sequencer": "30.3.0",
+        "@jest/types": "30.3.0",
+        "babel-jest": "30.3.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "deepmerge": "^4.3.1",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "jest-circus": "30.3.0",
+        "jest-docblock": "30.2.0",
+        "jest-environment-node": "30.3.0",
+        "jest-regex-util": "30.0.1",
+        "jest-resolve": "30.3.0",
+        "jest-runner": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-validate": "30.3.0",
+        "parse-json": "^5.2.0",
+        "pretty-format": "30.3.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "esbuild-register": ">=3.4.0",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "esbuild-register": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz",
+      "integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.3.0",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.2.0.tgz",
+      "integrity": "sha512-tR/FFgZKS1CXluOQzZvNH3+0z9jXr3ldGSD8bhyuxvlVUwbeLOGynkunvlTMxchC5urrKndYiwCFC0DLVjpOCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.3.0.tgz",
+      "integrity": "sha512-V8eMndg/aZ+3LnCJgSm13IxS5XSBM22QSZc9BtPK8Dek6pm+hfUNfwBdvsB3d342bo1q7wnSkC38zjX259qZNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "@jest/types": "30.3.0",
+        "chalk": "^4.1.2",
+        "jest-util": "30.3.0",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.3.0.tgz",
+      "integrity": "sha512-4i6HItw/JSiJVsC5q0hnKIe/hbYfZLVG9YJ/0pU9Hz2n/9qZe3Rhn5s5CUZA5ORZlcdT/vmAXRMyONXJwPrmYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/fake-timers": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-validate": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.3.0.tgz",
+      "integrity": "sha512-mMi2oqG4KRU0R9QEtscl87JzMXfUhbKaFqOxmjb2CKcbHcUGFrJCBWHmnTiUqi6JcnzoBlO4rWfpdl2k/RfLCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "anymatch": "^3.1.3",
+        "fb-watchman": "^2.0.2",
+        "graceful-fs": "^4.2.11",
+        "jest-regex-util": "30.0.1",
+        "jest-util": "30.3.0",
+        "jest-worker": "30.3.0",
+        "picomatch": "^4.0.3",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.3"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.3.0.tgz",
+      "integrity": "sha512-cuKmUUGIjfXZAiGJ7TbEMx0bcqNdPPI6P1V+7aF+m/FUJqFDxkFR4JqkTu8ZOiU5AaX/x0hZ20KaaIPXQzbMGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz",
+      "integrity": "sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.3.0",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+      "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.3.0",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.3.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
+      "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+      "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.3.0.tgz",
+      "integrity": "sha512-NRtTAHQlpd15F9rUR36jqwelbrDV/dY4vzNte3S2kxCKUJRYNd5/6nTSbYiak1VX5g8IoFF23Uj5TURkUW8O5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.3.0",
+        "jest-pnp-resolver": "^1.2.3",
+        "jest-util": "30.3.0",
+        "jest-validate": "30.3.0",
+        "slash": "^3.0.0",
+        "unrs-resolver": "^1.7.11"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.3.0.tgz",
+      "integrity": "sha512-9ev8s3YN6Hsyz9LV75XUwkCVFlwPbaFn6Wp75qnI0wzAINYWY8Fb3+6y59Rwd3QaS3kKXffHXsZMziMavfz/nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "30.0.1",
+        "jest-snapshot": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.3.0.tgz",
+      "integrity": "sha512-gDv6C9LGKWDPLia9TSzZwf4h3kMQCqyTpq+95PODnTRDO0g9os48XIYYkS6D236vjpBir2fF63YmJFtqkS5Duw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "30.3.0",
+        "@jest/environment": "30.3.0",
+        "@jest/test-result": "30.3.0",
+        "@jest/transform": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "emittery": "^0.13.1",
+        "exit-x": "^0.2.2",
+        "graceful-fs": "^4.2.11",
+        "jest-docblock": "30.2.0",
+        "jest-environment-node": "30.3.0",
+        "jest-haste-map": "30.3.0",
+        "jest-leak-detector": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-resolve": "30.3.0",
+        "jest-runtime": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-watcher": "30.3.0",
+        "jest-worker": "30.3.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.3.0.tgz",
+      "integrity": "sha512-CgC+hIBJbuh78HEffkhNKcbXAytQViplcl8xupqeIWyKQF50kCQA8J7GeJCkjisC6hpnC9Muf8jV5RdtdFbGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/fake-timers": "30.3.0",
+        "@jest/globals": "30.3.0",
+        "@jest/source-map": "30.0.1",
+        "@jest/test-result": "30.3.0",
+        "@jest/transform": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "cjs-module-lexer": "^2.1.0",
+        "collect-v8-coverage": "^1.0.2",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-mock": "30.3.0",
+        "jest-regex-util": "30.0.1",
+        "jest-resolve": "30.3.0",
+        "jest-snapshot": "30.3.0",
+        "jest-util": "30.3.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.3.0.tgz",
+      "integrity": "sha512-f14c7atpb4O2DeNhwcvS810Y63wEn8O1HqK/luJ4F6M4NjvxmAKQwBUWjbExUtMxWJQ0wVgmCKymeJK6NZMnfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@babel/generator": "^7.27.5",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.27.1",
+        "@babel/types": "^7.27.3",
+        "@jest/expect-utils": "30.3.0",
+        "@jest/get-type": "30.1.0",
+        "@jest/snapshot-utils": "30.3.0",
+        "@jest/transform": "30.3.0",
+        "@jest/types": "30.3.0",
+        "babel-preset-current-node-syntax": "^1.2.0",
+        "chalk": "^4.1.2",
+        "expect": "30.3.0",
+        "graceful-fs": "^4.2.11",
+        "jest-diff": "30.3.0",
+        "jest-matcher-utils": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-util": "30.3.0",
+        "pretty-format": "30.3.0",
+        "semver": "^7.7.2",
+        "synckit": "^0.11.8"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.3.0.tgz",
+      "integrity": "sha512-I/xzC8h5G+SHCb2P2gWkJYrNiTbeL47KvKeW5EzplkyxzBRBw1ssSHlI/jXec0ukH2q7x2zAWQm7015iusg62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "@jest/types": "30.3.0",
+        "camelcase": "^6.3.0",
+        "chalk": "^4.1.2",
+        "leven": "^3.1.0",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.3.0.tgz",
+      "integrity": "sha512-PJ1d9ThtTR8aMiBWUdcownq9mDdLXsQzJayTk4kmaBRHKvwNQn+ANveuhEBUyNI2hR1TVhvQ8D5kHubbzBHR/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "emittery": "^0.13.1",
+        "jest-util": "30.3.0",
+        "string-length": "^4.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.3.0.tgz",
+      "integrity": "sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@ungap/structured-clone": "^1.3.0",
+        "jest-util": "30.3.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.1.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1173,10 +3874,30 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1198,6 +3919,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -1208,7 +3930,8 @@
     "node_modules/jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -1221,6 +3944,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/levn": {
@@ -1237,16 +3970,27 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "^5.0.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lodash.merge": {
@@ -1256,10 +4000,76 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/makeerror": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1269,10 +4079,21 @@
         "node": "*"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "license": "MIT",
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -1281,9 +4102,26 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -1293,11 +4131,75 @@
       "license": "MIT"
     },
     "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/optionator": {
@@ -1319,34 +4221,52 @@
       }
     },
     "node_modules/p-limit": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-      "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "p-try": "^2.0.0"
+        "yocto-queue": "^0.1.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "p-limit": "^2.0.0"
+        "p-limit": "^3.0.2"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -1361,12 +4281,42 @@
         "node": ">=6"
       }
     },
-    "node_modules/path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -1379,12 +4329,136 @@
         "node": ">=8"
       }
     },
-    "node_modules/pngjs": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
-      "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
       "engines": {
-        "node": ">=4.0.0"
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -1397,6 +4471,34 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -1407,32 +4509,211 @@
         "node": ">=6"
       }
     },
+    "node_modules/pure-rand": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/qrcode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.4.1.tgz",
-      "integrity": "sha512-3JhHQJkKqJL4PfoM6t+B40f0GWv9eNJAJmuNx2X/sHEOLvMyvEPN8GfbdN1qmr19O8N2nLraOzeWjXocHz1S4w==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
       "dependencies": {
         "dijkstrajs": "^1.0.1",
-        "isarray": "^2.0.1",
-        "pngjs": "^3.3.0",
-        "yargs": "^13.2.4"
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
       },
       "bin": {
         "qrcode": "bin/qrcode"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=10.13.0"
       }
     },
-    "node_modules/regenerator-runtime": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+    "node_modules/qrcode/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/qrcode/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1440,7 +4721,31 @@
     "node_modules/require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
+    },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-cwd/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -1460,10 +4765,21 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -1488,26 +4804,237 @@
         "node": ">=8"
       }
     },
-    "node_modules/string-width": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-length/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-length/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^4.1.0"
+        "ansi-regex": "^6.2.2"
       },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -1538,6 +5065,74 @@
         "node": ">=8"
       }
     },
+    "node_modules/synckit": {
+      "version": "0.11.12",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
+      "integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.2.9"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -1551,12 +5146,109 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/unrs-resolver": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
+      "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "napi-postinstall": "^0.3.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+        "@unrs/resolver-binding-android-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-x64": "1.11.1",
+        "@unrs/resolver-binding-freebsd-x64": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+        "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
       }
     },
     "node_modules/uri-js": {
@@ -1573,12 +5265,39 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/walker": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "makeerror": "1.0.12"
       }
     },
     "node_modules/which": {
@@ -1598,9 +5317,10 @@
       }
     },
     "node_modules/which-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
@@ -1613,22 +5333,126 @@
       }
     },
     "node_modules/wrap-ansi": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^3.2.0",
-        "string-width": "^3.0.0",
-        "strip-ansi": "^5.0.0"
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -1646,45 +5470,96 @@
       }
     },
     "node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.6.0.tgz",
-      "integrity": "sha512-iZfse3lwrJRoSlfs/9KQ9iIXxs9++RvBFVzAqbbBiFT+giYtyanevreF9r61ZTbGMgWQBxAua3FzJiniiJXWWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.4.5"
-      },
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
       "engines": {
         "node": ">= 6"
       }
     },
     "node_modules/yargs": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
-      "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
       "dependencies": {
-        "cliui": "^5.0.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^2.0.1",
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^3.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.1"
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yargs-parser": {
-      "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
       "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A community-maintained Homebridge plugin for controlling Tuya devices locally over LAN. Includes new features, fixes, and updated device support.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "lint": "eslint index.js lib/**.js bin/**.js"
   },
   "bin": {
@@ -38,12 +38,13 @@
     "tuya"
   ],
   "engines": {
-    "homebridge": ">=0.4.0",
-    "node": ">=8.6.0"
+    "homebridge": "^1.8.0 || ^2.0.0-beta.0",
+    "node": "^20.18.0 || ^22.10.0 || ^24.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",
     "eslint": "^9.30.1",
-    "globals": "^16.3.0"
+    "globals": "^16.3.0",
+    "jest": "^30.3.0"
   }
 }

--- a/test/BaseAccessory.test.js
+++ b/test/BaseAccessory.test.js
@@ -1,0 +1,269 @@
+'use strict';
+
+const BaseAccessory = require('../lib/BaseAccessory');
+const { makeInstance } = require('./support/mocks');
+
+// Minimal concrete subclass — BaseAccessory itself doesn't define _registerCharacteristics
+class TestAccessory extends BaseAccessory {
+    _registerCharacteristics() {}
+}
+
+function make(deviceState = {}, deviceContext = {}) {
+    return makeInstance(TestAccessory, deviceState, deviceContext);
+}
+
+// ---------------------------------------------------------------------------
+// Brightness conversion
+// ---------------------------------------------------------------------------
+describe('convertBrightnessFromTuyaToHomeKit', () => {
+    test('maps scale value (255) to 100%', () => {
+        const { instance } = make();
+        expect(instance.convertBrightnessFromTuyaToHomeKit(255)).toBe(100);
+    });
+
+    test('maps minimum value (27) to ~1%', () => {
+        const { instance } = make();
+        expect(instance.convertBrightnessFromTuyaToHomeKit(27)).toBe(1);
+    });
+
+    test('round-trips with convertBrightnessFromHomeKitToTuya at boundaries', () => {
+        const { instance } = make();
+        for (const hk of [1, 25, 50, 75, 100]) {
+            const tuya = instance.convertBrightnessFromHomeKitToTuya(hk);
+            expect(instance.convertBrightnessFromTuyaToHomeKit(tuya)).toBe(hk);
+        }
+    });
+
+    test('respects custom scaleBrightness from device context', () => {
+        const { instance } = make({}, { scaleBrightness: 1000 });
+        expect(instance.convertBrightnessFromTuyaToHomeKit(1000)).toBe(100);
+    });
+});
+
+describe('convertBrightnessFromHomeKitToTuya', () => {
+    test('maps 100% to scale (255)', () => {
+        const { instance } = make();
+        expect(instance.convertBrightnessFromHomeKitToTuya(100)).toBe(255);
+    });
+
+    test('maps 1% to minimum (27)', () => {
+        const { instance } = make();
+        expect(instance.convertBrightnessFromHomeKitToTuya(1)).toBe(27);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Color temperature conversion
+// ---------------------------------------------------------------------------
+describe('convertColorTemperatureFromTuyaToHomeKit', () => {
+    test('maps scale (255) to min mireds (140)', () => {
+        const { instance } = make();
+        expect(instance.convertColorTemperatureFromTuyaToHomeKit(255)).toBe(140);
+    });
+
+    test('maps 0 to max mireds (400)', () => {
+        const { instance } = make();
+        expect(instance.convertColorTemperatureFromTuyaToHomeKit(0)).toBe(400);
+    });
+
+    test('clamps result to [71, 600]', () => {
+        const { instance } = make();
+        expect(instance.convertColorTemperatureFromTuyaToHomeKit(255)).toBeGreaterThanOrEqual(71);
+        expect(instance.convertColorTemperatureFromTuyaToHomeKit(0)).toBeLessThanOrEqual(600);
+    });
+
+    test('round-trips with convertColorTemperatureFromHomeKitToTuya at boundaries', () => {
+        const { instance } = make();
+        for (const hk of [140, 200, 300, 400]) {
+            const tuya = instance.convertColorTemperatureFromHomeKitToTuya(hk);
+            expect(instance.convertColorTemperatureFromTuyaToHomeKit(tuya)).toBe(hk);
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// HEXHSB color conversion
+// ---------------------------------------------------------------------------
+describe('convertColorFromTuyaToHomeKit (HEXHSB)', () => {
+    test('parses a known HEXHSB value correctly', () => {
+        const { instance } = make({}, { colorFunction: 'HEXHSB' });
+        instance.colorFunction = 'HEXHSB';
+        // Format: RRGGBB + HHHH + SS + BB
+        // h=0x00b4=180, s=0x64=100→39%, b=0x64=100→39%
+        const result = instance.convertColorFromTuyaToHomeKit('00000000b46464');
+        expect(result.h).toBe(180);
+        expect(result.s).toBe(Math.round(100 / 2.55)); // 39
+        expect(result.b).toBe(Math.round(100 / 2.55)); // 39
+    });
+
+    test('handles null/undefined with a default value', () => {
+        const { instance } = make({}, { colorFunction: 'HEXHSB' });
+        instance.colorFunction = 'HEXHSB';
+        const result = instance.convertColorFromTuyaToHomeKit(null);
+        expect(result).toHaveProperty('h');
+        expect(result).toHaveProperty('s');
+        expect(result).toHaveProperty('b');
+    });
+});
+
+describe('convertColorFromTuyaToHomeKit (HSB)', () => {
+    test('parses a known HSB value correctly', () => {
+        const { instance } = make({}, { colorFunction: 'HSB' });
+        instance.colorFunction = 'HSB';
+        // h=0x00b4=180, s=0x03e8=1000→100%, b=0x03e8=1000→100%
+        const result = instance.convertColorFromTuyaToHomeKit('00b403e803e8');
+        expect(result.h).toBe(180);
+        expect(result.s).toBe(100); // 1000/10
+        expect(result.b).toBe(100); // 1000/10
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Color temperature → HomeKit color conversion
+// ---------------------------------------------------------------------------
+describe('convertHomeKitColorTemperatureToHomeKitColor', () => {
+    test('returns an object with h, s, b properties', () => {
+        const { instance } = make();
+        const color = instance.convertHomeKitColorTemperatureToHomeKitColor(200);
+        expect(color).toHaveProperty('h');
+        expect(color).toHaveProperty('s');
+        expect(color).toHaveProperty('b');
+    });
+
+    test('produces values within valid HomeKit ranges', () => {
+        const { instance } = make();
+        for (const ct of [140, 200, 300, 400, 500]) {
+            const { h, s, b } = instance.convertHomeKitColorTemperatureToHomeKitColor(ct);
+            expect(h).toBeGreaterThanOrEqual(0);
+            expect(h).toBeLessThanOrEqual(360);
+            expect(s).toBeGreaterThanOrEqual(0);
+            expect(s).toBeLessThanOrEqual(100);
+            expect(b).toBeGreaterThanOrEqual(0);
+            expect(b).toBeLessThanOrEqual(100);
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Async helpers
+// ---------------------------------------------------------------------------
+describe('getStateAsync', () => {
+    test('returns a single DP value when connected', () => {
+        const { instance } = make({ '1': true });
+        expect(instance.getStateAsync('1')).toBe(true);
+    });
+
+    test('returns an object keyed by DP when passed an array', () => {
+        const { instance } = make({ '1': true, '2': 50 });
+        expect(instance.getStateAsync(['1', '2'])).toEqual({ '1': true, '2': 50 });
+    });
+
+    test('throws when device is not connected', () => {
+        const { instance, device } = make();
+        device.connected = false;
+        expect(() => instance.getStateAsync('1')).toThrow('Not connected');
+    });
+});
+
+describe('setStateAsync', () => {
+    test('calls device.update with the correct DP and value', () => {
+        const { instance, device } = make({ '1': false });
+        instance.setStateAsync('1', true);
+        expect(device.update).toHaveBeenCalledWith({ '1': true });
+    });
+
+    test('does not call device.update when value matches current state', () => {
+        const { instance, device } = make({ '1': true });
+        instance.setStateAsync('1', true);
+        expect(device.update).not.toHaveBeenCalled();
+    });
+
+    test('throws when device is not connected', () => {
+        const { instance, device } = make({ '1': false });
+        device.connected = false;
+        expect(() => instance.setStateAsync('1', true)).toThrow('Not connected');
+    });
+});
+
+describe('setMultiStateAsync', () => {
+    test('calls device.update once per changed DP', () => {
+        const { instance, device } = make({ '1': false, '2': 0 });
+        instance.setMultiStateAsync({ '1': true, '2': 50 });
+        expect(device.update).toHaveBeenCalledTimes(2);
+        expect(device.update).toHaveBeenCalledWith({ '1': true });
+        expect(device.update).toHaveBeenCalledWith({ '2': 50 });
+    });
+
+    test('skips DPs whose value has not changed', () => {
+        const { instance, device } = make({ '1': true, '2': 50 });
+        instance.setMultiStateAsync({ '1': true, '2': 50 });
+        expect(device.update).not.toHaveBeenCalled();
+    });
+});
+
+describe('setMultiStateLegacyAsync', () => {
+    test('calls device.update once with the full dps object', () => {
+        const { instance, device } = make();
+        instance.setMultiStateLegacyAsync({ '1': true, '3': '2' });
+        expect(device.update).toHaveBeenCalledTimes(1);
+        expect(device.update).toHaveBeenCalledWith({ '1': true, '3': '2' });
+    });
+});
+
+describe('getDividedStateAsync', () => {
+    test('returns state value divided by divisor', () => {
+        const { instance } = make({ '5': 2200 });
+        expect(instance.getDividedStateAsync('5', 10)).toBeCloseTo(220);
+    });
+
+    test('throws when state value is not finite', () => {
+        const { instance } = make({ '5': 'bad' });
+        expect(() => instance.getDividedStateAsync('5', 10)).toThrow();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Utility helpers
+// ---------------------------------------------------------------------------
+describe('_getCustomDP', () => {
+    test('returns string for valid positive integers', () => {
+        const { instance } = make();
+        expect(instance._getCustomDP(1)).toBe('1');
+        expect(instance._getCustomDP('101')).toBe('101');
+    });
+
+    test('returns false for invalid values', () => {
+        const { instance } = make();
+        expect(instance._getCustomDP(0)).toBe(false);
+        expect(instance._getCustomDP(-1)).toBe(false);
+        expect(instance._getCustomDP('abc')).toBe(false);
+        expect(instance._getCustomDP(undefined)).toBe(false);
+    });
+});
+
+describe('_coerceBoolean', () => {
+    test('passes through booleans', () => {
+        const { instance } = make();
+        expect(instance._coerceBoolean(true)).toBe(true);
+        expect(instance._coerceBoolean(false)).toBe(false);
+    });
+
+    test('coerces strings', () => {
+        const { instance } = make();
+        expect(instance._coerceBoolean('true')).toBe(true);
+        expect(instance._coerceBoolean('false')).toBe(false);
+        expect(instance._coerceBoolean('TRUE')).toBe(true);
+    });
+
+    test('coerces numbers', () => {
+        const { instance } = make();
+        expect(instance._coerceBoolean(1)).toBe(true);
+        expect(instance._coerceBoolean(0)).toBe(false);
+    });
+
+    test('falls back to defaultValue for unrecognised input', () => {
+        const { instance } = make();
+        expect(instance._coerceBoolean(null, true)).toBe(true);
+        expect(instance._coerceBoolean(undefined, false)).toBe(false);
+    });
+});

--- a/test/EnergyCharacteristics.test.js
+++ b/test/EnergyCharacteristics.test.js
@@ -1,0 +1,74 @@
+'use strict';
+
+const EnergyCharacteristics = require('../lib/EnergyCharacteristics');
+const { HAP } = require('./support/mocks');
+
+// The factory needs Characteristic as a base class.
+// We use a minimal class that supports super(displayName, UUID) and setProps/getDefaultValue.
+class MockCharacteristicBase {
+    constructor(displayName, uuid) {
+        this.displayName = displayName;
+        this.UUID = uuid;
+        this._props = {};
+    }
+    setProps(props) {
+        this._props = { ...this._props, ...props };
+        return this;
+    }
+    getDefaultValue() {
+        return 0;
+    }
+}
+
+const mockHap = {
+    ...HAP,
+    Characteristic: Object.assign(MockCharacteristicBase, HAP.Characteristic),
+    Formats: HAP.Formats,
+    Perms: HAP.Perms,
+};
+
+describe('EnergyCharacteristics', () => {
+    let chars;
+
+    beforeAll(() => {
+        chars = EnergyCharacteristics(mockHap);
+    });
+
+    test('exports Amperes, KilowattHours, VoltAmperes, Volts, Watts', () => {
+        expect(chars).toHaveProperty('Amperes');
+        expect(chars).toHaveProperty('KilowattHours');
+        expect(chars).toHaveProperty('VoltAmperes');
+        expect(chars).toHaveProperty('Volts');
+        expect(chars).toHaveProperty('Watts');
+    });
+
+    test('each characteristic has a UUID', () => {
+        for (const [, Cls] of Object.entries(chars)) {
+            expect(typeof Cls.UUID).toBe('string');
+            expect(Cls.UUID.length).toBeGreaterThan(0);
+        }
+    });
+
+    test('characteristics are instantiable', () => {
+        for (const [name, Cls] of Object.entries(chars)) {
+            const instance = new Cls();
+            expect(instance.displayName).toBeTruthy();
+            expect(instance.UUID).toBe(Cls.UUID);
+        }
+    });
+
+    test('Amperes uses FLOAT format', () => {
+        const instance = new chars.Amperes();
+        expect(instance._props.format).toBe(HAP.Formats.FLOAT);
+    });
+
+    test('KilowattHours uses FLOAT format', () => {
+        const instance = new chars.KilowattHours();
+        expect(instance._props.format).toBe(HAP.Formats.FLOAT);
+    });
+
+    test('all UUIDs are unique', () => {
+        const uuids = Object.values(chars).map(Cls => Cls.UUID);
+        expect(new Set(uuids).size).toBe(uuids.length);
+    });
+});

--- a/test/GarageDoorAccessory.test.js
+++ b/test/GarageDoorAccessory.test.js
@@ -1,0 +1,131 @@
+'use strict';
+
+const GarageDoorAccessory = require('../lib/GarageDoorAccessory');
+const { HAP, makeInstance } = require('./support/mocks');
+
+const { CurrentDoorState: CDS, TargetDoorState: TDS } = HAP.Characteristic;
+
+// Helper: create an instance with manufacturer pre-configured and
+// all the state fields that _registerCharacteristics would normally set.
+function makeGarage(manufacturer = 'Generic', flipState = false) {
+    const { instance, device } = makeInstance(GarageDoorAccessory, {}, { manufacturer });
+
+    // Replicate what _registerCharacteristics sets
+    instance.manufacturer = manufacturer.trim();
+    instance.dpAction = manufacturer === 'Kogan' ? '101' : '1';
+    instance.dpStatus = manufacturer === 'Kogan' ? '102' : '2';
+
+    instance.currentOpen    = flipState ? CDS.CLOSED   : CDS.OPEN;
+    instance.currentOpening = flipState ? CDS.CLOSING  : CDS.OPENING;
+    instance.currentClosing = flipState ? CDS.OPENING  : CDS.CLOSING;
+    instance.currentClosed  = flipState ? CDS.OPEN     : CDS.CLOSED;
+    instance.currentStopped = CDS.STOPPED;
+    instance.targetOpen     = flipState ? TDS.CLOSED   : TDS.OPEN;
+    instance.targetClosed   = flipState ? TDS.OPEN     : TDS.CLOSED;
+
+    return { instance, device };
+}
+
+// ---------------------------------------------------------------------------
+// _getTargetDoorState
+// ---------------------------------------------------------------------------
+describe('GarageDoorAccessory._getTargetDoorState — generic (boolean)', () => {
+    test('true → targetOpen', () => {
+        const { instance } = makeGarage('Generic');
+        expect(instance._getTargetDoorState(true)).toBe(TDS.OPEN);
+    });
+
+    test('false → targetClosed', () => {
+        const { instance } = makeGarage('Generic');
+        expect(instance._getTargetDoorState(false)).toBe(TDS.CLOSED);
+    });
+});
+
+describe('GarageDoorAccessory._getTargetDoorState — Kogan (string)', () => {
+    let instance;
+    beforeEach(() => ({ instance } = makeGarage('Kogan')));
+
+    test('"opened" → targetOpen', () => expect(instance._getTargetDoorState('opened')).toBe(TDS.OPEN));
+    test('"openning" → targetOpen', () => expect(instance._getTargetDoorState('openning')).toBe(TDS.OPEN));
+    test('"opening" → targetOpen', () => expect(instance._getTargetDoorState('opening')).toBe(TDS.OPEN));
+    test('"closed" → targetClosed', () => expect(instance._getTargetDoorState('closed')).toBe(TDS.CLOSED));
+    test('"closing" → targetClosed', () => expect(instance._getTargetDoorState('closing')).toBe(TDS.CLOSED));
+});
+
+// ---------------------------------------------------------------------------
+// _getCurrentDoorState
+// ---------------------------------------------------------------------------
+describe('GarageDoorAccessory._getCurrentDoorState — generic (boolean)', () => {
+    test('true → currentOpen', () => {
+        const { instance } = makeGarage('Generic');
+        expect(instance._getCurrentDoorState(true)).toBe(CDS.OPEN);
+    });
+
+    test('false → currentClosed', () => {
+        const { instance } = makeGarage('Generic');
+        expect(instance._getCurrentDoorState(false)).toBe(CDS.CLOSED);
+    });
+});
+
+describe('GarageDoorAccessory._getCurrentDoorState — Kogan (string)', () => {
+    let instance;
+    beforeEach(() => ({ instance } = makeGarage('Kogan')));
+
+    test('"opened" → OPEN',    () => expect(instance._getCurrentDoorState('opened')).toBe(CDS.OPEN));
+    test('"openning" → OPENING', () => expect(instance._getCurrentDoorState('openning')).toBe(CDS.OPENING));
+    test('"opening" → OPENING',  () => expect(instance._getCurrentDoorState('opening')).toBe(CDS.OPENING));
+    test('"closing" → CLOSING',  () => expect(instance._getCurrentDoorState('closing')).toBe(CDS.CLOSING));
+    test('"closed" → CLOSED',    () => expect(instance._getCurrentDoorState('closed')).toBe(CDS.CLOSED));
+});
+
+// ---------------------------------------------------------------------------
+// setTargetDoorState — device command
+// ---------------------------------------------------------------------------
+describe('GarageDoorAccessory.setTargetDoorState — generic', () => {
+    test('OPEN sends true to dpAction', () => {
+        const { instance, device } = makeGarage('Generic');
+        device.state['1'] = false;
+        instance.setTargetDoorState(TDS.OPEN);
+        expect(device.update).toHaveBeenCalledWith({ '1': true });
+    });
+
+    test('CLOSED sends false to dpAction', () => {
+        const { instance, device } = makeGarage('Generic');
+        device.state['1'] = true;
+        instance.setTargetDoorState(TDS.CLOSED);
+        expect(device.update).toHaveBeenCalledWith({ '1': false });
+    });
+});
+
+describe('GarageDoorAccessory.setTargetDoorState — Kogan', () => {
+    test('OPEN sends "open" to dpAction (101)', () => {
+        const { instance, device } = makeGarage('Kogan');
+        device.state['101'] = 'closed';
+        instance.setTargetDoorState(TDS.OPEN);
+        expect(device.update).toHaveBeenCalledWith({ '101': 'open' });
+    });
+
+    test('CLOSED sends "close" to dpAction (101)', () => {
+        const { instance, device } = makeGarage('Kogan');
+        device.state['101'] = 'opened';
+        instance.setTargetDoorState(TDS.CLOSED);
+        expect(device.update).toHaveBeenCalledWith({ '101': 'close' });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// flipState
+// ---------------------------------------------------------------------------
+describe('GarageDoorAccessory with flipState', () => {
+    test('inverts currentOpen/currentClosed', () => {
+        const { instance } = makeGarage('Generic', true);
+        expect(instance.currentOpen).toBe(CDS.CLOSED);
+        expect(instance.currentClosed).toBe(CDS.OPEN);
+    });
+
+    test('inverts targetOpen/targetClosed', () => {
+        const { instance } = makeGarage('Generic', true);
+        expect(instance.targetOpen).toBe(TDS.CLOSED);
+        expect(instance.targetClosed).toBe(TDS.OPEN);
+    });
+});

--- a/test/MultiOutletAccessory.test.js
+++ b/test/MultiOutletAccessory.test.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const MultiOutletAccessory = require('../lib/MultiOutletAccessory');
+const { makeInstance } = require('./support/mocks');
+
+function makeOutlet(state = {}) {
+    return makeInstance(MultiOutletAccessory, state);
+}
+
+describe('MultiOutletAccessory.getPower', () => {
+    test('returns the current DP value from device state', () => {
+        const { instance } = makeOutlet({ '1': true, '2': false });
+        expect(instance.getPower('1')).toBe(true);
+        expect(instance.getPower('2')).toBe(false);
+    });
+
+    test('throws when device is disconnected', () => {
+        const { instance, device } = makeOutlet();
+        device.connected = false;
+        expect(() => instance.getPower('1')).toThrow('Not connected');
+    });
+});
+
+describe('MultiOutletAccessory.setPower — debounce batching', () => {
+    beforeEach(() => jest.useFakeTimers());
+    afterEach(() => jest.useRealTimers());
+
+    test('does not call device.update before the debounce timer fires', () => {
+        const { instance, device } = makeOutlet({ '1': false });
+        instance.setPower('1', true);
+        expect(device.update).not.toHaveBeenCalled();
+    });
+
+    test('calls device.update after 500ms', async () => {
+        const { instance, device } = makeOutlet({ '1': false });
+        const p = instance.setPower('1', true);
+        jest.advanceTimersByTime(500);
+        await p;
+        expect(device.update).toHaveBeenCalledWith({ '1': true });
+    });
+
+    test('batches two setPower calls within the window into one setMultiStateAsync', async () => {
+        const { instance, device } = makeOutlet({ '1': false, '2': true });
+        const p1 = instance.setPower('1', true);
+        const p2 = instance.setPower('2', false);
+        jest.advanceTimersByTime(500);
+        await Promise.all([p1, p2]);
+        expect(device.update).toHaveBeenCalledTimes(2);
+        expect(device.update).toHaveBeenCalledWith({ '1': true });
+        expect(device.update).toHaveBeenCalledWith({ '2': false });
+    });
+
+    test('a second call within the window resets the timer', async () => {
+        const { instance, device } = makeOutlet({ '1': false, '2': true });
+        instance.setPower('1', true);
+        jest.advanceTimersByTime(300);
+        // Timer has not fired yet — a second call resets it
+        const p2 = instance.setPower('2', false);
+        jest.advanceTimersByTime(300);
+        // First timer (300ms after first call) should not have fired
+        expect(device.update).not.toHaveBeenCalled();
+        jest.advanceTimersByTime(200);
+        await p2;
+        // Now the reset timer (500ms after second call) fires
+        expect(device.update).toHaveBeenCalledTimes(2);
+    });
+
+    test('the returned Promise resolves when the batch fires', async () => {
+        const { instance } = makeOutlet({ '1': false });
+        let resolved = false;
+        const p = instance.setPower('1', true).then(() => { resolved = true; });
+        expect(resolved).toBe(false);
+        jest.advanceTimersByTime(500);
+        await p;
+        expect(resolved).toBe(true);
+    });
+
+    test('skips update when value already matches state (setMultiStateAsync optimisation)', async () => {
+        // DP '1' is already true — no update should be sent
+        const { instance, device } = makeOutlet({ '1': true });
+        const p = instance.setPower('1', true);
+        jest.advanceTimersByTime(500);
+        await p;
+        expect(device.update).not.toHaveBeenCalled();
+    });
+});

--- a/test/RGBTWLightAccessory.test.js
+++ b/test/RGBTWLightAccessory.test.js
@@ -1,0 +1,143 @@
+'use strict';
+
+const RGBTWLightAccessory = require('../lib/RGBTWLightAccessory');
+const { makeInstance, makeMockCharacteristic } = require('./support/mocks');
+
+function makeLight(state = {}, context = {}) {
+    const result = makeInstance(RGBTWLightAccessory, state, { colorFunction: 'HEXHSB', ...context });
+    const { instance } = result;
+
+    // Set up the state that _registerCharacteristics would normally establish
+    instance.dpPower = '1';
+    instance.dpMode  = '2';
+    instance.dpBrightness = '3';
+    instance.dpColorTemperature = '4';
+    instance.dpColor = '5';
+    instance.cmdWhite = 'white';
+    instance.cmdColor = 'colour';
+    instance.colorFunction = 'HEXHSB';
+
+    // Provide the cross-characteristic references _setHueSaturation writes to
+    instance.characteristicColorTemperature = makeMockCharacteristic(0);
+
+    return result;
+}
+
+// ---------------------------------------------------------------------------
+// getBrightness
+// ---------------------------------------------------------------------------
+describe('RGBTWLightAccessory.getBrightness', () => {
+    test('returns converted brightness when in white mode', () => {
+        const { instance } = makeLight({ '2': 'white', '3': 255 });
+        // convertBrightnessFromTuyaToHomeKit(255) == 100
+        expect(instance.getBrightness()).toBe(100);
+    });
+
+    test('returns color brightness when in color mode', () => {
+        const { instance } = makeLight({ '2': 'colour', '5': '00000000b46464' });
+        // b byte = 0x64 = 100 → Math.round(100/2.55) = 39
+        expect(instance.getBrightness()).toBe(39);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// setBrightness
+// ---------------------------------------------------------------------------
+describe('RGBTWLightAccessory.setBrightness', () => {
+    test('sets dpBrightness when in white mode', () => {
+        const { instance, device } = makeLight({ '2': 'white', '3': 27 });
+        instance.setBrightness(100);
+        expect(device.update).toHaveBeenCalledWith({ '3': 255 });
+    });
+
+    test('sets dpColor when in color mode', () => {
+        const { instance, device } = makeLight({ '2': 'colour', '5': '00000000b46464' });
+        instance.setBrightness(50);
+        expect(device.update).toHaveBeenCalled();
+        const call = device.update.mock.calls[0][0];
+        expect(call).toHaveProperty('5');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// getColorTemperature
+// ---------------------------------------------------------------------------
+describe('RGBTWLightAccessory.getColorTemperature', () => {
+    test('returns minWhiteColor when in color mode', () => {
+        const { instance, device } = makeLight({ '2': 'colour' });
+        device.context.minWhiteColor = 140;
+        expect(instance.getColorTemperature()).toBe(140);
+    });
+
+    test('returns converted color temperature when in white mode', () => {
+        const { instance } = makeLight({ '2': 'white', '4': 255 });
+        // convertColorTemperatureFromTuyaToHomeKit(255) = 140
+        expect(instance.getColorTemperature()).toBe(140);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// _setHueSaturation — debounce/Promise pattern
+// ---------------------------------------------------------------------------
+describe('RGBTWLightAccessory._setHueSaturation', () => {
+    beforeEach(() => jest.useFakeTimers());
+    afterEach(() => jest.useRealTimers());
+
+    test('does not call device.update before timer fires', () => {
+        const { instance, device } = makeLight({ '2': 'colour', '5': '00000000b46464' });
+        instance.setHue(120);
+        expect(device.update).not.toHaveBeenCalled();
+    });
+
+    test('batches hue + saturation into a single device call for dpColor', async () => {
+        // Already in colour mode — mode DP is optimized out (matches current state)
+        const { instance, device } = makeLight({ '2': 'colour', '5': '00000000b46464' });
+        const ph = instance.setHue(120);
+        const ps = instance.setSaturation(80);
+        jest.advanceTimersByTime(500);
+        await Promise.all([ph, ps]);
+        const calls = device.update.mock.calls.map(c => c[0]);
+        expect(calls.some(c => c['5'] !== undefined)).toBe(true);
+        // Should be one batch, not two separate calls per property
+        expect(device.update).toHaveBeenCalledTimes(1);
+    });
+
+    test('sends mode update when switching from white to colour', async () => {
+        const { instance, device } = makeLight({ '2': 'white', '3': 255 });
+        const p = instance.setHue(120);
+        jest.advanceTimersByTime(500);
+        await p;
+        const calls = device.update.mock.calls.map(c => c[0]);
+        expect(calls.some(c => c['2'] === 'colour')).toBe(true);
+        expect(calls.some(c => c['5'] !== undefined)).toBe(true);
+    });
+
+    test('resolves both Promises when the timer fires', async () => {
+        const { instance } = makeLight({ '2': 'colour', '5': '00000000b46464' });
+        let hResolved = false, sResolved = false;
+        const ph = instance.setHue(120).then(() => { hResolved = true; });
+        const ps = instance.setSaturation(80).then(() => { sResolved = true; });
+        jest.advanceTimersByTime(500);
+        await Promise.all([ph, ps]);
+        expect(hResolved).toBe(true);
+        expect(sResolved).toBe(true);
+    });
+
+    test('a sham (h=0, s=0) in white mode does not call device.update', async () => {
+        const { instance, device } = makeLight({ '2': 'white', '3': 255 });
+        const ph = instance.setHue(0);
+        const ps = instance.setSaturation(0);
+        jest.advanceTimersByTime(500);
+        await Promise.all([ph, ps]);
+        expect(device.update).not.toHaveBeenCalled();
+    });
+
+    test('updates characteristicColorTemperature to minWhiteColor after firing', async () => {
+        const { instance } = makeLight({ '2': 'colour', '5': '00000000b46464' });
+        instance.device.context.minWhiteColor = 140;
+        const p = instance.setHue(180);
+        jest.advanceTimersByTime(500);
+        await p;
+        expect(instance.characteristicColorTemperature.updateValue).toHaveBeenCalledWith(140);
+    });
+});

--- a/test/support/mocks.js
+++ b/test/support/mocks.js
@@ -1,0 +1,163 @@
+'use strict';
+
+// HomeKit characteristic/service constant values (from HAP spec)
+const HAP = {
+    Characteristic: {
+        On: { UUID: 'B0' },
+        Brightness: { UUID: 'B3' },
+        ColorTemperature: { UUID: 'CE' },
+        Hue: { UUID: '13' },
+        Saturation: { UUID: 'BF' },
+        Name: { UUID: '23' },
+        Active: { INACTIVE: 0, ACTIVE: 1, UUID: 'B0' },
+        CurrentDoorState: { OPEN: 0, CLOSED: 1, OPENING: 2, CLOSING: 3, STOPPED: 4 },
+        TargetDoorState: { OPEN: 0, CLOSED: 1 },
+        CurrentHeaterCoolerState: { INACTIVE: 0, IDLE: 1, HEATING: 2, COOLING: 3 },
+        TargetHeaterCoolerState: { AUTO: 0, HEAT: 1, COOL: 2 },
+        PositionState: { DECREASING: 0, INCREASING: 1, STOPPED: 2 },
+        LockPhysicalControls: { CONTROL_LOCK_DISABLED: 0, CONTROL_LOCK_ENABLED: 1 },
+        TemperatureDisplayUnits: { CELSIUS: 0, FAHRENHEIT: 1 },
+        SwingMode: { SWING_DISABLED: 0, SWING_ENABLED: 1 },
+        AirQuality: { UNKNOWN: 0, EXCELLENT: 1, GOOD: 2, FAIR: 3, INFERIOR: 4, POOR: 5 },
+        CurrentAirPurifierState: { INACTIVE: 0, IDLE: 1, PURIFYING_AIR: 2 },
+        TargetAirPurifierState: { MANUAL: 0, AUTO: 1 },
+        CurrentHumidifierDehumidifierState: { INACTIVE: 0, IDLE: 1, HUMIDIFYING: 2, DEHUMIDIFYING: 3 },
+        TargetHumidifierDehumidifierState: { HUMIDIFIER_OR_DEHUMIDIFIER: 0, HUMIDIFIER: 1, DEHUMIDIFIER: 2 },
+        LockTargetState: { UNSECURED: 0, SECURED: 1 },
+        LockCurrentState: { UNSECURED: 0, SECURED: 1, JAMMED: 2, UNKNOWN: 3 },
+        RotationDirection: { CLOCKWISE: 0, COUNTER_CLOCKWISE: 1 },
+        RotationSpeed: { UUID: '29' },
+        ValveType: { UUID: 'D5' },
+        InUse: { UUID: 'D2' },
+        SetDuration: { UUID: 'D3' },
+        RemainingDuration: { UUID: 'D4' },
+        HeatingThresholdTemperature: { UUID: '12' },
+        CoolingThresholdTemperature: { UUID: '0D' },
+        CurrentTemperature: { UUID: '11' },
+        CurrentRelativeHumidity: { UUID: '10' },
+        RelativeHumidityDehumidifierThreshold: { UUID: 'C9' },
+        WaterLevel: { UUID: 'B5' },
+        ProgrammableSwitchEvent: { SINGLE_PRESS: 0 },
+        PM2_5Density: { UUID: 'C1' },
+    },
+    Service: {
+        Lightbulb: { UUID: '43' },
+        Outlet: { UUID: '47' },
+        Switch: { UUID: '49' },
+        Fan: { UUID: 'B7' },
+        GarageDoorOpener: { UUID: '41' },
+        WindowCovering: { UUID: '8C' },
+        HeaterCooler: { UUID: '7B' },
+        AirPurifier: { UUID: 'BB' },
+        AirQualitySensor: { UUID: '8D' },
+        HumidifierDehumidifier: { UUID: 'BD' },
+        HumiditySensor: { UUID: '82' },
+        TemperatureSensor: { UUID: '8A' },
+        LockMechanism: { UUID: '45' },
+        Valve: { UUID: 'D0' },
+        Doorbell: { UUID: '41' },
+        AccessoryInformation: { UUID: '3E' },
+    },
+    Formats: { FLOAT: 'float', UINT32: 'uint32', UINT16: 'uint16' },
+    Perms: { READ: 'pr', NOTIFY: 'ev', WRITE: 'pw' },
+};
+
+function makeMockCharacteristic(initialValue = null) {
+    const char = {
+        value: initialValue,
+        props: { perms: [] },
+        updateValue: jest.fn().mockImplementation(function(v) { this.value = v; return this; }),
+        onGet: jest.fn().mockReturnThis(),
+        onSet: jest.fn().mockReturnThis(),
+        on: jest.fn().mockReturnThis(),
+        setProps: jest.fn().mockReturnThis(),
+        setValue: jest.fn().mockImplementation(function(v) { this.value = v; return this; }),
+        addCharacteristic: jest.fn().mockReturnThis(),
+    };
+    return char;
+}
+
+function makeMockService(uuid = 'test-uuid') {
+    const char = makeMockCharacteristic();
+    return {
+        UUID: uuid,
+        subtype: null,
+        displayName: 'Test Service',
+        characteristics: [],
+        getCharacteristic: jest.fn().mockReturnValue(char),
+        addCharacteristic: jest.fn().mockReturnValue(char),
+        removeCharacteristic: jest.fn(),
+        updateCharacteristic: jest.fn(),
+        setPrimaryService: jest.fn(),
+        _mockChar: char,
+    };
+}
+
+function makeMockAccessory() {
+    const service = makeMockService();
+    return {
+        UUID: 'test-accessory-uuid',
+        displayName: 'Test Device',
+        category: null,
+        services: [],
+        context: {},
+        on: jest.fn(),
+        addService: jest.fn().mockReturnValue(service),
+        getService: jest.fn().mockReturnValue(service),
+        getServiceById: jest.fn().mockReturnValue(null),
+        removeService: jest.fn(),
+        configureController: jest.fn(),
+        _mockService: service,
+    };
+}
+
+function makeMockDevice(state = {}, context = {}) {
+    const device = {
+        connected: true,
+        state: { ...state },
+        context: {
+            name: 'Test Device',
+            manufacturer: 'Generic',
+            model: 'Generic',
+            type: 'simplelight',
+            version: '3.3',
+            id: '12345678abcdef',
+            ...context,
+        },
+        _connect: jest.fn(),
+        once: jest.fn(),
+        on: jest.fn(),
+        update: jest.fn().mockReturnValue(true),
+    };
+    return device;
+}
+
+function makeMockPlatform() {
+    const log = jest.fn();
+    log.info = jest.fn();
+    log.warn = jest.fn();
+    log.error = jest.fn();
+    log.debug = jest.fn();
+
+    return {
+        log,
+        api: {
+            hap: HAP,
+            versionGreaterOrEqual: jest.fn().mockReturnValue(false),
+        },
+        registerPlatformAccessories: jest.fn(),
+    };
+}
+
+// Build a BaseAccessory (or subclass) instance without triggering the device lifecycle.
+// Pass isNew=false so _registerPlatformAccessory is skipped.
+// The device.once/on calls are recorded but not triggered.
+function makeInstance(AccessoryClass, deviceState = {}, deviceContext = {}) {
+    const platform = makeMockPlatform();
+    const accessory = makeMockAccessory();
+    const device = makeMockDevice(deviceState, deviceContext);
+    const instance = new AccessoryClass(platform, accessory, device, false);
+    return { instance, platform, accessory, device };
+}
+
+module.exports = { HAP, makeInstance, makeMockPlatform, makeMockAccessory, makeMockDevice, makeMockCharacteristic, makeMockService };


### PR DESCRIPTION
# Homebridge 2.0 compatibility

This PR brings homebridge-tuya-plus into full compliance with Homebridge 2.0 / HAP-NodeJS v1, while remaining backward compatible with Homebridge 1.8+.

## Background

Homebridge 2.0 ships with HAP-NodeJS v1, which removes several long-deprecated APIs and generates warnings for others. Without these changes, the plugin produces per-request deprecation warnings on every Homebridge 1.x install, and will fail outright on Homebridge 2.0.

---

## Changes

### 1. Removed API replacements (hard breaks in Homebridge 2.0)

**`getServiceByUUIDAndSubType` → `getServiceById`** — the old Homebridge-level wrapper was removed in Homebridge 2.0. Replaced across all multi-service accessories:

```js
// Before
this.accessory.getServiceByUUIDAndSubType(Service.Outlet, 'outlet 1')
// After
this.accessory.getServiceById(Service.Outlet.UUID, 'outlet 1')
```

Affected: `MultiOutletAccessory`, `CustomMultiOutletAccessory`, `SwitchAccessory`, `RGBTWOutletAccessory`, `OilDiffuserAccessory`

**`Characteristic.Formats` / `Characteristic.Perms` static enum access** — removed from the `Characteristic` class in HAP-NodeJS v1; now only available as top-level `api.hap` exports:

```js
// Before
module.exports = function(Characteristic) {
    format: Characteristic.Formats.FLOAT,
    perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
}
// After
module.exports = function({Characteristic, Formats, Perms}) {
    format: Formats.FLOAT,
    perms: [Perms.READ, Perms.NOTIFY]
}
```

Affected: `EnergyCharacteristics.js`, `index.js`

### 2. Full `onGet` / `onSet` migration (174 handlers, all 22 accessory files)

The callback-based `.on('get')` / `.on('set')` pattern is deprecated in Homebridge 2.0 and generates a warning on every characteristic access. All handlers have been migrated to the async API:

```js
// Before — generates deprecation warnings
characteristic
    .on('get', (callback) => { callback(null, value); })
    .on('set', (value, callback) => { callback(null); });

// After
characteristic
    .onGet(() => value)
    .onSet(value => { /* send to device */ });
```

Five async helpers were added to `BaseAccessory` to support this cleanly:

| Helper | Purpose |
|---|---|
| `getStateAsync(dp)` | Read one or more DPs; throws if disconnected |
| `setStateAsync(dp, value)` | Send a single DP update |
| `setMultiStateAsync(dps)` | Send multiple DPs, skipping unchanged values |
| `setMultiStateLegacyAsync(dps)` | Single-call batch update (used by fan accessories) |
| `getDividedStateAsync(dp, divisor)` | Read and divide (energy monitoring) |

Accessories that debounce multiple HomeKit writes into one device command (hue+saturation on color lights, multi-outlet/switch batching) were converted from a callback accumulator pattern to a `Promise`-based equivalent that resolves once the debounced timer fires.

### 3. `package.json` engine requirements updated

```json
"engines": {
    "homebridge": "^1.8.0 || ^2.0.0-beta.0",
    "node": "^20.18.0 || ^22.10.0 || ^24.0.0"
}
```

### 4. Test suite (78 tests, Jest)

A new `test/` directory with full Jest coverage of the logic most likely to regress:

- **`BaseAccessory`** — all conversion utilities (brightness, color temperature, HEXHSB/HSB color, temperature→color), all five async helpers, `_getCustomDP`, `_coerceBoolean`
- **`EnergyCharacteristics`** — factory output, UUIDs, instantiation, format constants
- **`GarageDoorAccessory`** — state machine for Kogan (string states) and generic (boolean), `flipState` inversion, device command dispatching
- **`MultiOutletAccessory`** — debounce timer batching, Promise resolution, skip-unchanged-DP optimisation
- **`RGBTWLightAccessory`** — brightness/color temperature getters, hue+saturation debounce/Promise pattern, white↔colour mode transitions, sham guard (h=0, s=0 in white mode)

Run with `npm test`.

### 5. Documentation

`docs/homebridge-2.0-migration.md` — explains all API changes, the rationale, and the backward compatibility analysis.

---

## Backward compatibility

**This branch is safe for Homebridge 1.8+ users with no migration steps required.**

| Change | Analysis |
|---|---|
| `getServiceById` | In HAP-NodeJS since v0.5.10 (April 2020); present throughout all of Homebridge 1.x |
| `onGet` / `onSet` | Available since Homebridge 1.3.0; our declared minimum is 1.8.0 |
| `api.hap.Formats` / `api.hap.Perms` | Top-level HAP exports, available throughout 1.x |
| Cached accessory data | Service UUIDs, subtypes, and characteristics are unchanged; no re-pairing required |

The only visible change for existing users: Homebridge stops logging per-request deprecation warnings. No config changes, no re-pairing, no accessory reconfiguration needed.
