### PR TITLE
Add PercentBlindsAccessory for blinds with native position reporting

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ const ValveAccessory = require('./lib/ValveAccessory');
 const OilDiffuserAccessory = require('./lib/OilDiffuserAccessory');
 const DoorbellAccessory = require('./lib/DoorbellAccessory');
 const VerticalBlindsWithTilt = require('./lib/VerticalBlindsWithTilt');
+const PercentBlindsAccessory = require('./lib/PercentBlindsAccessory');
 
 const PLUGIN_NAME = 'homebridge-tuya-plus';
 const PLATFORM_NAME = 'TuyaLan';
@@ -56,7 +57,8 @@ const CLASS_DEF = {
     watervalve: ValveAccessory,
     oildiffuser: OilDiffuserAccessory,
     doorbell: DoorbellAccessory,
-    verticalblindswithtilt: VerticalBlindsWithTilt
+    verticalblindswithtilt: VerticalBlindsWithTilt,
+    percentblinds: PercentBlindsAccessory
 };
 
 let Characteristic, Formats, Perms, Categories, PlatformAccessory, Service, AdaptiveLightingController, UUID;

--- a/lib/PercentBlindsAccessory.js
+++ b/lib/PercentBlindsAccessory.js
@@ -1,0 +1,80 @@
+const BaseAccessory = require('./BaseAccessory');
+
+class PercentBlindsAccessory extends BaseAccessory {
+    static getCategory(Categories) {
+        return Categories.WINDOW_COVERING;
+    }
+
+    constructor(...props) {
+        super(...props);
+    }
+
+    _registerPlatformAccessory() {
+        const {Service} = this.hap;
+        this.accessory.addService(Service.WindowCovering, this.device.context.name);
+        super._registerPlatformAccessory();
+    }
+
+    _registerCharacteristics(dps) {
+        const {Service, Characteristic} = this.hap;
+        const service = this.accessory.getService(Service.WindowCovering);
+        this._checkServiceName(service, this.device.context.name);
+
+        this.dpPercentControl = this._getCustomDP(this.device.context.dpPercentControl) || '2';
+        this.dpPercentState = this._getCustomDP(this.device.context.dpPercentState) || '2';
+        this.flipState = !!this.device.context.flipState;
+
+        const characteristicCurrentPosition = service.getCharacteristic(Characteristic.CurrentPosition)
+            .updateValue(this._mapPosition(dps[this.dpPercentState] !== undefined ? dps[this.dpPercentState] : 0))
+            .on('get', this.getCurrentPosition.bind(this));
+
+        const characteristicTargetPosition = service.getCharacteristic(Characteristic.TargetPosition)
+            .updateValue(this._mapPosition(dps[this.dpPercentControl] !== undefined ? dps[this.dpPercentControl] : 0))
+            .on('get', this.getTargetPosition.bind(this))
+            .on('set', this.setTargetPosition.bind(this));
+
+        service.getCharacteristic(Characteristic.PositionState)
+            .updateValue(Characteristic.PositionState.STOPPED)
+            .on('get', callback => callback(null, Characteristic.PositionState.STOPPED));
+
+        this.device.on('change', changes => {
+            if (changes.hasOwnProperty(this.dpPercentState)) {
+                const position = this._mapPosition(changes[this.dpPercentState]);
+                this.log.debug(`[TuyaAccessory] Blind current position updated to ${position}`);
+                characteristicCurrentPosition.updateValue(position);
+            }
+            if (changes.hasOwnProperty(this.dpPercentControl)) {
+                const position = this._mapPosition(changes[this.dpPercentControl]);
+                this.log.debug(`[TuyaAccessory] Blind target position updated to ${position}`);
+                characteristicTargetPosition.updateValue(position);
+            }
+        });
+    }
+
+    _mapPosition(value) {
+        const position = parseInt(value) || 0;
+        return this.flipState ? 100 - position : position;
+    }
+
+    getCurrentPosition(callback) {
+        this.getState(this.dpPercentState, (err, dp) => {
+            if (err) return callback(err);
+            callback(null, this._mapPosition(dp));
+        });
+    }
+
+    getTargetPosition(callback) {
+        this.getState(this.dpPercentControl, (err, dp) => {
+            if (err) return callback(err);
+            callback(null, this._mapPosition(dp));
+        });
+    }
+
+    setTargetPosition(value, callback) {
+        const position = this._mapPosition(value);
+        this.log.debug(`[TuyaAccessory] Setting blind position to ${position}`);
+        this.setState(this.dpPercentControl, position, callback);
+    }
+}
+
+module.exports = PercentBlindsAccessory;

