### PR TITLE
Fix malformed v3.5 discovery probe (fixes silent-until-probed devices)

### DIFF
--- a/lib/TuyaDiscovery.js
+++ b/lib/TuyaDiscovery.js
@@ -9,6 +9,7 @@ const PREFIX_55AA = 0x000055aa; // v3.1-3.4
 const PREFIX_6699 = 0x00006699; // v3.5+
 const SUFFIX_AA55 = 0x0000aa55;
 const SUFFIX_9966 = 0x00009966;
+const REQ_DEVINFO = 0x25; // v3.5+ broadcast probe command (FR_TYPE_BOARDCAST_LPV34/REQ_DEVINFO)
 
 class TuyaDiscovery extends EventEmitter {
     constructor() {
@@ -37,7 +38,14 @@ class TuyaDiscovery extends EventEmitter {
         this._start(6666);
         this._start(6667);
         this._start(7000); // v3.5+ direct-reply port
-        this._sendV35Probe(); // broadcast a probe so silent 3.5+ devices answer us
+
+        // v3.5+ devices stay silent until solicited. One probe usually suffices,
+        // but UDP is lossy and the device may have been mid-boot — repeat every
+        // 6s (matches tinytuya's BROADCASTTIME) so a single dropped packet
+        // doesn't burn the entire discovery window.
+        this._sendV35Probe();
+        if (this._v35ProbeTimer) clearInterval(this._v35ProbeTimer);
+        this._v35ProbeTimer = setInterval(() => this._sendV35Probe(), 6000);
 
         return this;
     }
@@ -47,6 +55,11 @@ class TuyaDiscovery extends EventEmitter {
         this._stop(6666);
         this._stop(6667);
         this._stop(7000);
+
+        if (this._v35ProbeTimer) {
+            clearInterval(this._v35ProbeTimer);
+            this._v35ProbeTimer = null;
+        }
 
         return this;
     }
@@ -245,25 +258,43 @@ class TuyaDiscovery extends EventEmitter {
         }
     }
 
+    // Broadcast a v3.5+ REQ_DEVINFO probe to UDP/7000. v3.5+ devices do not
+    // emit periodic plaintext broadcasts like 3.1-3.3, so they are invisible
+    // to passive listeners until something solicits them. Each correctly-formed
+    // probe causes the device to unicast its discovery JSON back to us, which
+    // _handleV35 then decodes.
+    //
+    // Frame layout (big-endian):
+    //   prefix(4) + reserved(2) + seq(4) + cmd(4) + length(4)   [14B header after prefix]
+    // + iv(12) + ciphertext(payloadLen) + tag(16) + suffix(4)
+    //
+    // AAD for GCM must be the 14 header bytes after the prefix exactly as
+    // they appear on the wire. Anything else and the receiver's auth tag
+    // verification fails and the packet is silently dropped.
     _sendV35Probe() {
-        const socket = dgram.createSocket('udp4');
         const payload = Buffer.from('{"from":"app","ip":"255.255.255.255"}');
-        const iv = crypto.randomBytes(12);
+
+        const prefix   = Buffer.from('00006699', 'hex');
+        const suffix   = Buffer.from('00009966', 'hex');
+        const reserved = Buffer.alloc(2); // 0x0000
+        const seq      = Buffer.alloc(4); // 0
+        const cmd      = Buffer.alloc(4); cmd.writeUInt32BE(REQ_DEVINFO, 0);
+        const iv       = crypto.randomBytes(12);
+        const len      = Buffer.alloc(4); len.writeUInt32BE(iv.length + payload.length + 16, 0);
+        const aad      = Buffer.concat([reserved, seq, cmd, len]);
+
         const cipher = crypto.createCipheriv('aes-128-gcm', GCM_DISCOVERY_KEY, iv);
-        cipher.setAAD(Buffer.alloc(14)); // UUUU+seq+cmd+len = zeros OK for probe
+        cipher.setAAD(aad);
         const enc = Buffer.concat([cipher.update(payload), cipher.final()]);
         const tag = cipher.getAuthTag();
-        const len = Buffer.alloc(4); len.writeUInt32BE(iv.length + enc.length + tag.length, 0);
-        const frame = Buffer.concat([
-            Buffer.from([0,0,0,0x66,0x99].slice(0,4)), // 6699 prefix
-            Buffer.alloc(14), // UUUU + seq + cmd (0) + len placeholder
-            len,
-            iv,
-            enc,
-            tag,
-            Buffer.from('00009966','hex')
-        ]);
-        socket.send(frame, 7000, '255.255.255.255', () => socket.close());
+
+        const frame = Buffer.concat([prefix, reserved, seq, cmd, len, iv, enc, tag, suffix]);
+
+        const socket = dgram.createSocket('udp4');
+        socket.bind(0, () => {
+            socket.setBroadcast(true);
+            socket.send(frame, 7000, '255.255.255.255', () => socket.close());
+        });
     }
 }
 


### PR DESCRIPTION
## Summary

`TuyaDiscovery` has **two** paths for finding a v3.5 device:

1. **Passive**: bind UDP/7000 and pick up the encrypted broadcasts most v3.5 devices emit on their own. This path is fine and isn't touched here — it's why discovery has worked for most users.
2. **Active**: on `start()`, broadcast a `REQ_DEVINFO` probe so devices that *don't* volunteer themselves still answer. **This path was completely broken.**

For the (small) subset of v3.5 devices that stay silent until solicited — e.g. some gate/door controllers I tested against — the passive path never sees them, so the broken probe meant they were undiscoverable unless `ip` was hardcoded in config (in which case discovery is bypassed and the direct connect fallback in `index.js` runs).

Confirmed against a live 3.5 device of that kind:
- buggy probe → **no reply, ever**
- correctly-formed probe → **reply in 60–90 ms**

## Bugs in `_sendV35Probe()`

| | Was | Now |
|---|---|---|
| **Prefix** | `Buffer.from([0,0,0,0x66,0x99].slice(0,4))` → `00 00 00 66` (the length-bounded `.slice` on the literal drops `0x99`) | `Buffer.from('00006699', 'hex')` — the magic the device looks for |
| **Header layout** | `Buffer.alloc(14) + len(4)` = 18 B post-prefix (one uint32 too many) | `reserved(2) + seq(4) + cmd(4) + length(4)` = 14 B, laid out explicitly |
| **Command** | `0` | `REQ_DEVINFO = 0x25` (matches tinytuya/scanner.py) |
| **GCM AAD** | `Buffer.alloc(14)` zeros — doesn't match on-wire bytes, so auth tag verification fails | derived from the same `reserved+seq+cmd+len` bytes going out |

## Also

- `socket.setBroadcast(true)` after binding — required on some hosts for `255.255.255.255` to actually leave the interface.
- Re-probe every 6 s (matches tinytuya's `BROADCASTTIME`) until `stop()`. UDP is lossy and a device may have been mid-boot when discovery started; without retries, one dropped probe meant a silent-until-probed device wasted the full 60 s discovery window. Interval is cleared in `stop()`.

## Test plan

- [x] Lint clean (\`npm run lint\`)
- [x] All 174 jest tests still pass (\`npm test\`)
- [x] Live verification (real silent-until-probed 3.5 device that #46 alone could not discover): with this patch on top of #46, \`TuyaDiscovery\` emits the \`discover\` event in 81 ms, with **no IP configured**. Without this patch, the same setup never discovered the device within the 60 s window.
- [x] Devices that already worked (passive broadcasters): unaffected — the passive listener path is untouched, and the new probe just provides additional, valid solicit traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)