### PR TITLE
Expose scale settings for tunable white lights

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -260,14 +260,14 @@
               "type": "integer",
               "placeholder": "255",
               "condition": {
-                "functionBody": "return model.devices && model.devices[arrayIndices] && ['RGBTWLight','RGBTWOutlet', 'FanLight'].includes(model.devices[arrayIndices].type);"
+                "functionBody": "return model.devices && model.devices[arrayIndices] && ['TWLight','RGBTWLight','RGBTWOutlet', 'FanLight'].includes(model.devices[arrayIndices].type);"
               }
             },
             "scaleWhiteColor": {
               "type": "integer",
               "placeholder": "255",
               "condition": {
-                "functionBody": "return model.devices && model.devices[arrayIndices] && ['RGBTWLight','RGBTWOutlet'].includes(model.devices[arrayIndices].type);"
+                "functionBody": "return model.devices && model.devices[arrayIndices] && ['TWLight','RGBTWLight','RGBTWOutlet'].includes(model.devices[arrayIndices].type);"
               }
             },
             "outletCount": {


### PR DESCRIPTION
It turned out that my tunable white bulbs were only reaching about 26% brightness when set to 100% in HomeKit. I found that the brightness and white color scales could not be configured for tunable white lights, even though the runtime already supports those options.

This exposes the existing scale settings for `TWLight` devices in the config schema.