### PR TITLE
Add forward-compatible Tuya protocol handling (3.6-ready) and fix version routing

### DIFF
--- a/Readme.MD
+++ b/Readme.MD
@@ -17,6 +17,7 @@
 A community-maintained Homebridge plugin for controlling Tuya devices locally over LAN. Control your supported Tuya accessories locally in HomeKit.
 
 * [Supported Device Types](#supported-device-types)
+* [Supported Tuya Protocol Versions](#supported-tuya-protocol-versions)
 * [Installation Instructions](#installation-instructions)
 * [Configuration](#configuration)
 * [Known Issues](#known-issues)
@@ -48,6 +49,24 @@ A community-maintained Homebridge plugin for controlling Tuya devices locally ov
 
 Note: Motion, and other sensor types don't behave well with responce requests, so they will not be added. 
 
+## Supported Tuya Protocol Versions
+
+The plugin speaks every published Tuya LAN protocol version:
+
+| Tuya LAN protocol | Framing | Encryption | Status |
+|---|---|---|---|
+| 3.1 | `0x55AA` | AES-128-ECB (base64, control only) | ✅ Supported |
+| 3.2 | `0x55AA` | AES-128-ECB | ✅ Supported |
+| 3.3 | `0x55AA` | AES-128-ECB | ✅ Supported |
+| 3.4 | `0x55AA` | AES-128-ECB, session key, HMAC-SHA256 | ✅ Supported |
+| 3.5 | `0x6699` | AES-128-GCM, session key | ✅ Supported |
+| 3.6 and newer | — | — | ✅ Forward-compatible (see below) |
+
+The protocol version is auto-detected from the device's discovery broadcast, so you normally don't need to configure anything.
+
+Protocol **3.5** is currently the newest Tuya LAN protocol in existence: it is the latest version implemented by Tuya's own open-source device SDK ([TuyaOpen](https://github.com/tuya/TuyaOpen)) and by the reference reverse-engineered implementations ([tinytuya](https://github.com/jasonacox/tinytuya/blob/master/PROTOCOL.md)). No device firmware speaking a "3.6" protocol has been observed in the wild so far.
+
+This plugin is nevertheless **3.6-ready**: if a device reports a newer protocol version (e.g. `3.6`) in its broadcast, the plugin automatically talks to it using the newest (3.5/GCM) protocol stack while tagging payloads with the device's reported version — the same forward-compatibility strategy used by tinytuya. Should such a device misbehave, you can pin it to a specific protocol with the `forceVersion` device option (e.g. `"forceVersion": "3.5"`), or use `version` to set a protocol for devices that can't be discovered (e.g. on another subnet).
 
 ## Installation Instructions
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -141,6 +141,24 @@
                 "functionBody": "return model.devices && model.devices[arrayIndices].type !== 'null';"
               }
             },
+            "version": {
+              "title": "Tuya protocol version",
+              "type": "string",
+              "placeholder": "e.g. 3.3",
+              "description": "Leave empty to auto-detect. Used when the device cannot be discovered (e.g. fixed IP across subnets). Supported: 3.1, 3.2, 3.3, 3.4, 3.5 (newer reported versions such as 3.6 are handled with the 3.5 stack automatically).",
+              "condition": {
+                "functionBody": "return model.devices && model.devices[arrayIndices].type !== 'null';"
+              }
+            },
+            "forceVersion": {
+              "title": "Force Tuya protocol version",
+              "type": "string",
+              "placeholder": "e.g. 3.5",
+              "description": "Overrides the protocol version even when the device broadcasts a different one. Only set this if a device misbehaves with its auto-detected version.",
+              "condition": {
+                "functionBody": "return model.devices && model.devices[arrayIndices].type !== 'null';"
+              }
+            },
             "manufacturer": {
               "type": "string",
               "description": "Anything you'd like to use to help identify this device.",

--- a/index.js
+++ b/index.js
@@ -127,8 +127,12 @@ class TuyaLan {
 
                 this.log.info('Discovered %s (%s) identified as %s (%s)', devices[config.id].name, config.id, devices[config.id].type, config.version);
 
+                // The version broadcast by the device wins over a configured `version`,
+                // but `forceVersion` overrides everything (e.g. to pin a device that
+                // reports a newer protocol, like 3.6, to a specific stack).
                 const device = new TuyaAccessory({
                     ...devices[config.id], ...config,
+                    ...(devices[config.id].forceVersion ? {version: devices[config.id].forceVersion} : {}),
                     log: this.log,
                     UUID: UUID.generate(UUID_SEED + ':' + config.id),
                     connect: false
@@ -156,6 +160,7 @@ class TuyaLan {
 
                     const device = new TuyaAccessory({
                         ...devices[deviceId],
+                        ...(devices[deviceId].forceVersion ? {version: devices[deviceId].forceVersion} : {}),
                         log: this.log,
                         UUID: UUID.generate(UUID_SEED + ':' + deviceId),
                         connect: false

--- a/lib/TuyaAccessory.js
+++ b/lib/TuyaAccessory.js
@@ -23,16 +23,35 @@ class TuyaAccessory extends EventEmitter {
             ...props,
         };
 
+        // The version can arrive as a string ('3.4', from broadcasts) or a number (3.4,
+        // from config.json). Keep a canonical string for protocol headers and a float for
+        // capability checks so devices reporting newer versions (e.g. a future 3.6) are
+        // handled by the newest stack instead of falling into a broken legacy path.
+        if (this.context.version === undefined || this.context.version === null || String(this.context.version).trim() === '') {
+            this.context.version = '3.5';
+        } else {
+            this.context.version = String(this.context.version).trim();
+        }
+        this._protocolVersion = parseFloat(this.context.version);
+        if (isNaN(this._protocolVersion)) {
+            if (this.log) this.log.warn(`Unrecognized protocol version "${this.context.version}" for ${this.context.name}; assuming 3.5.`);
+            this.context.version = '3.5';
+            this._protocolVersion = 3.5;
+        }
+        if (this._protocolVersion > 3.5 && this.log) {
+            this.log.info(`${this.context.name} reports protocol ${this.context.version}, newer than the newest known Tuya LAN protocol (3.5); using the 3.5 (GCM) stack with ${this.context.version} headers.`);
+        }
+
         this.state = {};
         this._cachedBuffer = Buffer.allocUnsafe(0);
 
         this._msgQueue = async.queue(this[
-            this.context.version < 3.2 ? '_msgHandler_3_1' :
-            this.context.version === '3.3' ? '_msgHandler_3_3' :
-            this.context.version === '3.4' ? '_msgHandler_3_4' : '_msgHandler_3_5'
+            this._protocolVersion < 3.2 ? '_msgHandler_3_1' :
+            this._protocolVersion < 3.4 ? '_msgHandler_3_3' :
+            this._protocolVersion < 3.5 ? '_msgHandler_3_4' : '_msgHandler_3_5'
         ].bind(this), 1);
 
-        if (this.context.version >= 3.2) {
+        if (this._protocolVersion >= 3.2) {
             this.context.pingGap = Math.min(this.context.pingGap || 9, 9);
             //this.log.info(`Changing ping gap for ${this.context.name} to ${this.context.pingGap}s`);
         }
@@ -110,7 +129,7 @@ class TuyaAccessory extends EventEmitter {
         };
 
         this._socket.on('connect', () => {
-            if (this.context.version !== '3.4' && this.context.version !== '3.5') {
+            if (this._protocolVersion < 3.4) {
                 clearTimeout(this._socket._connTimeout);
 
                 this.connected = true;
@@ -130,7 +149,7 @@ class TuyaAccessory extends EventEmitter {
             if (this.context.intro === false) return;
             this.connected = true;
 
-            if (this.context.version === '3.4' || this.context.version === '3.5') {
+            if (this._protocolVersion >= 3.4) {
                 this._tmpLocalKey = crypto.randomBytes(16);
                 const payload = {
                     data: this._tmpLocalKey,
@@ -148,7 +167,7 @@ class TuyaAccessory extends EventEmitter {
 
             do {
                 let startingIndex;
-                if (this.context.version === '3.5') {
+                if (this._protocolVersion >= 3.5) {
                     startingIndex = this._cachedBuffer.indexOf('00006699', 'hex');
                 } else {
                     startingIndex = this._cachedBuffer.indexOf('000055aa', 'hex');
@@ -160,7 +179,7 @@ class TuyaAccessory extends EventEmitter {
                 if (startingIndex !== 0) this._cachedBuffer = this._cachedBuffer.slice(startingIndex);
 
                 let endingIndex;
-                if (this.context.version === '3.5') {
+                if (this._protocolVersion >= 3.5) {
                     endingIndex = this._cachedBuffer.indexOf('00009966', 'hex');
                     if (endingIndex !== -1) endingIndex += 4;
                 } else {
@@ -336,7 +355,8 @@ class TuyaAccessory extends EventEmitter {
             return callback();
         }
 
-        let versionPos = task.msg.indexOf('3.3');
+        let versionPos = task.msg.indexOf(this.context.version);
+        if (versionPos === -1) versionPos = task.msg.indexOf('3.3');
         if (versionPos === -1) versionPos = task.msg.indexOf('3.2');
         const cleanMsg = task.msg.slice(versionPos === -1 ? len - size + ((task.msg.readUInt32BE(16) & 0xFFFFFF00) ? 0 : 4) : 15 + versionPos, len - 8);
 
@@ -410,7 +430,7 @@ class TuyaAccessory extends EventEmitter {
             return callback();
         }
 
-        let versionPos = task.msg.indexOf('3.4');
+        let versionPos = task.msg.indexOf(this.context.version);
         const cleanMsg = task.msg.slice(versionPos === -1 ? len - size + ((task.msg.readUInt32BE(16) & 0xFFFFFF00) ? 0 : 4) : 15 + versionPos, len - 0x24);
 
         const expectedCrc = task.msg.slice(len - 0x24, task.msg.length - 4).toString('hex');
@@ -430,7 +450,7 @@ class TuyaAccessory extends EventEmitter {
 
         let parsedPayload;
         try {
-            if (decryptedMsg.indexOf(this.context.version) === 0) {
+            if (hasVersionHeader(decryptedMsg)) {
                 decryptedMsg = decryptedMsg.slice(15)
             }
             let res =  JSON.parse(decryptedMsg)
@@ -508,7 +528,8 @@ class TuyaAccessory extends EventEmitter {
     }
 
     /*
-     * 3.5 Protocol message handler
+     * 3.5+ Protocol message handler (0x6699 frames, AES-128-GCM). Also used for any
+     * newer version a device may report (e.g. 3.6) until a format change is documented.
      */
     _msgHandler_3_5(task, callback) {
         if (!(task.msg instanceof Buffer)) return callback();
@@ -558,8 +579,8 @@ class TuyaAccessory extends EventEmitter {
             }
         }
 
-        // remove leading version header
-        if (payload.indexOf(this.context.version) === 0) payload = payload.slice(15);
+        // remove leading version header ("3.x" + 12 bytes), whichever 3.x the device used
+        if (hasVersionHeader(payload)) payload = payload.slice(15);
 
         // Attempt JSON parse
         let parsedPayload;
@@ -651,7 +672,7 @@ class TuyaAccessory extends EventEmitter {
                 t,
                 dps
             };
-            const data = (this.context.version === '3.4' || this.context.version === '3.5')
+            const data = this._protocolVersion >= 3.4
                 ? {
                     data: {
                         ...payload,
@@ -664,12 +685,12 @@ class TuyaAccessory extends EventEmitter {
                 : payload;
             result = this._send({
                 data,
-                cmd: (this.context.version === '3.4' || this.context.version === '3.5') ? 13 : 7
+                cmd: this._protocolVersion >= 3.4 ? 13 : 7
             });
             if (result !== true) this.log.info(" Result", result);
             if (this.context.sendEmptyUpdate) {
                 //this.log.info(" Sending", this.context.name, 'empty signature');
-                this._send({cmd: (this.context.version === '3.4' || this.context.version === '3.5') ? 13 : 7});
+                this._send({cmd: this._protocolVersion >= 3.4 ? 13 : 7});
             }
         } else {
             //this.log.info(`Sending first query to ${this.context.name} (${this.context.version})`);
@@ -678,7 +699,7 @@ class TuyaAccessory extends EventEmitter {
                     gwId: this.context.id,
                     devId: this.context.id
                 },
-                cmd: (this.context.version === '3.4' || this.context.version === '3.5') ? 16 : 10
+                cmd: this._protocolVersion >= 3.4 ? 16 : 10
             });
         }
 
@@ -705,9 +726,9 @@ class TuyaAccessory extends EventEmitter {
         if (this.context.fake) return;
         if (!this.connected) return false;
 
-        if (this.context.version < 3.2) return this._send_3_1(o);
-        if (this.context.version === '3.3') return this._send_3_3(o);
-        if (this.context.version === '3.4') return this._send_3_4(o);
+        if (this._protocolVersion < 3.2) return this._send_3_1(o);
+        if (this._protocolVersion < 3.4) return this._send_3_3(o);
+        if (this._protocolVersion < 3.5) return this._send_3_4(o);
         return this._send_3_5(o);
     }
 
@@ -759,9 +780,9 @@ class TuyaAccessory extends EventEmitter {
             cmd.toString(16).padStart(8, '0'), //command
             '00000000' //size
         ];
-        //version
+        //version ("3.x" + 12 null bytes, e.g. '332e33...' for 3.3)
         if (cmd === 7 && !data) hex.push('00000000');
-        else if (cmd !== 9 && cmd !== 10) hex.push('332e33000000000000000000000000');
+        else if (cmd !== 9 && cmd !== 10) hex.push(Buffer.concat([Buffer.from(this.context.version), Buffer.alloc(12)]).toString('hex'));
         //data
         if (data) {
             const cipher = crypto.createCipheriv('aes-128-ecb', this.context.key, '');
@@ -804,10 +825,10 @@ class TuyaAccessory extends EventEmitter {
           cmd !== 3 &&
           cmd !== 5 &&
           cmd !== 18) {
-            // Add 3.4 header
+            // Add version header (the version the device reported, e.g. '3.4')
             // check this: mqc_very_pcmcd_mcd(int a1, unsigned int a2)
             const buffer = Buffer.alloc(data.length + 15);
-            Buffer.from('3.4').copy(buffer, 0);
+            Buffer.from(this.context.version).copy(buffer, 0);
             data.copy(buffer, 15);
             data = buffer;
         }
@@ -843,7 +864,8 @@ class TuyaAccessory extends EventEmitter {
     }
 
     /*
-     * 3.5 Protocol send
+     * 3.5+ Protocol send (0x6699 frames, AES-128-GCM). Also used for any newer version
+     * a device may report (e.g. 3.6) until a format change is documented.
      */
     _send_3_5(o) {
         let {cmd, data} = {...o};
@@ -855,8 +877,9 @@ class TuyaAccessory extends EventEmitter {
         }
 
         if (cmd !== 10 && cmd !== 9 && cmd !== 16 && cmd !== 3 && cmd !== 5 && cmd !== 18) {
+            // Version header uses the version the device reported (3.5, or newer like 3.6)
             const buffer = Buffer.alloc(data.length + 15);
-            Buffer.from('3.5').copy(buffer, 0);
+            Buffer.from(this.context.version).copy(buffer, 0);
             data.copy(buffer, 15);
             data = buffer;
         }
@@ -933,6 +956,12 @@ const encrypt35 = (data, encryptKey, iv) => {
 const hmac = (data, hmacKey) => {
     return crypto.createHmac('sha256', hmacKey).update(data, 'utf8').digest();
 };
+
+// Payloads of protocol 3.2+ may start with a 15-byte version header: "3.x" followed by
+// 12 bytes. Match any "3.<digit>" so replies still parse when the device answers with a
+// different minor version than the one we connected with.
+const hasVersionHeader = buf =>
+    buf.length >= 15 && buf[0] === 0x33 && buf[1] === 0x2e && buf[2] >= 0x30 && buf[2] <= 0x39;
 
 const xorBuffers = (a, b) => {
     const len = Math.min(a.length, b.length);

--- a/lib/TuyaDiscovery.js
+++ b/lib/TuyaDiscovery.js
@@ -4,9 +4,9 @@ const EventEmitter = require('events');
 
 const UDP_KEY = Buffer.from('6c1ec8e2bb9bb59ab50b0daf649b410a', 'hex');
 
-const GCM_DISCOVERY_KEY = crypto.createHash('md5').update('yGAdlopoPVldABfn').digest(); // v3.5 UDP/GCM key
+const GCM_DISCOVERY_KEY = crypto.createHash('md5').update('yGAdlopoPVldABfn').digest(); // v3.5+ UDP/GCM key
 const PREFIX_55AA = 0x000055aa; // v3.1-3.4
-const PREFIX_6699 = 0x00006699; // v3.5
+const PREFIX_6699 = 0x00006699; // v3.5+
 const SUFFIX_AA55 = 0x0000aa55;
 const SUFFIX_9966 = 0x00009966;
 
@@ -36,8 +36,8 @@ class TuyaDiscovery extends EventEmitter {
         this._running = true;
         this._start(6666);
         this._start(6667);
-        this._start(7000); // v3.5 direct-reply port
-        this._sendV35Probe(); // broadcast a probe so silent 3.5 devices answer us
+        this._start(7000); // v3.5+ direct-reply port
+        this._sendV35Probe(); // broadcast a probe so silent 3.5+ devices answer us
 
         return this;
     }
@@ -114,7 +114,9 @@ class TuyaDiscovery extends EventEmitter {
         const suffix = msg.readUInt32BE(len - 4);
 
         /* 3.1-3.4 packets: 0x55AA … 0xAA55
-           3.5  packets: 0x6699 … 0x9966  */
+           3.5+ packets: 0x6699 … 0x9966
+           The 6699 payload carries the device's "version" field (3.5, or newer like
+           3.6), which flows into TuyaAccessory and selects the protocol stack. */
         const isV34Frame = prefix === 0x000055aa && suffix === 0x0000aa55;
         const isV35Frame = prefix === 0x00006699 && suffix === 0x00009966;
 

--- a/test/TuyaAccessory.protocol.test.js
+++ b/test/TuyaAccessory.protocol.test.js
@@ -1,0 +1,528 @@
+'use strict';
+
+// Protocol-level tests for TuyaAccessory.
+//
+// Covers version routing (3.1 - 3.5), packet construction/parsing for the
+// 0x55AA (ECB/HMAC) and 0x6699 (GCM) stacks, the 3.4+/3.5+ session-key
+// handshake, and forward compatibility: a device reporting a newer protocol
+// version (e.g. a future 3.6) must be served by the newest (3.5/GCM) stack
+// with the reported version string in payload headers - never by a broken
+// mix of legacy paths.
+
+const crypto = require('crypto');
+const TuyaAccessory = require('../lib/TuyaAccessory');
+const TuyaDiscovery = require('../lib/TuyaDiscovery');
+
+const KEY = '0123456789abcdef'; // 16-byte AES-128 local key
+
+const makeLog = () => {
+    const log = jest.fn();
+    log.info = jest.fn();
+    log.warn = jest.fn();
+    log.error = jest.fn();
+    log.debug = jest.fn();
+    return log;
+};
+
+const makeDevice = (version, extra = {}) => new TuyaAccessory({
+    id: 'bf1234567890abcdef12',
+    key: KEY,
+    ip: '192.168.1.50',
+    name: 'Protocol Test Device',
+    version,
+    connect: false,
+    log: makeLog(),
+    ...extra,
+});
+
+const attachSocketStub = device => {
+    const written = [];
+    device.connected = true;
+    device._socket = {
+        write: buf => { written.push(buf); return true; },
+        _ping: jest.fn(),
+    };
+    return written;
+};
+
+// ---- 0x6699 (3.5+) frame helpers, mirroring the documented format ----
+
+const buildPacket35 = (key, cmd, seq, plainPayload) => {
+    const iv = crypto.randomBytes(12);
+    const unknown = Buffer.alloc(2);
+    const seqBuf = Buffer.alloc(4); seqBuf.writeUInt32BE(seq, 0);
+    const cmdBuf = Buffer.alloc(4); cmdBuf.writeUInt32BE(cmd, 0);
+    const lenBuf = Buffer.alloc(4); lenBuf.writeUInt32BE(12 + plainPayload.length + 16, 0);
+    const aad = Buffer.concat([unknown, seqBuf, cmdBuf, lenBuf]);
+
+    const cipher = crypto.createCipheriv('aes-128-gcm', key, iv);
+    cipher.setAAD(aad);
+    const encrypted = Buffer.concat([cipher.update(plainPayload), cipher.final()]);
+    const tag = cipher.getAuthTag();
+
+    return Buffer.concat([
+        Buffer.from('00006699', 'hex'),
+        aad,
+        iv,
+        encrypted,
+        tag,
+        Buffer.from('00009966', 'hex'),
+    ]);
+};
+
+const decryptPacket35 = (key, pkt) => {
+    const len = pkt.length;
+    const iv = pkt.slice(18, 30);
+    const encrypted = pkt.slice(30, len - 20);
+    const tag = pkt.slice(len - 20, len - 4);
+    const aad = pkt.slice(4, 18);
+
+    const decipher = crypto.createDecipheriv('aes-128-gcm', key, iv);
+    decipher.setAAD(aad);
+    decipher.setAuthTag(tag);
+    return Buffer.concat([decipher.update(encrypted), decipher.final()]);
+};
+
+// "3.x" + 12 null bytes + retcode-less payload (client -> device has no retcode)
+const versionHeader = version => Buffer.concat([Buffer.from(version), Buffer.alloc(12)]);
+
+// PKCS#7 used by 3.4 (ECB without auto padding)
+const pkcs7pad = data => {
+    const padding = 0x10 - (data.length & 0xf);
+    return Buffer.concat([data, Buffer.alloc(padding, padding)]);
+};
+
+const ecbEncrypt = (key, data) => {
+    const cipher = crypto.createCipheriv('aes-128-ecb', key, null);
+    cipher.setAutoPadding(false);
+    const out = cipher.update(pkcs7pad(data));
+    cipher.final();
+    return out;
+};
+
+const hmac256 = (key, data) => crypto.createHmac('sha256', key).update(data).digest();
+
+// CRC32 as used by the 3.2/3.3 frames
+const crc32Table = (() => {
+    const table = [];
+    for (let i = 0; i < 256; i++) {
+        let crc = i;
+        for (let j = 8; j > 0; j--) crc = (crc & 1) ? (crc >>> 1) ^ 3988292384 : crc >>> 1;
+        table.push(crc);
+    }
+    return table;
+})();
+const crc32 = buffer => {
+    let crc = 0xffffffff;
+    for (let i = 0; i < buffer.length; i++) crc = crc32Table[buffer[i] ^ (crc & 0xff)] ^ (crc >>> 8);
+    return ~crc;
+};
+
+afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+});
+
+describe('protocol version normalization', () => {
+    test.each([
+        ['3.1', '3.1', 3.1],
+        ['3.3', '3.3', 3.3],
+        [3.3, '3.3', 3.3],     // numbers from config.json
+        ['3.4', '3.4', 3.4],
+        [3.4, '3.4', 3.4],
+        ['3.5', '3.5', 3.5],
+        ['3.6', '3.6', 3.6],   // future version: kept verbatim for headers
+        [3.6, '3.6', 3.6],
+        [undefined, '3.5', 3.5],
+        ['', '3.5', 3.5],
+    ])('version %p becomes context %p / numeric %p', (input, expectedStr, expectedNum) => {
+        const device = makeDevice(input);
+        expect(device.context.version).toBe(expectedStr);
+        expect(device._protocolVersion).toBe(expectedNum);
+    });
+
+    test('unparseable version falls back to 3.5 with a warning', () => {
+        const device = makeDevice('bananas');
+        expect(device.context.version).toBe('3.5');
+        expect(device._protocolVersion).toBe(3.5);
+        expect(device.log.warn).toHaveBeenCalled();
+    });
+
+    test('versions newer than 3.5 log an informational note', () => {
+        const device = makeDevice('3.6');
+        expect(device.log.info).toHaveBeenCalledWith(expect.stringContaining('3.6'));
+    });
+});
+
+describe('message handler routing', () => {
+    const HANDLERS = ['_msgHandler_3_1', '_msgHandler_3_3', '_msgHandler_3_4', '_msgHandler_3_5'];
+
+    const selectedHandler = async version => {
+        const spies = {};
+        HANDLERS.forEach(name => {
+            spies[name] = jest.spyOn(TuyaAccessory.prototype, name)
+                .mockImplementation((task, callback) => callback());
+        });
+
+        const device = makeDevice(version);
+        await device._msgQueue.push({msg: Buffer.alloc(0)});
+
+        const called = HANDLERS.filter(name => spies[name].mock.calls.length > 0);
+        expect(called).toHaveLength(1);
+        return called[0];
+    };
+
+    test.each([
+        ['3.1', '_msgHandler_3_1'],
+        ['3.2', '_msgHandler_3_3'], // 3.2 shares the 3.3 stack
+        ['3.3', '_msgHandler_3_3'],
+        [3.3, '_msgHandler_3_3'],
+        ['3.4', '_msgHandler_3_4'],
+        [3.4, '_msgHandler_3_4'],
+        ['3.5', '_msgHandler_3_5'],
+        ['3.6', '_msgHandler_3_5'], // newer than 3.5: newest stack
+        [3.6, '_msgHandler_3_5'],
+        [undefined, '_msgHandler_3_5'],
+    ])('version %p uses %s', async (version, expected) => {
+        expect(await selectedHandler(version)).toBe(expected);
+    });
+});
+
+describe('send routing', () => {
+    const SENDERS = ['_send_3_1', '_send_3_3', '_send_3_4', '_send_3_5'];
+
+    const selectedSender = version => {
+        const spies = {};
+        SENDERS.forEach(name => {
+            spies[name] = jest.spyOn(TuyaAccessory.prototype, name).mockReturnValue(true);
+        });
+
+        const device = makeDevice(version);
+        device.connected = true;
+        device._send({cmd: 9});
+
+        const called = SENDERS.filter(name => spies[name].mock.calls.length > 0);
+        expect(called).toHaveLength(1);
+        return called[0];
+    };
+
+    test.each([
+        ['3.1', '_send_3_1'],
+        ['3.2', '_send_3_3'],
+        ['3.3', '_send_3_3'],
+        [3.3, '_send_3_3'],
+        ['3.4', '_send_3_4'],
+        [3.4, '_send_3_4'],
+        ['3.5', '_send_3_5'],
+        ['3.6', '_send_3_5'],
+        [3.6, '_send_3_5'],
+    ])('version %p uses %s', (version, expected) => {
+        expect(selectedSender(version)).toBe(expected);
+    });
+});
+
+describe('0x6699 (3.5+) sends', () => {
+    test('control packet for a 3.6 device is valid GCM with a 3.6 version header', () => {
+        const device = makeDevice('3.6');
+        const written = attachSocketStub(device);
+
+        expect(device.update({1: true})).toBe(true);
+        expect(written).toHaveLength(1);
+
+        const pkt = written[0];
+        expect(pkt.readUInt32BE(0)).toBe(0x00006699);
+        expect(pkt.readUInt32BE(pkt.length - 4)).toBe(0x00009966);
+        expect(pkt.readUInt32BE(10)).toBe(13); // CONTROL_NEW
+        // length field counts IV + ciphertext + tag
+        expect(pkt.readUInt32BE(14)).toBe(pkt.length - 22);
+
+        const plain = decryptPacket35(KEY, pkt); // throws on AAD/tag mismatch
+        expect(plain.slice(0, 3).toString()).toBe('3.6');
+        expect([...plain.slice(3, 15)].every(b => b === 0)).toBe(true);
+
+        const json = JSON.parse(plain.slice(15).toString());
+        expect(json.protocol).toBe(5);
+        expect(json.data.dps).toEqual({'1': true});
+        expect(json.data.devId).toBe(device.context.id);
+    });
+
+    test('initial query for 3.5+/3.6 devices uses DP_QUERY_NEW (16) without version header', () => {
+        const device = makeDevice('3.6');
+        const written = attachSocketStub(device);
+
+        device.update();
+        const pkt = written[0];
+        expect(pkt.readUInt32BE(10)).toBe(16);
+
+        const json = JSON.parse(decryptPacket35(KEY, pkt).toString());
+        expect(json.gwId).toBe(device.context.id);
+        expect(json.devId).toBe(device.context.id);
+    });
+
+    test('control packet for a 3.5 device keeps the 3.5 version header', () => {
+        const device = makeDevice('3.5');
+        const written = attachSocketStub(device);
+
+        device.update({2: 'low'});
+        const plain = decryptPacket35(KEY, written[0]);
+        expect(plain.slice(0, 3).toString()).toBe('3.5');
+    });
+});
+
+describe('0x6699 (3.5+) receives', () => {
+    const statusPayload = (version, dps) => Buffer.concat([
+        Buffer.alloc(4), // return code
+        versionHeader(version),
+        Buffer.from(JSON.stringify({protocol: 4, t: 1750000000, data: {dps}})),
+    ]);
+
+    test('a 3.6 device status push decodes and updates state', async () => {
+        const device = makeDevice('3.6');
+        const changes = [];
+        device.on('change', c => changes.push(c));
+
+        const pkt = buildPacket35(KEY, 8, 7, statusPayload('3.6', {'1': true, '4': 22}));
+        await new Promise(resolve => device._msgHandler_3_5({msg: pkt}, resolve));
+
+        expect(changes).toEqual([{'1': true, '4': 22}]);
+        expect(device.state).toEqual({'1': true, '4': 22});
+    });
+
+    test('version header mismatch is tolerated (device answers 3.5, configured 3.6)', async () => {
+        const device = makeDevice('3.6');
+        const pkt = buildPacket35(KEY, 8, 8, statusPayload('3.5', {'20': false}));
+        await new Promise(resolve => device._msgHandler_3_5({msg: pkt}, resolve));
+        expect(device.state).toEqual({'20': false});
+    });
+
+    test('DP_QUERY_NEW (16) responses without version header decode', async () => {
+        const device = makeDevice('3.5');
+        const payload = Buffer.concat([
+            Buffer.alloc(4),
+            Buffer.from(JSON.stringify({dps: {'1': false}})),
+        ]);
+        const pkt = buildPacket35(KEY, 16, 2, payload);
+        await new Promise(resolve => device._msgHandler_3_5({msg: pkt}, resolve));
+        expect(device.state).toEqual({'1': false});
+    });
+
+    test('messages are decrypted with the session key once negotiated', async () => {
+        const device = makeDevice('3.6');
+        device.session_key = crypto.randomBytes(16);
+
+        const pkt = buildPacket35(device.session_key, 8, 9, statusPayload('3.6', {'3': 'auto'}));
+        await new Promise(resolve => device._msgHandler_3_5({msg: pkt}, resolve));
+        expect(device.state).toEqual({'3': 'auto'});
+    });
+});
+
+describe('3.5+ session key negotiation', () => {
+    test.each(['3.5', '3.6'])('handshake derives the session key and queries state (version %s)', async version => {
+        jest.useFakeTimers();
+
+        const device = makeDevice(version);
+        const written = attachSocketStub(device);
+        const connected = jest.fn();
+        device.on('connect', connected);
+
+        // Normally generated when the socket becomes ready (BIND / cmd 3)
+        device._tmpLocalKey = crypto.randomBytes(16);
+
+        // Device replies to BIND with: retcode + remote nonce + HMAC(local nonce)
+        const remoteNonce = crypto.randomBytes(16);
+        const sessNegResponse = Buffer.concat([
+            Buffer.alloc(4),
+            remoteNonce,
+            hmac256(KEY, device._tmpLocalKey),
+        ]);
+        const pkt = buildPacket35(KEY, 4, 1, sessNegResponse);
+        await new Promise(resolve => device._msgHandler_3_5({msg: pkt}, resolve));
+
+        // Expected session key: GCM(localNonce XOR remoteNonce) under the local
+        // key with IV = first 12 bytes of the local nonce
+        const xored = Buffer.from(device._tmpLocalKey);
+        for (let i = 0; i < xored.length; i++) xored[i] ^= remoteNonce[i];
+        const cipher = crypto.createCipheriv('aes-128-gcm', KEY, device._tmpLocalKey.slice(0, 12));
+        cipher.setAAD(Buffer.alloc(0));
+        const expectedSessionKey = Buffer.concat([cipher.update(xored), cipher.final()]);
+
+        expect(Buffer.isBuffer(device.session_key)).toBe(true);
+        expect(device.session_key.equals(expectedSessionKey)).toBe(true);
+        expect(connected).toHaveBeenCalled();
+
+        // First write: SESS_KEY_NEG_FINISH (cmd 5) carrying HMAC(remote nonce),
+        // still encrypted with the local key
+        expect(written.length).toBe(2);
+        expect(written[0].readUInt32BE(10)).toBe(5);
+        expect(decryptPacket35(KEY, written[0]).equals(hmac256(KEY, remoteNonce))).toBe(true);
+
+        // Second write: state query (cmd 16) already under the session key
+        expect(written[1].readUInt32BE(10)).toBe(16);
+        const query = JSON.parse(decryptPacket35(device.session_key, written[1]).toString());
+        expect(query.gwId).toBe(device.context.id);
+
+        jest.clearAllTimers();
+    });
+
+    test('handshake aborts on local-nonce HMAC mismatch', async () => {
+        jest.useFakeTimers();
+
+        const device = makeDevice('3.6');
+        attachSocketStub(device);
+        device._tmpLocalKey = crypto.randomBytes(16);
+
+        const badResponse = Buffer.concat([
+            Buffer.alloc(4),
+            crypto.randomBytes(16),
+            crypto.randomBytes(32), // wrong HMAC
+        ]);
+        const pkt = buildPacket35(KEY, 4, 1, badResponse);
+
+        expect(() => device._msgHandler_3_5({msg: pkt}, () => {})).toThrow(/HMAC mismatch/);
+        expect(device.session_key).toBeNull();
+
+        jest.clearAllTimers();
+    });
+});
+
+describe('0x55AA (3.4) stack', () => {
+    test('control packet is ECB-encrypted with a 3.4 header and valid HMAC', () => {
+        const device = makeDevice('3.4');
+        const written = attachSocketStub(device);
+
+        device.update({1: false});
+        const pkt = written[0];
+        const len = pkt.length;
+
+        expect(pkt.readUInt32BE(0)).toBe(0x000055aa);
+        expect(pkt.readUInt32BE(len - 4)).toBe(0x0000aa55);
+        expect(pkt.readUInt32BE(8)).toBe(13); // CONTROL_NEW
+        expect(pkt.readUInt32BE(12)).toBe(len - 16); // ciphertext + hmac + suffix
+
+        const mac = pkt.slice(len - 36, len - 4);
+        expect(mac.equals(hmac256(KEY, pkt.slice(0, len - 36)))).toBe(true);
+
+        const decipher = crypto.createDecipheriv('aes-128-ecb', KEY, null);
+        decipher.setAutoPadding(false);
+        let plain = decipher.update(pkt.slice(16, len - 36));
+        decipher.final();
+        plain = plain.slice(0, plain.length - plain[plain.length - 1]);
+
+        expect(plain.slice(0, 3).toString()).toBe('3.4');
+        const json = JSON.parse(plain.slice(15).toString());
+        expect(json.protocol).toBe(5);
+        expect(json.data.dps).toEqual({'1': false});
+    });
+
+    test('status push (cmd 8) with retcode and encrypted 3.4 header updates state', async () => {
+        const device = makeDevice('3.4');
+
+        const plain = Buffer.concat([
+            versionHeader('3.4'),
+            Buffer.from(JSON.stringify({protocol: 4, t: 1750000000, data: {dps: {'5': 'mid'}}})),
+        ]);
+        const encrypted = ecbEncrypt(KEY, plain);
+
+        const header = Buffer.alloc(16);
+        header.writeUInt32BE(0x000055aa, 0);
+        header.writeUInt32BE(3, 4); // seq
+        header.writeUInt32BE(8, 8); // STATUS
+        header.writeUInt32BE(4 + encrypted.length + 36, 12); // retcode + payload + hmac + suffix
+        const retcode = Buffer.alloc(4);
+
+        const body = Buffer.concat([header, retcode, encrypted]);
+        const pkt = Buffer.concat([body, hmac256(KEY, body), Buffer.from('0000aa55', 'hex')]);
+
+        await new Promise(resolve => device._msgHandler_3_4({msg: pkt}, resolve));
+        expect(device.state).toEqual({'5': 'mid'});
+    });
+});
+
+describe('0x55AA (3.2/3.3) stack', () => {
+    test('3.2 devices send control packets with a cleartext 3.2 header', () => {
+        const device = makeDevice('3.2');
+        const written = attachSocketStub(device);
+
+        device.update({1: true});
+        const pkt = written[0];
+        const len = pkt.length;
+
+        expect(pkt.readUInt32BE(0)).toBe(0x000055aa);
+        expect(pkt.readUInt32BE(8)).toBe(7); // CONTROL
+        expect(pkt.slice(16, 19).toString()).toBe('3.2');
+        expect(pkt.readInt32BE(len - 8)).toBe(crc32(pkt.slice(0, len - 8)));
+
+        const decipher = crypto.createDecipheriv('aes-128-ecb', KEY, '');
+        const plain = Buffer.concat([decipher.update(pkt.slice(31, len - 8)), decipher.final()]);
+        expect(JSON.parse(plain.toString()).dps).toEqual({'1': true});
+    });
+
+    test('3.3 devices keep the 3.3 cleartext header', () => {
+        const device = makeDevice('3.3');
+        const written = attachSocketStub(device);
+
+        device.update({1: true});
+        expect(written[0].slice(16, 19).toString()).toBe('3.3');
+    });
+
+    test('3.3 initial query uses DP_QUERY (10)', () => {
+        const device = makeDevice('3.3');
+        const written = attachSocketStub(device);
+
+        device.update();
+        expect(written[0].readUInt32BE(8)).toBe(10);
+    });
+
+    test('3.2 status messages decode through the 3.3 handler', async () => {
+        const device = makeDevice('3.2');
+
+        const json = Buffer.from(JSON.stringify({dps: {'1': true}}));
+        const cipher = crypto.createCipheriv('aes-128-ecb', KEY, '');
+        const encrypted = Buffer.concat([cipher.update(json), cipher.final()]);
+
+        const header = Buffer.alloc(16);
+        header.writeUInt32BE(0x000055aa, 0);
+        header.writeUInt32BE(1, 4);
+        header.writeUInt32BE(8, 8); // STATUS
+        header.writeUInt32BE(15 + encrypted.length + 8, 12);
+        const pkt = Buffer.concat([
+            header,
+            versionHeader('3.2'),
+            encrypted,
+            Buffer.alloc(4), // crc (not validated on receive)
+            Buffer.from('0000aa55', 'hex'),
+        ]);
+
+        await new Promise(resolve => device._msgHandler_3_3({msg: pkt}, resolve));
+        expect(device.state).toEqual({'1': true});
+    });
+});
+
+describe('discovery of 3.5+/3.6 devices', () => {
+    const GCM_DISCOVERY_KEY = crypto.createHash('md5').update('yGAdlopoPVldABfn').digest();
+
+    afterEach(() => {
+        TuyaDiscovery.removeAllListeners();
+        TuyaDiscovery.discovered.clear();
+        TuyaDiscovery.limitedIds.splice(0);
+    });
+
+    test('a 6699 broadcast advertising version 3.6 is passed through verbatim', () => {
+        TuyaDiscovery.log = makeLog();
+
+        const payload = Buffer.concat([
+            Buffer.alloc(4),
+            Buffer.from(JSON.stringify({ip: '192.168.1.99', gwId: 'bf9999999999999999ff', version: '3.6'})),
+        ]);
+        const pkt = buildPacket35(GCM_DISCOVERY_KEY, 0, 1, payload);
+
+        const found = [];
+        TuyaDiscovery.on('discover', d => found.push(d));
+        TuyaDiscovery._handleV35(pkt, 7000, {address: '192.168.1.99'});
+
+        expect(found).toHaveLength(1);
+        expect(found[0].id).toBe('bf9999999999999999ff');
+        expect(found[0].ip).toBe('192.168.1.99');
+        expect(found[0].version).toBe('3.6');
+    });
+});


### PR DESCRIPTION
Researched the current state of the Tuya LAN protocol: 3.5 (0x6699
frames, AES-128-GCM, session key) is the newest version that exists.
It is the latest implemented by Tuya's own open-source device SDK
(TuyaOpen) and by the reference reverse-engineered implementations
(tinytuya PROTOCOL.md); no 3.6 firmware has been observed in the wild.

This change makes the plugin ready for devices that report newer
versions (e.g. a future 3.6) and fixes broken routing along the way:

- Replace exact string version comparisons (=== '3.4' / '3.5') with
  numeric range checks, mirroring tinytuya's strategy. Devices
  reporting 3.6+ now use the newest (3.5/GCM) stack, including the
  session-key handshake and 0x6699 framing, instead of a broken mix
  of legacy paths.
- Fix protocol 3.2 devices being routed to the 3.5 GCM stack; they now
  correctly share the 3.3 (ECB, 0x55AA) stack with a '3.2' header.
- Fix numeric versions from config.json (e.g. "version": 3.4) being
  routed to the 3.5 stack; versions are normalized once on construction.
- Send the device's reported version string in payload headers instead
  of hardcoded '3.4'/'3.5', so a 3.6 device is addressed as 3.6.
- Accept any "3.x" version header when parsing replies, so a device
  answering with a different minor version than configured still parses.
- Add a forceVersion device option to pin a device to a specific
  protocol even when discovery reports another one; expose version and
  forceVersion in the config UI schema.
- Document supported protocol versions in the README.
- Add a protocol-level test suite (48 tests): version routing, 0x55AA
  ECB/HMAC and 0x6699 GCM packet build/parse round trips, the 3.5+
  session-key negotiation (incl. HMAC-mismatch abort), forward-compat
  3.6 send/receive, and 6699 discovery version passthrough.

https://claude.ai/code/session_01Bcp4vDavhR8tJyh47q5EXr