### PR TITLE
Sync tuya dimmer to Wled.

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -71,6 +71,10 @@
                   "enum": ["Convector"]
                 },
                 {
+                  "title": "WLED Dimmer",
+                  "enum": ["WledDimmer"]
+                },
+                {
                   "title": "Simple Dimmer",
                   "enum": ["SimpleDimmer"]
                 },
@@ -208,16 +212,24 @@
               "type": "integer",
               "placeholder": "1",
               "condition": {
-                "functionBody": "return model.devices && model.devices[arrayIndices] && ['Outlet', 'TWLight', 'RGBTWLight', 'SimpleDimmer','RGBTWOutlet'].includes(model.devices[arrayIndices].type);"
+                "functionBody": "return model.devices && model.devices[arrayIndices] && ['Outlet', 'TWLight', 'RGBTWLight', 'WledDimmer', 'SimpleDimmer','RGBTWOutlet'].includes(model.devices[arrayIndices].type);"
               }
             },
             "dpBrightness": {
               "type": "integer",
               "placeholder": "2",
               "condition": {
-                "functionBody": "return model.devices && model.devices[arrayIndices] && ['TWLight', 'RGBTWLight', 'SimpleDimmer','RGBTWOutlet', 'FanLight'].includes(model.devices[arrayIndices].type);"
+                "functionBody": "return model.devices && model.devices[arrayIndices] && ['TWLight', 'RGBTWLight', 'WledDimmer', 'SimpleDimmer','RGBTWOutlet', 'FanLight'].includes(model.devices[arrayIndices].type);"
               }
             },
+            "syncBrightnessToWled": {
+              "type": "string",
+              "title": "Sync brightness to WLED (IP[:port])",
+              "placeholder": "192.168.1.100",
+              "condition": {
+                "functionBody": "return model.devices && model.devices[arrayIndices] && ['WledDimmer', 'SimpleDimmer'].includes(model.devices[arrayIndices].type);"
+              }
+            },            
             "dpColorTemperature": {
               "type": "integer",
               "placeholder": "3",
@@ -260,11 +272,18 @@
                 "functionBody": "return model.devices && model.devices[arrayIndices] && ['RGBTWLight','RGBTWOutlet'].includes(model.devices[arrayIndices].type);"
               }
             },
