### PR TITLE
Add SimpleGarageDoor accessory for open/stop/close-only gates

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -83,6 +83,10 @@
                   "enum": ["GarageDoor"]
                 },
                 {
+                  "title": "Simple Garage Door (Open/Stop/Close)",
+                  "enum": ["SimpleGarageDoor"]
+                },
+                {
                   "title": "Simple Blinds",
                   "enum": ["SimpleBlinds"]
                 },
@@ -491,6 +495,27 @@
               "placeholder": "2",
               "condition": {
                 "functionBody": "return model.devices && model.devices[arrayIndices] && ['GarageDoor'].includes(model.devices[arrayIndices].type);"
+              }
+            },
+            "dpOpen": {
+              "type": "integer",
+              "placeholder": "1",
+              "condition": {
+                "functionBody": "return model.devices && model.devices[arrayIndices] && ['SimpleGarageDoor'].includes(model.devices[arrayIndices].type);"
+              }
+            },
+            "dpStop": {
+              "type": "integer",
+              "placeholder": "2",
+              "condition": {
+                "functionBody": "return model.devices && model.devices[arrayIndices] && ['SimpleGarageDoor'].includes(model.devices[arrayIndices].type);"
+              }
+            },
+            "dpClose": {
+              "type": "integer",
+              "placeholder": "3",
+              "condition": {
+                "functionBody": "return model.devices && model.devices[arrayIndices] && ['SimpleGarageDoor'].includes(model.devices[arrayIndices].type);"
               }
             },
             "flipState": {

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const AirPurifierAccessory = require('./lib/AirPurifierAccessory');
 const DehumidifierAccessory = require('./lib/DehumidifierAccessory');
 const ConvectorAccessory = require('./lib/ConvectorAccessory');
 const GarageDoorAccessory = require('./lib/GarageDoorAccessory');
+const SimpleGarageDoorAccessory = require('./lib/SimpleGarageDoorAccessory');
 const SimpleDimmerAccessory = require('./lib/SimpleDimmerAccessory');
 const SimpleDimmer2Accessory = require('./lib/SimpleDimmer2Accessory');
 const SimpleBlindsAccessory = require('./lib/SimpleBlindsAccessory');
@@ -47,6 +48,7 @@ const CLASS_DEF = {
     dehumidifier: DehumidifierAccessory,
     convector: ConvectorAccessory,
     garagedoor: GarageDoorAccessory,
+    simplegaragedoor: SimpleGarageDoorAccessory,
     simpledimmer: SimpleDimmerAccessory,
     simpledimmer2: SimpleDimmer2Accessory,
     simpleblinds: SimpleBlindsAccessory,

--- a/lib/SimpleGarageDoorAccessory.js
+++ b/lib/SimpleGarageDoorAccessory.js
@@ -1,0 +1,84 @@
+const BaseAccessory = require('./BaseAccessory');
+
+// Window during which CurrentDoorState lags TargetDoorState so HomeKit's
+// "Opening..."/"Closing..." caption is visible after a toggle. The device
+// has no position feedback, so this is purely cosmetic.
+const CURRENT_STATE_DELAY_MS = 1000;
+
+class SimpleGarageDoorAccessory extends BaseAccessory {
+    static getCategory(Categories) {
+        return Categories.GARAGE_DOOR_OPENER;
+    }
+
+    constructor(...props) {
+        super(...props);
+    }
+
+    _registerPlatformAccessory() {
+        const {Service} = this.hap;
+
+        this.accessory.addService(Service.GarageDoorOpener, this.device.context.name);
+
+        super._registerPlatformAccessory();
+    }
+
+    _registerCharacteristics() {
+        const {Service, Characteristic} = this.hap;
+        const service = this.accessory.getService(Service.GarageDoorOpener);
+        this._checkServiceName(service, this.device.context.name);
+
+        this.dpOpen = this._getCustomDP(this.device.context.dpOpen) || '1';
+        this.dpStop = this._getCustomDP(this.device.context.dpStop) || '2';
+        this.dpClose = this._getCustomDP(this.device.context.dpClose) || '3';
+
+        // The device only exposes momentary action DPs, so the target state is
+        // tracked locally and persisted via the homebridge accessory context.
+        if (this.accessory.context.cachedTargetDoorState !== Characteristic.TargetDoorState.OPEN &&
+            this.accessory.context.cachedTargetDoorState !== Characteristic.TargetDoorState.CLOSED) {
+            this.accessory.context.cachedTargetDoorState = Characteristic.TargetDoorState.OPEN;
+        }
+        const initialTarget = this.accessory.context.cachedTargetDoorState;
+        this.currentDoorState = initialTarget === Characteristic.TargetDoorState.OPEN
+            ? Characteristic.CurrentDoorState.OPEN
+            : Characteristic.CurrentDoorState.CLOSED;
+
+        this.characteristicTargetDoorState = service.getCharacteristic(Characteristic.TargetDoorState)
+            .updateValue(initialTarget)
+            .onGet(() => this.accessory.context.cachedTargetDoorState)
+            .onSet(value => this.setTargetDoorState(value));
+
+        this.characteristicCurrentDoorState = service.getCharacteristic(Characteristic.CurrentDoorState)
+            .updateValue(this.currentDoorState)
+            .onGet(() => this.currentDoorState);
+
+        service.getCharacteristic(Characteristic.ObstructionDetected)
+            .updateValue(false)
+            .onGet(() => false);
+    }
+
+    setTargetDoorState(value) {
+        const {Characteristic} = this.hap;
+
+        this.accessory.context.cachedTargetDoorState = value;
+
+        // Send stop first so reversing direction mid-motion works; if the gate
+        // is already idle, the stop is a no-op on the device side.
+        this.setMultiStateLegacyAsync({[this.dpStop]: true});
+        if (value === Characteristic.TargetDoorState.OPEN) {
+            this.setMultiStateLegacyAsync({[this.dpOpen]: true});
+        } else {
+            this.setMultiStateLegacyAsync({[this.dpClose]: true});
+        }
+
+        if (this.currentStateTimeout) clearTimeout(this.currentStateTimeout);
+        this.currentStateTimeout = setTimeout(() => {
+            this.currentStateTimeout = null;
+            this.currentDoorState = value === Characteristic.TargetDoorState.OPEN
+                ? Characteristic.CurrentDoorState.OPEN
+                : Characteristic.CurrentDoorState.CLOSED;
+            this.characteristicCurrentDoorState.updateValue(this.currentDoorState);
+        }, CURRENT_STATE_DELAY_MS);
+    }
+}
+
+module.exports = SimpleGarageDoorAccessory;

--- a/test/SimpleGarageDoorAccessory.test.js
+++ b/test/SimpleGarageDoorAccessory.test.js
@@ -1,0 +1,129 @@
+'use strict';
+
+const SimpleGarageDoorAccessory = require('../lib/SimpleGarageDoorAccessory');
+const { HAP, makeInstance } = require('./support/mocks');
+
+const { CurrentDoorState: CDS, TargetDoorState: TDS } = HAP.Characteristic;
+
+function makeSimpleGarage(contextOverrides = {}) {
+    const { instance, device, accessory, platform } = makeInstance(
+        SimpleGarageDoorAccessory,
+        {},
+        { manufacturer: 'Generic', ...contextOverrides }
+    );
+
+    // Replicate what _registerCharacteristics would set up.
+    instance.dpOpen = '1';
+    instance.dpStop = '2';
+    instance.dpClose = '3';
+    instance.currentDoorState = CDS.OPEN;
+    instance.characteristicCurrentDoorState = {
+        value: CDS.OPEN,
+        updateValue: jest.fn().mockImplementation(function(v) { this.value = v; return this; }),
+    };
+
+    return { instance, device, accessory, platform };
+}
+
+// ---------------------------------------------------------------------------
+// setTargetDoorState — device commands
+// ---------------------------------------------------------------------------
+describe('SimpleGarageDoorAccessory.setTargetDoorState — device commands', () => {
+    test('OPEN sends stop=true then open=true', () => {
+        const { instance, device } = makeSimpleGarage();
+        instance.setTargetDoorState(TDS.OPEN);
+        expect(device.update).toHaveBeenNthCalledWith(1, { '2': true });
+        expect(device.update).toHaveBeenNthCalledWith(2, { '1': true });
+    });
+
+    test('CLOSED sends stop=true then close=true', () => {
+        const { instance, device } = makeSimpleGarage();
+        instance.setTargetDoorState(TDS.CLOSED);
+        expect(device.update).toHaveBeenNthCalledWith(1, { '2': true });
+        expect(device.update).toHaveBeenNthCalledWith(2, { '3': true });
+    });
+
+    test('Skips writes when the device is disconnected', () => {
+        const { instance, device } = makeSimpleGarage();
+        device.connected = false;
+        instance.setTargetDoorState(TDS.OPEN);
+        expect(device.update).not.toHaveBeenCalled();
+    });
+
+    test('Custom DPs are respected', () => {
+        const { instance, device } = makeSimpleGarage();
+        instance.dpOpen = '101';
+        instance.dpStop = '102';
+        instance.dpClose = '103';
+        instance.setTargetDoorState(TDS.OPEN);
+        expect(device.update).toHaveBeenNthCalledWith(1, { '102': true });
+        expect(device.update).toHaveBeenNthCalledWith(2, { '101': true });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// CurrentDoorState transition
+// ---------------------------------------------------------------------------
+describe('SimpleGarageDoorAccessory.setTargetDoorState — CurrentDoorState transition', () => {
+    beforeEach(() => jest.useFakeTimers());
+    afterEach(() => jest.useRealTimers());
+
+    test('CurrentDoorState lags the target by 1s when opening', () => {
+        const { instance } = makeSimpleGarage();
+        instance.currentDoorState = CDS.CLOSED;
+        instance.characteristicCurrentDoorState.value = CDS.CLOSED;
+
+        instance.setTargetDoorState(TDS.OPEN);
+        expect(instance.characteristicCurrentDoorState.value).toBe(CDS.CLOSED);
+
+        jest.advanceTimersByTime(999);
+        expect(instance.characteristicCurrentDoorState.value).toBe(CDS.CLOSED);
+
+        jest.advanceTimersByTime(1);
+        expect(instance.currentDoorState).toBe(CDS.OPEN);
+        expect(instance.characteristicCurrentDoorState.value).toBe(CDS.OPEN);
+    });
+
+    test('CurrentDoorState lags the target by 1s when closing', () => {
+        const { instance } = makeSimpleGarage();
+        instance.currentDoorState = CDS.OPEN;
+        instance.characteristicCurrentDoorState.value = CDS.OPEN;
+
+        instance.setTargetDoorState(TDS.CLOSED);
+        expect(instance.characteristicCurrentDoorState.value).toBe(CDS.OPEN);
+
+        jest.advanceTimersByTime(1000);
+        expect(instance.currentDoorState).toBe(CDS.CLOSED);
+        expect(instance.characteristicCurrentDoorState.value).toBe(CDS.CLOSED);
+    });
+
+    test('Reversing direction within the 1s window resets the timer', () => {
+        const { instance } = makeSimpleGarage();
+        instance.currentDoorState = CDS.OPEN;
+        instance.characteristicCurrentDoorState.value = CDS.OPEN;
+
+        instance.setTargetDoorState(TDS.CLOSED);
+        jest.advanceTimersByTime(500);
+        instance.setTargetDoorState(TDS.OPEN);
+
+        jest.advanceTimersByTime(500);
+        expect(instance.characteristicCurrentDoorState.value).toBe(CDS.OPEN);
+
+        jest.advanceTimersByTime(500);
+        expect(instance.currentDoorState).toBe(CDS.OPEN);
+        expect(instance.characteristicCurrentDoorState.value).toBe(CDS.OPEN);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Persistence
+// ---------------------------------------------------------------------------
+describe('SimpleGarageDoorAccessory persistence', () => {
+    test('Stores the latest target on the accessory context', () => {
+        const { instance, accessory } = makeSimpleGarage();
+        instance.setTargetDoorState(TDS.CLOSED);
+        expect(accessory.context.cachedTargetDoorState).toBe(TDS.CLOSED);
+        instance.setTargetDoorState(TDS.OPEN);
+        expect(accessory.context.cachedTargetDoorState).toBe(TDS.OPEN);
+    });
+});


### PR DESCRIPTION
## Summary
- New `SimpleGarageDoor` accessory type for very basic Tuya gate/opener controllers that expose only three momentary action DPs: open, stop, close (defaults `1` / `2` / `3`, configurable as `dpOpen` / `dpStop` / `dpClose`).
- Maps to the HomeKit `GarageDoorOpener` service with the three required characteristics — `TargetDoorState`, `CurrentDoorState`, `ObstructionDetected` — and nothing else (lock characteristics intentionally skipped).
- Target state is persisted across restarts via the homebridge accessory context, defaulting to `OPEN` on first run.
- On a HomeKit-triggered change, sends `stop=true` first (so reversing direction mid-motion works; a no-op when the gate is idle) and then `open=true` / `close=true`. After 1s, flips `CurrentDoorState` to match `TargetDoorState` — this is the only window in which HomeKit's "Opening..."/"Closing..." caption is shown, since the device gives no position feedback. `ObstructionDetected` is always `false`.

## Notes
- Uses `setMultiStateLegacyAsync` to bypass the diff-check in `BaseAccessory` (the action DPs are momentary, so re-sending the same value must always reach the device).
- External state changes (e.g. wall remote, physical button) are not reflected — there is no status DP to listen to.
- Existing `GarageDoor` accessory (with `dpAction` / `dpStatus`) is untouched.

## Test plan
- [x] `npm test` — 7 suites, 101 tests pass (new tests cover device commands, the 1s `CurrentDoorState` transition, mid-motion reversal, persistence, custom DPs, and the disconnected-device case).
- [x] `npm run lint` — clean.
- [x] `config.schema.json` parses; new "Simple Garage Door (Open/Stop/Close)" option appears in the type dropdown with the three DP fields conditionally shown.
- [ ] Real-device check: pair a Tuya gate device of this type and confirm open / close / mid-motion reverse all work end-to-end in HomeKit.

https://claude.ai/code/session_01XsBJoYjXhQ4yUzfTrbkgwc

---
_Generated by [Claude Code](https://claude.ai/code/session_01XsBJoYjXhQ4yUzfTrbkgwc)_