--- a/wiki/Supported-Device-Types.md
+++ b/wiki/Supported-Device-Types.md
@@ -21,6 +21,7 @@ If you are looking for verified configurations for your specific device, please 
 |Simple Blinds|`SimpleBlinds`<sup>[11](#simple-blinds)</sup>|Smart blinds and smart switches that control blinds <small>([instructions](#simple-blinds))</small>|
 |Simple Blinds2|`SimpleBlinds2`<sup>[11](#simple-blinds)</sup>|Smart blinds and smart switches that control blinds(Use if simple Blinds (1) doesn't work for you. <small>([instructions](#simple-blinds))</small>|
 |Vertical Blinds with Tilt|`VerticalBlindsWithTilt`<sup>[11](#vertical-blinds-with-tilt)</sup>|Smart vertical blinds with open/close and panel rotation <small>([instructions](#vertical-blinds-with-tilt))</small>|
+|Percent Control Blinds|`PercentBlinds`<sup>[11](#percent-control-blinds)</sup>|Blinds that natively report and accept a percentage position via a `percent_control` datapoint <small>([instructions](#percent-control-blinds))</small>|
 |Smart Plug w/ White and Color Lights|`RGBTWOutlet`<sup>[12](#outlets-with-white-and-color-lights)</sup>|Smart plugs that have controllable RGBTW LEDs <small>([instructions](#outlets-with-white-and-color-lights))</small>|
 |Smart Fan Regulator|`SimpleFanAccessory`<sup>[more](#smart-fan-regulators-and-accessories)</sup>|Smart Fan Regulators that have controllable Speeds <small>([instructions](#smart-fan-regulators-and-accessories))</small>|
 |Smart Fan with Light|`SimpleFanLightAccessory`<sup>[more](#smart-fan-with-light)</sup>|Smart Fan devices that have controllable Speeds, Directions and a built-in Light<small>([instructions](#smart-fan-with-light))</small>|
@@ -453,6 +454,43 @@ Support for Tuya/Graywind Smart Vertical Blinds with open/close (retract/extend)
   "dpTilt": 2,
   "dpTiltState": 3,
   "timeToClose": 30
+}
+```
+
+### Percent Control Blinds
+These are blinds or roller shades that natively report their current position and accept a target position as a percentage via a `percent_control` datapoint. Unlike `SimpleBlinds`, no timing calibration is needed — the device reports its actual position directly.
+
+#### Minimal Configuration
+```json
+{
+    "name": "My Blinds",
+    "type": "PercentBlinds",
+    "id": "032000123456789abcde",
+    "key": "0123456789abcdef"
+}
+```
+
+#### Full Configuration
+```json5
+{
+    "name": "My Blinds",
+    "type": "PercentBlinds",
+    "manufacturer": "Tuya",
+    "model": "Smart Roller Blind",
+    "id": "032000123456789abcde",
+    "key": "0123456789abcdef",
+
+    /* Additional parameters to override defaults only if needed */
+
+    /* Override the default datapoint identifier for setting target position (0–100) */
+    "dpPercentControl": "2",
+
+    /* Override the default datapoint identifier for reading current position (0–100).
+       Use "3" if your device reports position on a separate datapoint from control. */
+    "dpPercentState": "2",
+
+    /* If the device reports 0 as fully open instead of fully closed, flip the range */
+    "flipState": true
 }
 ```
 


### PR DESCRIPTION
Adds a new `PercentBlinds` device type for Tuya blinds/shades that natively report and accept a percentage position via a `percent_control` datapoint, rather than estimating position based on open/close timing like `SimpleBlinds`.

## Configuration

```json5
{
    "name": "My Blinds",
    "type": "PercentBlinds",
    "id": "032000123456789abcde",
    "key": "0123456789abcdef",

    /* Override the DP for setting target position (default: '2') */
    "dpPercentControl": "2",

    /* Override the DP for reading current position (default: '2') */
    "dpPercentState": "2",

    /* Flip 0-100 range for devices where 0=open */
    "flipState": true
}
```

## Changes
- `lib/PercentBlindsAccessory.js` — new accessory class
- `index.js` — registered as `percentblinds` type
- `wiki/Supported-Device-Types.md` — documentation with minimal and full config examples

## Test plan
- Tested on a Tuya roller blind (protocol 3.3)
- Position set via HomeKit moves blind to correct position
- Position reported back accurately from device
- `flipState: true` correctly inverts orientation