+            "minBrightness": {
+              "type": "integer",
+              "placeholder": "1",
+              "condition": {
+                "functionBody": "return model.devices && model.devices[arrayIndices] && ['FanLight','WledDimmer', 'SimpleDimmer'].includes(model.devices[arrayIndices].type);"
+              }
+            },
             "scaleBrightness": {
               "type": "integer",
               "placeholder": "255",
               "condition": {
-                "functionBody": "return model.devices && model.devices[arrayIndices] && ['TWLight','RGBTWLight','RGBTWOutlet', 'FanLight'].includes(model.devices[arrayIndices].type);"
+                "functionBody": "return model.devices && model.devices[arrayIndices] && ['RGBTWLight','RGBTWOutlet','FanLight','WledDimmer', 'SimpleDimmer'].includes(model.devices[arrayIndices].type);"
               }
             },
             "scaleWhiteColor": {

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const DehumidifierAccessory = require('./lib/DehumidifierAccessory');
 const ConvectorAccessory = require('./lib/ConvectorAccessory');
 const GarageDoorAccessory = require('./lib/GarageDoorAccessory');
 const SimpleGarageDoorAccessory = require('./lib/SimpleGarageDoorAccessory');
-const SimpleDimmerAccessory = require('./lib/SimpleDimmerAccessory');
+const WledDimmerAccessory = require('./lib/WledDimmerAccessory');
 const SimpleDimmer2Accessory = require('./lib/SimpleDimmer2Accessory');
 const SimpleBlindsAccessory = require('./lib/SimpleBlindsAccessory');
 const SimpleHeaterAccessory = require('./lib/SimpleHeaterAccessory');
@@ -49,7 +49,8 @@ const CLASS_DEF = {
     convector: ConvectorAccessory,
     garagedoor: GarageDoorAccessory,
     simplegaragedoor: SimpleGarageDoorAccessory,
-    simpledimmer: SimpleDimmerAccessory,
+    simpledimmer: WledDimmerAccessory,
+    wleddimmer: WledDimmerAccessory,
     simpledimmer2: SimpleDimmer2Accessory,
     simpleblinds: SimpleBlindsAccessory,
     simpleheater: SimpleHeaterAccessory,

--- a/lib/BaseAccessory.js
+++ b/lib/BaseAccessory.js
@@ -173,23 +173,15 @@ class BaseAccessory {
     }
 
     convertBrightnessFromHomeKitToTuya(value) {
-        const min = this.device.context.minBrightness != null ? this.device.context.minBrightness : 27;
+        const min = this.device.context.minBrightness || 27;
         const scale = this.device.context.scaleBrightness || 255;
-        var r = Math.round(((scale - min) * value + 100 * min - scale) / 99);
-        this.log.debug("convertBrightnessFromHomeKitToTuya ",value,' -> ',r,' min:',min," scale:",scale);
-        if(min == 10)
-        {
-            return Math.max(20, r)
-        }
-        return r;
+        return Math.round(((scale - min) * value + 100 * min - scale) / 99);
     }
 
     convertBrightnessFromTuyaToHomeKit(value) {
-        const min = this.device.context.minBrightness != null ? this.device.context.minBrightness : 27;
+        const min = this.device.context.minBrightness || 27;
         const scale = this.device.context.scaleBrightness || 255;
-        const r = Math.round((99 * (value || 0) - 100 * min + scale) / (scale - min));
-        this.log.debug('convertBrightnessFromTuyaToHomeKit ', value, '->', r,' min:',min," scale:",scale )
-        return r
+        return Math.round((99 * (value || 0) - 100 * min + scale) / (scale - min));
     }
     
     convertRotationSpeedFromHomeKitToTuya(value) {
@@ -208,20 +200,16 @@ class BaseAccessory {
         const min = this.device.context.minWhiteColor || 140;
         const max = this.device.context.maxWhiteColor || 400;
         const scale = this.device.context.scaleWhiteColor || 255;
-        const adjustedValue = (value - 71) * (max - min) / (600 - 71) + 153;
-        const convertedValue = Math.round((scale * min / (max - min)) * ((max / adjustedValue) - 1));
-        //this.log('convertColorTemperatureFromHomeKitToTuya ', value, '->', convertedValue,' min:',min," scale:",scale )
-        return Math.min(scale, Math.max(0, convertedValue));
+        const result = Math.round(Math.max(Math.min(scale-(scale-1)/(max-min)*(value-min),scale),1));
+        return result;
     }
 
     convertColorTemperatureFromTuyaToHomeKit(value) {
         const min = this.device.context.minWhiteColor || 140;
         const max = this.device.context.maxWhiteColor || 400;
         const scale = this.device.context.scaleWhiteColor || 255;
-        const unadjustedValue = max / ((value * (max - min) / (scale * min)) + 1);
-        const convertedValue = Math.round((unadjustedValue - 153) * (600 - 71) / (max - min) + 71);
-        //this.log('convertColorTemperatureFromTuyaToHomeKit ', value, '->', convertedValue,' min:',min," scale:",scale )
-        return Math.min(600, Math.max(71, convertedValue));
+        const result = Math.round(Math.max(Math.min((scale-value)/((scale-1)/(max-min))+min,max),min));
+        return Math.min(600, Math.max(71, result));
     }
 
     convertColorFromHomeKitToTuya(value, dpValue) {

--- a/lib/BaseAccessory.js
+++ b/lib/BaseAccessory.js
@@ -173,15 +173,23 @@ class BaseAccessory {
     }
 
     convertBrightnessFromHomeKitToTuya(value) {
-        const min = this.device.context.minBrightness || 27;
+        const min = this.device.context.minBrightness != null ? this.device.context.minBrightness : 27;
         const scale = this.device.context.scaleBrightness || 255;
-        return Math.round(((scale - min) * value + 100 * min - scale) / 99);
+        var r = Math.round(((scale - min) * value + 100 * min - scale) / 99);
+        this.log.debug("convertBrightnessFromHomeKitToTuya ",value,' -> ',r,' min:',min," scale:",scale);
+        if(min == 10)
+        {
+            return Math.max(20, r)
+        }
+        return r;
     }
 
     convertBrightnessFromTuyaToHomeKit(value) {
-        const min = this.device.context.minBrightness || 27;
+        const min = this.device.context.minBrightness != null ? this.device.context.minBrightness : 27;
         const scale = this.device.context.scaleBrightness || 255;
-        return Math.round((99 * (value || 0) - 100 * min + scale) / (scale - min));
+        const r = Math.round((99 * (value || 0) - 100 * min + scale) / (scale - min));
+        this.log.debug('convertBrightnessFromTuyaToHomeKit ', value, '->', r,' min:',min," scale:",scale )
+        return r
     }
     
     convertRotationSpeedFromHomeKitToTuya(value) {
@@ -200,16 +208,20 @@ class BaseAccessory {
         const min = this.device.context.minWhiteColor || 140;
         const max = this.device.context.maxWhiteColor || 400;
         const scale = this.device.context.scaleWhiteColor || 255;
-        const result = Math.round(Math.max(Math.min(scale-(scale-1)/(max-min)*(value-min),scale),1));
-        return result;
+        const adjustedValue = (value - 71) * (max - min) / (600 - 71) + 153;
+        const convertedValue = Math.round((scale * min / (max - min)) * ((max / adjustedValue) - 1));
+        //this.log('convertColorTemperatureFromHomeKitToTuya ', value, '->', convertedValue,' min:',min," scale:",scale )
+        return Math.min(scale, Math.max(0, convertedValue));
     }
 
     convertColorTemperatureFromTuyaToHomeKit(value) {
         const min = this.device.context.minWhiteColor || 140;
         const max = this.device.context.maxWhiteColor || 400;
         const scale = this.device.context.scaleWhiteColor || 255;
-        const result = Math.round(Math.max(Math.min((scale-value)/((scale-1)/(max-min))+min,max),min));
-        return Math.min(600, Math.max(71, result));
+        const unadjustedValue = max / ((value * (max - min) / (scale * min)) + 1);
+        const convertedValue = Math.round((unadjustedValue - 153) * (600 - 71) / (max - min) + 71);
+        //this.log('convertColorTemperatureFromTuyaToHomeKit ', value, '->', convertedValue,' min:',min," scale:",scale )
+        return Math.min(600, Math.max(71, convertedValue));
     }
 
     convertColorFromHomeKitToTuya(value, dpValue) {

--- a/lib/WledDimmerAccessory.js
+++ b/lib/WledDimmerAccessory.js
@@ -1,0 +1,703 @@
+const BaseAccessory = require('./BaseAccessory');
+const http = require('http');
+const maxWledBrightness = 255;
+
+// Debounce and warmup settings for WLED calls
+const wledDebounceMs = 50;
+const wledWarmupMs = 8000;
+
+class WledDimmerAccessory extends BaseAccessory {
+    static getCategory(Categories) {
+        return Categories.LIGHTBULB;
+    }
+
+    constructor(...props) {
+        super(...props);
+    }
+
+    _registerPlatformAccessory() {
+        const {Service} = this.hap;
+
+        this.accessory.addService(Service.Lightbulb, this.device.context.name);
+
+        super._registerPlatformAccessory();
+    }
+
+    _registerCharacteristics(dps) {
+        const {Service, Characteristic} = this.hap;
+        const service = this.accessory.getService(Service.Lightbulb);
+        this._checkServiceName(service, this.device.context.name);
+
+        this.dpPower = this._getCustomDP(this.device.context.dpPower) || '1';
+        this.dpBrightness = this._getCustomDP(this.device.context.dpBrightness) || this._getCustomDP(this.device.context.dp) || '2';
+
+        // State for debounced / delayed WLED updates
+        this._wledPendingBri = null;
+        this._wledDebounceTimer = null;
+        this._wledReadyAt = 0;
+
+        // State for WLED preset effect switches
+        this._wledEffectSwitches = [];
+        this._wledCurrentEffectIndex = null;
+
+        // Allow a couple of different spellings just in case
+        const syncCfg =
+            this.device.context.syncBrightnessToWled ||
+            this.device.context.syncBrightnessToWLED ||
+            null;
+        this.syncBrightnessToWled = (syncCfg && ('' + syncCfg).trim()) || null;
+
+        this.log.info(
+            '[WLED Sync] %s: syncBrightnessToWled=%s',
+            this.device.context.name,
+            this.syncBrightnessToWled || 'disabled'
+        );
+
+        const characteristicOn = service.getCharacteristic(Characteristic.On)
+            .updateValue(dps[this.dpPower])
+            .onGet(() => this.getStateAsync(this.dpPower))
+            .onSet(value => this.setStateAsync(this.dpPower, value));
+
+        const characteristicBrightness = service.getCharacteristic(Characteristic.Brightness);
+        // Keep a reference so we can update brightness from background WLED calls
+        this._characteristicBrightness = characteristicBrightness;
+
+        if (this.syncBrightnessToWled) {
+            // Start with 100% locally while we fetch the actual WLED brightness
+            characteristicBrightness
+                .updateValue(100)
+                .onGet(() => this.getBrightness())
+                .onSet(value => this.setBrightness(value));
+
+            // Force Tuya dimmer brightness to 100% on startup
+            const maxTuyaBrightness = this.convertBrightnessFromHomeKitToTuya(100);
+            if (dps[this.dpBrightness] !== maxTuyaBrightness) {
+                this.log.info(
+                    '[WLED Sync] %s: setting Tuya brightness DP%s to max (%s)',
+                    this.device.context.name,
+                    this.dpBrightness,
+                    maxTuyaBrightness
+                );
+                this.setState(this.dpBrightness, maxTuyaBrightness, () => {});
+            }
+        } else {
+            const initial = this.convertBrightnessFromTuyaToHomeKit(dps[this.dpBrightness]);
+            this.log.debug(
+                '%s: initial Tuya brightness DP%s=%s -> HomeKit %s%%',
+                this.device.context.name,
+                this.dpBrightness,
+                dps[this.dpBrightness],
+                initial
+            );
+            characteristicBrightness
+                .updateValue(initial)
+                .onGet(() => this.getBrightness())
+                .onSet(value => this.setBrightness(value));
+        }
+
+        // Optional: create one HomeKit Switch per configured WLED preset effect.
+        // Each switch, when turned ON, will push the corresponding effect ID to WLED.
+        const presetEffects = this.device.context.presetEffects;
+        if (Array.isArray(presetEffects) && presetEffects.length) {
+            const {Service: HapService, Characteristic: HapCharacteristic} = this.hap;
+
+            const validEffectServices = [];
+            this._wledEffectSwitches = [];
+
+            presetEffects.forEach((effectCfg, index) => {
+                if (!effectCfg) return;
+
+                const effectId = effectCfg.fx != null ? effectCfg.fx : effectCfg.id;
+                if (!isFinite(effectId)) {
+                    this.log.warn(
+                        '[WLED Sync] %s: presetEffects[%s] is missing a numeric id/fx, skipping: %s',
+                        this.device.context.name,
+                        index,
+                        JSON.stringify(effectCfg)
+                    );
+                    return;
+                }
+
+                const effectName = (effectCfg.name && String(effectCfg.name).trim()) || `Effect ${index + 1}`;
+                const staticColor = effectCfg.staticColor && String(effectCfg.staticColor).trim();
+                const displayName = effectName;
+                const subtype = `wledEffect ${index + 1}`;
+
+                let effectService = this.accessory.getServiceById(HapService.Switch, subtype);
+                if (effectService) {
+                    this._checkServiceName(effectService, displayName);
+                } else {
+                    effectService = this.accessory.addService(HapService.Switch, displayName, subtype);
+                }
+
+                validEffectServices.push(effectService);
+
+                const onCharacteristic = effectService
+                    .getCharacteristic(HapCharacteristic.On)
+                    .on('set', (value, callback) => {
+                        // Only react to turning the switch ON; turning OFF just clears the toggle in HomeKit.
+                        if (!value) {
+                            return callback();
+                        }
+
+                        // If the light is off, ignore effect change and turn this switch back off.
+                        if (!this.device.state[this.dpPower]) {
+                            setImmediate(() => {
+                                effectService.getCharacteristic(HapCharacteristic.On).updateValue(false);
+                            });
+                            return callback();
+                        }
+
+                        this.log.info(
+                            '[WLED Sync] %s: setting preset effect "%s" (id=%s, index=%s)',
+                            this.device.context.name,
+                            effectName,
+                            effectId,
+                            index + 1
+                        );
+
+                        const rgb = this._parseStaticColor(staticColor);
+
+                        if (!this.device.state[this.dpPower]) {
+                            this.log.error(
+                                '[WLED Sync] %s: lamp is off',
+                                this.device.context.name
+                            );
+                            setImmediate(() => {
+                                effectService.getCharacteristic(HapCharacteristic.On).updateValue(false);
+                            });
+                            return callback();
+                        }
+
+                        this._setWledEffect(effectId, rgb, err => {
+                            if (err) {
+                                this.log.error(
+                                    '[WLED Sync] %s: failed to set preset effect "%s" (id=%s): %s',
+                                    this.device.context.name,
+                                    effectName,
+                                    effectId,
+                                    err
+                                );
+                                setImmediate(() => {
+                                    effectService.getCharacteristic(HapCharacteristic.On).updateValue(false);
+                                });
+                                return callback();
+                            }
+
+                            // Remember active effect locally and turn off other switches for a radio-button-style UX.
+                            this._wledCurrentEffectIndex = (index + 1);
+                            this._wledEffectSwitches.forEach(sw => {
+                                if (sw.effectName !== effectName && sw.characteristic.value) {
+                                    sw.characteristic.updateValue(false);
+                                }
+                            });
+
+                            callback();
+                        });
+                    })
+                    .on('get', cb => {
+                        cb(null, this.device.state[this.dpPower] && this._wledCurrentEffectIndex === (index + 1));
+                    });
+
+                this._wledEffectSwitches.push({
+                    effectId,
+                    name: effectName,
+                    characteristic: onCharacteristic
+                });
+            });
+
+            // Clean up any stale WLED preset effect services that are no longer in config.
+            this.accessory.services
+                .filter(service => service.UUID === HapService.Switch.UUID && service.subtype && service.subtype.startsWith('wledEffect '))
+                .forEach(service => {
+                    if (!validEffectServices.includes(service)) {
+                        this.log.info('Removing', service.displayName);
+                        this.accessory.removeService(service);
+                    }
+                });
+        }
+
+        this.device.on('change', changes => {
+            // Log full DPS changes so we can see exactly what Tuya reported
+            this.log.info(
+                '%s DPS changes: %s %s was:',
+                this.device.context.name,
+                JSON.stringify(changes),
+                'dpPower=' + this.dpPower,
+                this.device.state[this.dpPower]
+            );
+
+            if (changes.hasOwnProperty(this.dpPower)) {
+                const oldPower = !!characteristicOn.value;
+                const newPower = !!changes[this.dpPower];
+
+                this.log.info(
+                    '%s power change detected on DP%s: %s -> %s',
+                    this.device.context.name,
+                    this.dpPower,
+                    oldPower,
+                    newPower
+                );
+
+                if (oldPower !== newPower) {
+                    characteristicOn.updateValue(newPower);
+                }
+
+                // Track warmup window for WLED after power ON
+                if (this.syncBrightnessToWled && newPower) {
+                    this._wledReadyAt = Date.now() + wledWarmupMs;
+                    this.log.info(
+                        '[WLED Sync] %s: power ON -> delaying WLED API calls for %sms',
+                        this.device.context.name,
+                        wledWarmupMs
+                    );
+                }
+
+                // Cancel any pending brightness updates when turning OFF
+                if (this.syncBrightnessToWled && !newPower) {
+                    if (this._wledDebounceTimer) {
+                        clearTimeout(this._wledDebounceTimer);
+                        this._wledDebounceTimer = null;
+                    }
+                    this._wledPendingBri = null;
+                }
+            }
+
+            // When WLED sync is enabled, also mirror manual Tuya (Smart Life) brightness changes to WLED
+            if (this.syncBrightnessToWled && changes.hasOwnProperty(this.dpBrightness)) {
+                const tuyaValue = changes[this.dpBrightness];
+                const maxTuyaBrightness = this.convertBrightnessFromHomeKitToTuya(100);
+
+                // Ignore the "forced back to 100%" update to avoid feedback loops
+                if (tuyaValue === maxTuyaBrightness) {
+                    this.log.info(
+                        '[WLED Sync] %s: Tuya DP%s reported max brightness (%s), ignoring',
+                        this.device.context.name,
+                        this.dpBrightness,
+                        tuyaValue
+                    );
+                    return;
+                }
+
+                const percent = this.convertBrightnessFromTuyaToHomeKit(tuyaValue);
+                const bri = Math.max(0, Math.min(maxWledBrightness, Math.round((percent / 100) * maxWledBrightness)));
+
+                this.log.info(
+                    '[WLED Sync] %s: Tuya DP%s changed to %s -> %s%% -> WLED bri=%s (debounced)',
+                    this.device.context.name,
+                    this.dpBrightness,
+                    tuyaValue,
+                    percent,
+                    bri
+                );
+
+                // Queue a debounced WLED update to match the Tuya app change
+                this._scheduleWledBrightness(bri, 'Tuya brightness change', err => {
+                    if (err) {
+                        this.log.error(
+                            '[WLED Sync] %s: failed to push Tuya-origin brightness to WLED (err=%s)',
+                            this.device.context.name,
+                            err
+                        );
+                        return;
+                    }
+
+                    // Reflect that brightness back into HomeKit
+                    characteristicBrightness.updateValue(percent);
+
+                    // After a short delay, force Tuya brightness back to 100% so it stops dimming the strip
+                    if (this._wledForceMaxTimeout) {
+                        clearTimeout(this._wledForceMaxTimeout);
+                    }
+                    this._wledForceMaxTimeout = setTimeout(() => {
+                        this.log.info(
+                            '[WLED Sync] %s: forcing Tuya DP%s back to max (%s) after Tuya app change',
+                            this.device.context.name,
+                            this.dpBrightness,
+                            maxTuyaBrightness
+                        );
+                        this.setState(this.dpBrightness, maxTuyaBrightness, () => {});
+                    }, 5000);
+                });
+            } else if (!this.syncBrightnessToWled && changes.hasOwnProperty(this.dpBrightness) && this.convertBrightnessFromHomeKitToTuya(characteristicBrightness.value) !== changes[this.dpBrightness]) {
+                characteristicBrightness.updateValue(this.convertBrightnessFromTuyaToHomeKit(changes[this.dpBrightness]));
+            }
+        });
+    }
+
+    getBrightness() {
+        if (this.syncBrightnessToWled) {
+            // If we already have a cached WLED brightness, return it immediately.
+            if (this._lastWledPercent != null) {
+                this.log.info(
+                    '[WLED Sync] %s: getBrightness() -> using cached %s%%',
+                    this.device.context.name,
+                    this._lastWledPercent
+                );
+                return this._lastWledPercent;
+            }
+            return 50;
+        } else {
+            return this.convertBrightnessFromTuyaToHomeKit(this.device.state[this.dpBrightness]);
+        }
+    }
+
+    setBrightness(value) {
+        if (this.syncBrightnessToWled) {
+            this.log.info(
+                '[WLED Sync] %s: setBrightness(%s%%)',
+                this.device.context.name,
+                value
+            );
+
+            // Remember the target level immediately so HomeKit/UI stays in sync.
+            this._lastWledPercent = value;
+
+            // Ensure Tuya stays at 100% so it doesn't interfere with WLED.
+            const maxTuyaBrightness = this.convertBrightnessFromHomeKitToTuya(100);
+            if (this.device.state[this.dpBrightness] !== maxTuyaBrightness) {
+                this.log.info(
+                    '[WLED Sync] %s: ensuring Tuya DP%s=%s (max)',
+                    this.device.context.name,
+                    this.dpBrightness,
+                    maxTuyaBrightness
+                );
+                // Fire-and-forget; don't tie HomeKit callback to Tuya I/O.
+                this.setStateAsync(this.dpBrightness, maxTuyaBrightness);
+            }
+
+            // Compute desired WLED brightness once.
+            const bri = Math.max(0, Math.min(maxWledBrightness, Math.round((value / 100) * maxWledBrightness)));
+            this.log.info(
+                '[WLED Sync] %s: mapped HomeKit %s%% -> WLED bri=%s (debounced background)',
+                this.device.context.name,
+                value,
+                bri
+            );
+
+            // Schedule the WLED update in the background with debounce and warmup handling.
+            this._scheduleWledBrightness(bri, 'HomeKit setBrightness');
+
+            // Return to HomeKit immediately; don't wait for network I/O.
+            return null;
+        } else {
+            return this.setStateAsync(this.dpBrightness, this.convertBrightnessFromHomeKitToTuya(value));
+        }
+    }
+
+    _getWledTarget() {
+        if (!this.syncBrightnessToWled) return null;
+        const parts = String(this.syncBrightnessToWled).split(':');
+        const host = parts[0];
+        const port = parts[1] ? parseInt(parts[1], 10) || 80 : 80;
+        this.log.info(
+            '[WLED Sync] %s: target host=%s port=%s',
+            this.device.context.name,
+            host,
+            port
+        );
+        return {host, port};
+    }
+
+    _getWledBrightness(callback) {
+        const target = this._getWledTarget();
+        if (!target) {
+            this.log.error(
+                '[WLED Sync] %s: _getWledBrightness but no target configured',
+                this.device.context.name
+            );
+            return callback(true);
+        }
+
+        // Ensure we never call the provided callback more than once
+        const done = (err, bri) => {
+            if (done.called) return;
+            done.called = true;
+            callback(err, bri);
+        };
+
+        const options = {
+            host: target.host,
+            port: target.port,
+            path: '/json/state',
+            method: 'GET',
+            timeout: 1000
+        };
+
+        this.log.info(
+            '[WLED Sync] %s: GET http://%s:%s/json/state',
+            this.device.context.name,
+            target.host,
+            target.port
+        );
+
+        const req = http.request(options, res => {
+            let data = '';
+            res.on('data', chunk => data += chunk);
+            res.on('end', () => {
+                try {
+                    const json = JSON.parse(data || '{}');
+                    // WLED exposes brightness as "bri" in the root of the state response
+                    const bri = json.bri != null ? json.bri : (json.state && json.state.bri);
+                    if (!isFinite(bri)) {
+                        this.log.error(
+                            '[WLED Sync] %s: /json/state response has no numeric bri: %s',
+                            this.device.context.name,
+                            data
+                        );
+                        return done(true);
+                    }
+                    this.log.info(
+                        '[WLED Sync] %s: /json/state -> bri=%s',
+                        this.device.context.name,
+                        bri
+                    );
+                    done(null, bri);
+                } catch (e) {
+                    this.log.error('Failed to parse WLED state from %s: %s', this.syncBrightnessToWled, e.message);
+                    done(true);
+                }
+            });
+        });
+
+        req.on('error', err => {
+            this.log.error('Error talking to WLED at %s: %s', this.syncBrightnessToWled, err.message);
+            done(true);
+        });
+
+        req.on('timeout', () => {
+            req.destroy();
+            done(true);
+        });
+
+        req.end();
+    }
+
+    _setWledBrightness(brightness, callback) {
+        const target = this._getWledTarget();
+        if (!target) {
+            this.log.error(
+                '[WLED Sync] %s: _setWledBrightness but no target configured',
+                this.device.context.name
+            );
+            if (callback) callback(true);
+            return;
+        }
+
+        // Ensure we never call the provided callback more than once
+        const done = (err) => {
+            if (!callback) return;
+            if (done.called) return;
+            done.called = true;
+            callback(err);
+        };
+
+        const body = JSON.stringify({bri: brightness});
+
+        const options = {
+            host: target.host,
+            port: target.port,
+            path: '/json/state',
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Content-Length': Buffer.byteLength(body)
+            },
+            timeout: 1000
+        };
+
+        this.log.info(
+            '[WLED Sync] %s: POST http://%s:%s/json/state body=%s',
+            this.device.context.name,
+            target.host,
+            target.port,
+            body
+        );
+
+        const req = http.request(options, res => {
+            // Consume response and ignore body
+            res.on('data', () => {});
+            res.on('end', () => {
+                this.log.info(
+                    '[WLED Sync] %s: WLED brightness set, HTTP %s',
+                    this.device.context.name,
+                    res.statusCode
+                );
+                done && done();
+            });
+        });
+
+        req.on('error', err => {
+            this.log.error('Error setting WLED brightness on %s: %s', this.syncBrightnessToWled, err.message);
+            done && done(true);
+        });
+
+        req.on('timeout', () => {
+            req.destroy();
+            done && done(true);
+        });
+
+        req.write(body);
+        req.end();
+    }
+
+    _setWledEffect(effectId, rgbColor, callback) {
+        const target = this._getWledTarget();
+        if (!target) {
+            this.log.error(
+                '[WLED Sync] %s: _setWledEffect but no target configured',
+                this.device.context.name
+            );
+            if (callback) callback(true);
+            return;
+        }
+
+        // Ensure we never call the provided callback more than once
+        const done = (err) => {
+            if (!callback) return;
+            if (done.called) return;
+            done.called = true;
+            callback(err);
+        };
+
+        // Build WLED JSON: always set effect (fx), and if a valid staticColor
+        // is provided, also override the first segment color.
+        const seg = {fx: effectId};
+        if (Array.isArray(rgbColor) && rgbColor.length === 3 && rgbColor.every(c => Number.isInteger(c))) {
+            seg.col = [rgbColor];
+        }
+
+        const body = JSON.stringify({seg: [seg]});
+
+        const options = {
+            host: target.host,
+            port: target.port,
+            path: '/json/state',
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Content-Length': Buffer.byteLength(body)
+            },
+            timeout: 1000
+        };
+
+        this.log.info(
+            '[WLED Sync] %s: POST http://%s:%s/json/state body=%s (preset effect)',
+            this.device.context.name,
+            target.host,
+            target.port,
+            body
+        );
+
+        const req = http.request(options, res => {
+            // Consume response and ignore body
+            res.on('data', () => {});
+            res.on('end', () => {
+                this.log.info(
+                    '[WLED Sync] %s: WLED effect set to %s, HTTP %s',
+                    this.device.context.name,
+                    effectId,
+                    res.statusCode
+                );
+                done && done();
+            });
+        });
+
+        req.on('error', err => {
+            this.log.error('Error setting WLED effect on %s: %s', this.syncBrightnessToWled, err.message);
+            done && done(true);
+        });
+
+        req.on('timeout', () => {
+            req.destroy();
+            done && done(true);
+        });
+
+        req.write(body);
+        req.end();
+    }
+
+    _parseStaticColor(color) {
+        if (!color) return null;
+
+        let hex = String(color).trim().toLowerCase();
+        if (hex[0] === '#') hex = hex.slice(1);
+
+        if (hex.length !== 6 || !/^[0-9a-f]{6}$/.test(hex)) {
+            this.log.warn(
+                '[WLED Sync] %s: staticColor "%s" is not a valid 6-digit hex string, ignoring',
+                this.device.context.name,
+                color
+            );
+            return null;
+        }
+
+        const r = parseInt(hex.slice(0, 2), 16);
+        const g = parseInt(hex.slice(2, 4), 16);
+        const b = parseInt(hex.slice(4, 6), 16);
+
+        return [r, g, b];
+    }
+
+    _scheduleWledBrightness(brightness, reason, callback) {
+        if (!this.syncBrightnessToWled) {
+            callback && callback(true);
+            return;
+        }
+
+        // Remember the last requested brightness; multiple calls within the debounce window collapse into one.
+        this._wledPendingBri = brightness;
+
+        if (this._wledDebounceTimer) {
+            clearTimeout(this._wledDebounceTimer);
+            this._wledDebounceTimer = null;
+        }
+
+        const now = Date.now();
+        const warmupDelay = this._wledReadyAt && now < this._wledReadyAt ? (this._wledReadyAt - now) : 0;
+        const delay = warmupDelay + wledDebounceMs;
+
+        this.log.info(
+            '[WLED Sync] %s: scheduling WLED bri=%s in %sms (%s)',
+            this.device.context.name,
+            brightness,
+            delay,
+            reason || 'unspecified'
+        );
+
+        this._wledDebounceTimer = setTimeout(() => {
+            this._wledDebounceTimer = null;
+
+            // If the light is now off, skip the call.
+            if (!this.device.state[this.dpPower]) {
+                this.log.info(
+                    '[WLED Sync] %s: skipping scheduled WLED bri=%s because power is OFF',
+                    this.device.context.name,
+                    this._wledPendingBri
+                );
+                this._wledPendingBri = null;
+                callback && callback(true);
+                return;
+            }
+
+            const briToSend = this._wledPendingBri;
+            this._wledPendingBri = null;
+
+            setImmediate(() => {
+                this._setWledBrightness(briToSend, err => {
+                    if (err) {
+                        this.log.error(
+                            '[WLED Sync] %s: scheduled WLED bri=%s failed: %s',
+                            this.device.context.name,
+                            briToSend,
+                            err
+                        );
+                    }
+                    callback && callback(err);
+                });
+            });
+        }, delay);
+    }
+}
+
+module.exports = WledDimmerAccessory;

--- a/wiki/Supported-Device-Types.md
+++ b/wiki/Supported-Device-Types.md
@@ -15,7 +15,7 @@ If you are looking for verified configurations for your specific device, please 
 |Barely Smart Power Strip|`Outlet`|Smart power strips that don't allow individual control of the outlets|
 |Air Conditioner|`AirConditioner`<sup>[6](#air-conditioners)</sup>|Cooling and heating devices <small>([instructions](#air-conditioners))</small>|
 |Heat Convector|`Convector`<sup>[7](#heat-convectors)</sup>|Heating panels <small>([instructions](#heat-convectors))</small>|
-|Simple Dimmer|`SimpleDimmer`<sup>[8](#simple-dimmers)</sup>|Dimmer switches with power control <small>([instructions](#simple-dimmers))</small>|
+|WLED Dimmer|`WledDimmer` (or legacy `SimpleDimmer`)<sup>[8](#simple-dimmers)</sup>|Dimmer switches with power control, with optional WLED sync <small>([instructions](#simple-dimmers))</small>|
 |Simple Heater|`SimpleHeater`<sup>[9](#simple-heaters)</sup>|Heating solutions with only temperature control <small>([instructions](#simple-heaters))</small>|
 |Garage Door|`GarageDoor`<sup>[10](#garage-doors)</sup>|Smart garage doors or garage door openers <small>([instructions](#garage-doors))</small>|
 |Simple Garage Door|`SimpleGarageDoor`<sup>[10](#simple-garage-doors)</sup>|Garage doors and sliding gate openers that expose only three momentary action DPs: open, stop, close <small>([instructions](#simple-garage-doors))</small>|
@@ -316,13 +316,20 @@ If your signature doesn't have a variation of _low_ or _high_, `SimpleHeater` wo
 }
 ```
 
-### Simple Dimmers
-These are switches allow turning on and off, and dimming. 
+### Simple Dimmers / WLED Dimmers
+These are switches that allow turning on and off, and dimming. Use type `WledDimmer` (legacy `SimpleDimmer` alias is also supported for backward compatibility).
+
+When using with a WLED controller (e.g. a Tuya-based relay/dimmer feeding power to a WLED strip), you can use advanced sync options:
+
+- `syncBrightnessToWled`: set to WLED device IP (e.g. "192.168.1.50" or "192.168.1.50:80") to sync HomeKit brightness changes directly to WLED over HTTP, keeping the Tuya dimmer at 100%.
+- `presetEffects`: array of effect configs to expose as switches in HomeKit (each turns on a WLED fx preset, optionally with staticColor).
+
+See the accessory source for full details on WLED integration.
 
 ```json5
 {
-    "name": "My Simple Dimmer",
-    "type": "SimpleDimmer",
+    "name": "My WLED Dimmer",
+    "type": "WledDimmer",
     "manufacturer": "TESSAN",
     "model": "Smart Dimmer Switch",
     "id": "032000123456789abcde",
@@ -334,11 +341,19 @@ These are switches allow turning on and off, and dimming.
     "dpPower": 1,
 
     /* Override the default datapoint identifier for brightness */
-    "dpBrightness": 2
+    "dpBrightness": 2,
 
     /* Override the default datapoint identifier for scaleBrightness. Common values are 255 or 1000 */
-    "scaleBrightness": 1000
+    "scaleBrightness": 1000,
 
+    /* WLED sync: forward brightness to a WLED instance instead of using the Tuya dimmer's level */
+    "syncBrightnessToWled": "192.168.1.123",
+
+    /* Optional preset effect switches (for WLED) */
+    "presetEffects": [
+      { "name": "Solid", "fx": 0, "staticColor": "#FFFFFF" },
+      { "name": "Rainbow", "fx": 2 }
+    ]
 }
 ```
 

--- a/wiki/User-documented-device-config.md
+++ b/wiki/User-documented-device-config.md
@@ -17,6 +17,63 @@ Below is a list of configurations for devices by users of the plugin. Please fol
 
 # Dimmer
 
+## Wled Dimmer
+
+**Treatlife Dimmable Smart Plug for Lamps**
+
+
+
+Tested plugin version: ```2.0.1```
+
+Tested by: [@benwtf](https://www.github.com/benwtf)
+
+Link to buy: [Amazon](https://www.amazon.com/Treatlife-Dimmer-Halogen-Incandescent-Outlets/dp/B08LPYXK6L/ref=sr_1_2_sspa)
+
+Capabilities: 
+- [X] On/Off
+- [X] Dimming
+- [ ] Timer (Use Tuya app)
+- [ ] Dimming Config (Use Tuya app)
+
+Config: 
+```json
+            {
+                "type": "WledDimmer",
+                "name": "Lamp",
+                "id": "xxx",
+                "key": "xxx",
+                "manufacturer": "Treatlife",
+                "model": "WiFi Smart Dimmer Plug",
+                "scaleBrightness": 1000,
+				"minBrightness": 10,
+				"syncBrightnessToWled": "192.168.1.239",
+				"presetEffects": [
+					{
+						"name": "White Static",
+						"id": 0,
+						"staticColor": "#ffffff"
+					},
+					{
+						"name": "Cyan Static",
+						"id": 0,
+						"staticColor": "#5cecd9"
+					},
+					{
+						"name": "Juggle",
+						"id": 130
+					},
+					{
+						"name": "Fire",
+						"id": 80
+					}
+				]
+            }
+```
+
+Schema/DP's:
+```
+```
+
 ## Simple Dimmer
 
 **Treatlife Dimmable Smart Plug for Lamps**


### PR DESCRIPTION
Example config:
```
{
                "type": "WledDimmer",
                "name": "Lamp",
                "id": "xxx",
                "key": "xxx",
                "manufacturer": "Treatlife",
                "model": "WiFi Smart Dimmer Plug",
                "scaleBrightness": 1000,
				"minBrightness": 10,
				"syncBrightnessToWled": "192.168.1.239",
				"presetEffects": [
					{
						"name": "White Static",
						"id": 0,
						"staticColor": "#ffffff"
					},
					{
						"name": "Cyan Static",
						"id": 0,
						"staticColor": "#5cecd9"
					},
					{
						"name": "Juggle",
						"id": 130
					},
					{
						"name": "Fire",
						"id": 80
					}
				]
            }
```

Use case:
A Wled led strip connected to a smart dimmer switch, tuya brightness is forcefully stuck back to 100% brightness and the wled brightness caches and changes.