### PR TITLE
Fix HomeKit accessory category resolution

### DIFF
--- a/index.js
+++ b/index.js
@@ -217,14 +217,22 @@ class TuyaLan {
         let accessory = this.cachedAccessories.get(deviceConfig.UUID),
             isCached = true;
 
-        if (accessory && accessory.category !== Accessory.getCategory(Categories)) {
-            this.log.info("%s has a different type (%s vs %s)", accessory.displayName, accessory.category, Accessory.getCategory(Categories));
+        const expectedCategory = Accessory.getCategory(Categories);
+
+        // Only treat a cached accessory as a "different type" when we actually
+        // have a category to compare against. If getCategory() resolves to
+        // undefined (e.g. an unknown HAP category constant), HomeKit stores the
+        // accessory as Categories.OTHER, so an undefined expectation would never
+        // match and we would needlessly unregister & recreate the accessory on
+        // every restart — wiping its HomeKit identity (name, room, automations).
+        if (accessory && expectedCategory !== undefined && accessory.category !== expectedCategory) {
+            this.log.info("%s has a different type (%s vs %s)", accessory.displayName, accessory.category, expectedCategory);
             this.removeAccessory(accessory);
             accessory = null;
         }
 
         if (!accessory) {
-            accessory = new PlatformAccessory(deviceConfig.name, deviceConfig.UUID, Accessory.getCategory(Categories));
+            accessory = new PlatformAccessory(deviceConfig.name, deviceConfig.UUID, expectedCategory);
             accessory.getService(Service.AccessoryInformation)
                 .setCharacteristic(Characteristic.Manufacturer, deviceConfig.manufacturer || "Unknown")
                 .setCharacteristic(Characteristic.Model, deviceConfig.model || "Unknown")

--- a/lib/BaseAccessory.js
+++ b/lib/BaseAccessory.js
@@ -1,4 +1,11 @@
 class BaseAccessory {
+    // Default HomeKit category. Subclasses should override with a real HAP
+    // category constant; falling back to OTHER keeps a forgotten override from
+    // throwing and from churning the accessory on every restart (see issue #45).
+    static getCategory(Categories) {
+        return Categories.OTHER;
+    }
+
     constructor(...props) {
         let isNew;
         [this.platform, this.accessory, this.device, isNew = true] = [...props];

--- a/lib/DehumidifierAccessory.js
+++ b/lib/DehumidifierAccessory.js
@@ -4,7 +4,7 @@ const STATE_OTHER = 9;
 
 class DehumidifierAccessory extends BaseAccessory {
     static getCategory(Categories) {
-        return Categories.DEHUMIDIFIER;
+        return Categories.AIR_DEHUMIDIFIER;
     }
 
     constructor(...props) {

--- a/lib/OilDiffuserAccessory.js
+++ b/lib/OilDiffuserAccessory.js
@@ -2,7 +2,7 @@ const BaseAccessory = require('./BaseAccessory');
 
 class OilDiffuserAccessory extends BaseAccessory {
     static getCategory(Categories) {
-        return Categories.DEHUMIDIFIER;
+        return Categories.AIR_DEHUMIDIFIER;
     }
 
     constructor(...props) {

--- a/lib/SimpleFanLightAccessory.js
+++ b/lib/SimpleFanLightAccessory.js
@@ -2,7 +2,9 @@ const BaseAccessory = require('./BaseAccessory');
 
 class SimpleFanLightAccessory extends BaseAccessory {
     static getCategory(Categories) {
-        return Categories.FANLIGHT;
+        // HAP has no combined fan+light category; the fan is the primary
+        // service, so categorise as a FAN (matches SimpleFanAccessory).
+        return Categories.FAN;
     }
 
     constructor(...props) {

--- a/test/getCategory.test.js
+++ b/test/getCategory.test.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const { HAP } = require('./support/mocks');
+const { Categories } = HAP;
+
+// Mirror of index.js CLASS_DEF. Every configurable device type must resolve to
+// a real HAP category: getCategory() returning undefined makes HomeKit store
+// the accessory as Categories.OTHER, so the cached category never matches the
+// expectation again and the accessory is unregistered & recreated on every
+// Homebridge restart — wiping its name, room and automations (issue #45).
+const CLASS_DEF = {
+    outlet: require('../lib/OutletAccessory'),
+    simplelight: require('../lib/SimpleLightAccessory'),
+    rgbtwlight: require('../lib/RGBTWLightAccessory'),
+    rgbtwoutlet: require('../lib/RGBTWOutletAccessory'),
+    twlight: require('../lib/TWLightAccessory'),
+    multioutlet: require('../lib/MultiOutletAccessory'),
+    custommultioutlet: require('../lib/CustomMultiOutletAccessory'),
+    airconditioner: require('../lib/AirConditionerAccessory'),
+    airpurifier: require('../lib/AirPurifierAccessory'),
+    dehumidifier: require('../lib/DehumidifierAccessory'),
+    convector: require('../lib/ConvectorAccessory'),
+    garagedoor: require('../lib/GarageDoorAccessory'),
+    simplegaragedoor: require('../lib/SimpleGarageDoorAccessory'),
+    simpledimmer: require('../lib/SimpleDimmerAccessory'),
+    simpledimmer2: require('../lib/SimpleDimmer2Accessory'),
+    simpleblinds: require('../lib/SimpleBlindsAccessory'),
+    simpleheater: require('../lib/SimpleHeaterAccessory'),
+    switch: require('../lib/SwitchAccessory'),
+    fan: require('../lib/SimpleFanAccessory'),
+    fanlight: require('../lib/SimpleFanLightAccessory'),
+    watervalve: require('../lib/ValveAccessory'),
+    oildiffuser: require('../lib/OilDiffuserAccessory'),
+    doorbell: require('../lib/DoorbellAccessory'),
+    verticalblindswithtilt: require('../lib/VerticalBlindsWithTilt'),
+    percentblinds: require('../lib/PercentBlindsAccessory'),
+};
+
+const validCategoryValues = new Set(Object.values(Categories));
+
+describe('getCategory()', () => {
+    test.each(Object.entries(CLASS_DEF))('%s resolves to a real HAP category', (type, AccessoryClass) => {
+        expect(typeof AccessoryClass.getCategory).toBe('function');
+
+        const category = AccessoryClass.getCategory(Categories);
+
+        // Must be a defined, numeric category — not undefined (the issue #45 bug).
+        expect(category).toBeDefined();
+        expect(typeof category).toBe('number');
+        // ...and an actual member of the HAP Categories enum.
+        expect(validCategoryValues.has(category)).toBe(true);
+    });
+
+    test('the specific types reported in issue #45 are fixed', () => {
+        expect(CLASS_DEF.fanlight.getCategory(Categories)).toBe(Categories.FAN);
+        expect(CLASS_DEF.dehumidifier.getCategory(Categories)).toBe(Categories.AIR_DEHUMIDIFIER);
+        expect(CLASS_DEF.oildiffuser.getCategory(Categories)).toBe(Categories.AIR_DEHUMIDIFIER);
+    });
+
+    test('BaseAccessory falls back to OTHER for a missing override', () => {
+        const BaseAccessory = require('../lib/BaseAccessory');
+        expect(BaseAccessory.getCategory(Categories)).toBe(Categories.OTHER);
+    });
+});

--- a/test/support/mocks.js
+++ b/test/support/mocks.js
@@ -60,6 +60,21 @@ const HAP = {
     },
     Formats: { FLOAT: 'float', UINT32: 'uint32', UINT16: 'uint16' },
     Perms: { READ: 'pr', NOTIFY: 'ev', WRITE: 'pw' },
+    // Mirrors hap-nodejs Categories. Intentionally kept faithful to the real
+    // enum (no FANLIGHT, no bare DEHUMIDIFIER) so getCategory() regressions are
+    // caught here instead of in production (see issue #45).
+    Categories: {
+        OTHER: 1, BRIDGE: 2, FAN: 3, GARAGE_DOOR_OPENER: 4, LIGHTBULB: 5,
+        DOOR_LOCK: 6, OUTLET: 7, SWITCH: 8, THERMOSTAT: 9, SENSOR: 10,
+        ALARM_SYSTEM: 11, SECURITY_SYSTEM: 11, DOOR: 12, WINDOW: 13,
+        WINDOW_COVERING: 14, PROGRAMMABLE_SWITCH: 15, RANGE_EXTENDER: 16,
+        CAMERA: 17, IP_CAMERA: 17, VIDEO_DOORBELL: 18, AIR_PURIFIER: 19,
+        AIR_HEATER: 20, AIR_CONDITIONER: 21, AIR_HUMIDIFIER: 22,
+        AIR_DEHUMIDIFIER: 23, APPLE_TV: 24, HOMEPOD: 25, SPEAKER: 26,
+        AIRPORT: 27, SPRINKLER: 28, FAUCET: 29, SHOWER_HEAD: 30,
+        TELEVISION: 31, TARGET_CONTROLLER: 32, ROUTER: 33, AUDIO_RECEIVER: 34,
+        TV_SET_TOP_BOX: 35, TV_STREAMING_STICK: 36,
+    },
 };
 
 function makeMockCharacteristic(initialValue = null) {


### PR DESCRIPTION
## Summary
This PR fixes a critical bug where accessories with undefined or invalid HAP categories were being recreated on every Homebridge restart, causing loss of HomeKit identity (name, room, automations). The fix ensures all accessory types resolve to valid HAP category constants.

## Key Changes
- **Added `getCategory()` static method to `BaseAccessory`**: Provides a safe fallback to `Categories.OTHER` for any accessory type that doesn't override it, preventing undefined category values
- **Fixed category mappings for three accessory types**:
  - `SimpleFanLightAccessory`: Changed from non-existent `Categories.FANLIGHT` to `Categories.FAN` (the primary service)
  - `DehumidifierAccessory`: Changed from non-existent `Categories.DEHUMIDIFIER` to `Categories.AIR_DEHUMIDIFIER`
  - `OilDiffuserAccessory`: Changed from non-existent `Categories.DEHUMIDIFIER` to `Categories.AIR_DEHUMIDIFIER`
- **Updated category comparison logic in `index.js`**: Only treats a cached accessory as a "different type" when `getCategory()` returns a defined value, preventing unnecessary accessory recreation when the category is undefined
- **Added comprehensive test suite** (`test/getCategory.test.js`): Validates that all 25 configurable device types resolve to real HAP categories, with specific regression tests for the three fixed types
- **Enhanced mock HAP Categories** in test support: Added a faithful mirror of the real hap-nodejs Categories enum to catch regressions during testing rather than in production

## Implementation Details
The root cause was that some accessory classes referenced non-existent category constants (e.g., `Categories.FANLIGHT`, `Categories.DEHUMIDIFIER`), which returned `undefined`. When HomeKit couldn't find a valid category, it defaulted to `Categories.OTHER`. On the next restart, the comparison would fail (undefined ≠ OTHER), triggering an unnecessary unregister/recreate cycle.

The fix ensures:
1. All accessory types have a valid `getCategory()` implementation
2. The category comparison in `index.js` only triggers recreation when we have a concrete expectation to compare against
3. A comprehensive test prevents future regressions by validating all device types against the real HAP Categories enum

https://claude.ai/code/session_01GqvZNJBvfhXsaEBqtRCGqr

Fixes #45 