### PR TITLE
Rewrite SimpleGarageDoor for state-reporting gate controllers

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -536,21 +536,32 @@
             },
             "dpOpen": {
               "type": "integer",
-              "placeholder": "1",
-              "condition": {
-                "functionBody": "return model.devices && model.devices[arrayIndices] && ['SimpleGarageDoor'].includes(model.devices[arrayIndices].type);"
-              }
-            },
-            "dpStop": {
-              "type": "integer",
-              "placeholder": "2",
+              "placeholder": "101",
+              "description": "Datapoint identifier for the open action.",
               "condition": {
                 "functionBody": "return model.devices && model.devices[arrayIndices] && ['SimpleGarageDoor'].includes(model.devices[arrayIndices].type);"
               }
             },
             "dpClose": {
               "type": "integer",
-              "placeholder": "3",
+              "placeholder": "102",
+              "description": "Datapoint identifier for the close action.",
+              "condition": {
+                "functionBody": "return model.devices && model.devices[arrayIndices] && ['SimpleGarageDoor'].includes(model.devices[arrayIndices].type);"
+              }
+            },
+            "dpStop": {
+              "type": "integer",
+              "placeholder": "103",
+              "description": "Datapoint identifier for the stop action (used only for the partial-open feature).",
+              "condition": {
+                "functionBody": "return model.devices && model.devices[arrayIndices] && ['SimpleGarageDoor'].includes(model.devices[arrayIndices].type);"
+              }
+            },
+            "dpState": {
+              "type": "integer",
+              "placeholder": "105",
+              "description": "Datapoint identifier for the reported state. Values 11 (stopped) and 12 (opening/open) are treated as OPEN; 13 (closing/closed) is treated as CLOSED.",
               "condition": {
                 "functionBody": "return model.devices && model.devices[arrayIndices] && ['SimpleGarageDoor'].includes(model.devices[arrayIndices].type);"
               }
@@ -558,14 +569,14 @@
             "partialOpenMs": {
               "type": "integer",
               "placeholder": "2000",
-              "description": "Optional. If set, exposes an extra stateful switch that mirrors whether the gate is currently open. Tapping it ON triggers a partial-open (the gate opens and then stops itself this many milliseconds after the device acknowledges the open command, leaving the gate partially open). Tapping it OFF triggers a standard full close. Leave empty to skip the switch.",
+              "description": "Optional. If set, exposes an extra stateful switch that mirrors whether the gate is currently open. Tapping it ON triggers a partial-open (the gate opens and then stops itself this many milliseconds later, leaving the gate partially open). Tapping it OFF triggers a standard full close. Leave empty to skip the switch.",
               "condition": {
                 "functionBody": "return model.devices && model.devices[arrayIndices] && ['SimpleGarageDoor'].includes(model.devices[arrayIndices].type);"
               }
             },
             "forceSwitches": {
               "type": "boolean",
-              "description": "Optional. Exposes extra Force Open and Force Close momentary switches alongside the main GarageDoorOpener. They drive the gate through the same queue as the main toggle, but as plain switches they can be used in HomeKit automations (which won't accept GarageDoorOpener targets directly).",
+              "description": "Optional. Exposes extra Force Open and Force Close momentary switches alongside the main GarageDoorOpener. They fire the same open/close actions as the main toggle, but as plain switches they can be used in HomeKit automations (which won't accept GarageDoorOpener targets directly).",
               "condition": {
                 "functionBody": "return model.devices && model.devices[arrayIndices] && ['SimpleGarageDoor'].includes(model.devices[arrayIndices].type);"
               }

--- a/lib/SimpleGarageDoorAccessory.js
+++ b/lib/SimpleGarageDoorAccessory.js
@@ -1,27 +1,25 @@
 const BaseAccessory = require('./BaseAccessory');
 
-// Delay after the device echoes the stop DP back to false (signalling the
-// stop has finished) before sending the open/close command. Some controllers
-// drop the direction command when it arrives too soon after the stop, even
-// after the stop DP itself has been reset.
-const POST_RESET_DELAY_MS = 500;
-
-// Fallback if the device never echoes the stop DP back to false (e.g. when
-// the stop was a no-op because the gate was already idle, or the echo is
-// dropped). Picked to comfortably exceed the ~1s reset we observe in
-// practice.
-const STOP_RESET_TIMEOUT_MS = 3000;
-
-// Fallback for the direction DP echo when the device misses one.
-const DIRECTION_RESET_TIMEOUT_MS = 3000;
-
-// Debounce window for incoming HomeKit toggles. setTargetDoorState waits
-// this long after the most recent press before starting (or rescheduling) a
-// stop+direction cycle, so a rapid burst of taps coalesces into one cycle
-// on the final target instead of driving the gate back and forth.
-const SETTLE_MS = 1000;
-
-const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+// This controller reports its movement on a single status DP (default 105),
+// but only distinguishes three values:
+//
+//   11 -> stopped            (gate parked part-way, or fully open)
+//   12 -> opening OR open
+//   13 -> closing OR closed
+//
+// HomeKit's GarageDoorOpener only needs the two states it can act on, so we
+// collapse the three: 11/12 => OPEN, 13 => CLOSED. Both CurrentDoorState and
+// TargetDoorState are mirrored straight from this DP, which keeps HomeKit in
+// sync no matter how the gate was triggered (Home app, a physical remote, the
+// Tuya app, ...).
+//
+// Unlike the original open/stop/close-only gates, this controller switches
+// direction on its own — sending open while it is closing (or vice versa)
+// just reverses it — so there is no stop-first dance: a HomeKit toggle simply
+// fires the matching action.
+const STATE_STOPPED = 11;
+const STATE_OPENING_OR_OPEN = 12;
+const STATE_CLOSING_OR_CLOSED = 13;
 
 class SimpleGarageDoorAccessory extends BaseAccessory {
     static getCategory(Categories) {
@@ -69,39 +67,39 @@ class SimpleGarageDoorAccessory extends BaseAccessory {
         }
     }
 
-    _registerCharacteristics() {
+    _registerCharacteristics(dps) {
         this._reconcileOptionalServices();
 
         const {Service, Characteristic} = this.hap;
         const service = this.accessory.getService(Service.GarageDoorOpener);
         this._checkServiceName(service, this.device.context.name);
 
-        this.dpOpen = this._getCustomDP(this.device.context.dpOpen) || '1';
-        this.dpStop = this._getCustomDP(this.device.context.dpStop) || '2';
-        this.dpClose = this._getCustomDP(this.device.context.dpClose) || '3';
+        this.dpOpen = this._getCustomDP(this.device.context.dpOpen) || '101';
+        this.dpClose = this._getCustomDP(this.device.context.dpClose) || '102';
+        this.dpStop = this._getCustomDP(this.device.context.dpStop) || '103';
+        this.dpState = this._getCustomDP(this.device.context.dpState) || '105';
 
         const partialOpenMs = parseInt(this.device.context.partialOpenMs, 10);
         this.partialOpenMs = Number.isFinite(partialOpenMs) && partialOpenMs > 0 ? partialOpenMs : 0;
 
-        // The device exposes no status DPs, so the only "memory" of where the
-        // gate is comes from the last HomeKit-triggered change, persisted via
-        // the homebridge accessory context.
-        if (this.accessory.context.cachedTargetDoorState !== Characteristic.TargetDoorState.OPEN &&
-            this.accessory.context.cachedTargetDoorState !== Characteristic.TargetDoorState.CLOSED) {
-            this.accessory.context.cachedTargetDoorState = Characteristic.TargetDoorState.OPEN;
+        // The only pending side effect we track is the partial-open auto-stop.
+        this.partialStopTimer = null;
+
+        // Seed the initial state from whatever the device has already reported.
+        // If it hasn't reported yet, fall back to the persisted target, then to
+        // CLOSED (the safer assumption for a gate). The real state DP almost
+        // always arrives within a second of connecting and corrects this.
+        let isOpen = this._mapDpState(dps[this.dpState]);
+        if (isOpen === null) {
+            isOpen = this.accessory.context.cachedTargetDoorState === Characteristic.TargetDoorState.OPEN;
         }
-        const initialTarget = this.accessory.context.cachedTargetDoorState;
-        this.currentDoorState = initialTarget === Characteristic.TargetDoorState.OPEN
+        this.currentDoorState = isOpen
             ? Characteristic.CurrentDoorState.OPEN
             : Characteristic.CurrentDoorState.CLOSED;
-        this.desiredTarget = initialTarget;
-        this.worker = null;
-        this.scheduleTimer = null;
-        this.partialStopTimer = null;
-        this.partialOpenId = 0;
-        this._partialPending = false;
-        this._currentChangePending = null;
-        this._currentChangeResolve = null;
+        const initialTarget = isOpen
+            ? Characteristic.TargetDoorState.OPEN
+            : Characteristic.TargetDoorState.CLOSED;
+        this.accessory.context.cachedTargetDoorState = initialTarget;
 
         this.characteristicTargetDoorState = service.getCharacteristic(Characteristic.TargetDoorState)
             .updateValue(initialTarget)
@@ -112,22 +110,23 @@ class SimpleGarageDoorAccessory extends BaseAccessory {
             .updateValue(this.currentDoorState)
             .onGet(() => this.currentDoorState);
 
+        // The controller exposes limit switches (l_open/l_close) but they don't
+        // work in practice, and there's no obstruction sensor wired up, so this
+        // is always reported clear.
         service.getCharacteristic(Characteristic.ObstructionDetected)
             .updateValue(false)
             .onGet(() => false);
 
         const partialSwitch = this.accessory.getServiceById(Service.Switch, 'partialOpen');
         if (partialSwitch) {
-            const initialOn = this.currentDoorState === Characteristic.CurrentDoorState.OPEN;
             const onChar = partialSwitch.getCharacteristic(Characteristic.On)
-                .updateValue(initialOn)
+                .updateValue(isOpen)
                 .onGet(() => this.currentDoorState === Characteristic.CurrentDoorState.OPEN)
                 .onSet(value => {
-                    // Stateful: switch ON triggers a partial-open cycle,
-                    // switch OFF triggers a full close (queue stop+close).
-                    // The switch value itself mirrors CurrentDoorState (see
-                    // _setCurrentDoorState) so it sits at ON whenever the
-                    // gate is currently open in HomeKit's view.
+                    // Stateful: the switch mirrors CurrentDoorState (ON while
+                    // the gate is open in HomeKit's view — see
+                    // _applyReportedState). Tapping it ON triggers a
+                    // partial-open; tapping it OFF triggers a full close.
                     if (value) {
                         this._handlePartialOpen();
                     } else {
@@ -163,255 +162,107 @@ class SimpleGarageDoorAccessory extends BaseAccessory {
             this.characteristicForceClose = onChar;
         }
 
-        // CurrentDoorState follows the device's own pacing — it flips to OPEN
-        // when the open DP transitions back to false, and to CLOSED when the
-        // close DP transitions back to false. That reset echo is the closest
-        // thing to position feedback we have.
         this.device.on('change', changes => this._onDeviceChange(changes));
     }
 
+    // Maps a raw status DP value to open (true) / closed (false) / unknown
+    // (null). 11 (stopped) and 12 (opening or open) are both "open" as far as
+    // HomeKit is concerned; 13 (closing or closed) is "closed".
+    _mapDpState(raw) {
+        const value = typeof raw === 'string' ? parseInt(raw, 10) : raw;
+        if (value === STATE_STOPPED || value === STATE_OPENING_OR_OPEN) return true;
+        if (value === STATE_CLOSING_OR_CLOSED) return false;
+        return null;
+    }
+
     _onDeviceChange(changes) {
+        if (!changes || !changes.hasOwnProperty(this.dpState)) return;
+        const isOpen = this._mapDpState(changes[this.dpState]);
+        if (isOpen === null) {
+            this.log.info(`[SimpleGarageDoor] ${this.device.context.name}: ignoring unknown state DP value ${JSON.stringify(changes[this.dpState])}`);
+            return;
+        }
+        this._applyReportedState(isOpen);
+    }
+
+    // Mirrors the device's reported state onto both door-state characteristics
+    // (and the partial-open switch). Driving TargetDoorState from the DP too —
+    // not just CurrentDoorState — is what keeps HomeKit honest when the gate is
+    // operated outside HomeKit.
+    _applyReportedState(isOpen) {
         const {Characteristic} = this.hap;
-        if (!changes) return;
-        if (changes[this.dpOpen] === false) {
-            this._setCurrentDoorState(Characteristic.CurrentDoorState.OPEN);
-        } else if (changes[this.dpClose] === false) {
-            this._setCurrentDoorState(Characteristic.CurrentDoorState.CLOSED);
-        }
-    }
+        const current = isOpen
+            ? Characteristic.CurrentDoorState.OPEN
+            : Characteristic.CurrentDoorState.CLOSED;
+        const target = isOpen
+            ? Characteristic.TargetDoorState.OPEN
+            : Characteristic.TargetDoorState.CLOSED;
 
-    _setCurrentDoorState(state) {
-        if (this.currentDoorState === state) return;
-        this.currentDoorState = state;
-        this.characteristicCurrentDoorState.updateValue(state);
+        if (this.currentDoorState !== current) {
+            this.currentDoorState = current;
+            this.characteristicCurrentDoorState.updateValue(current);
+        }
+        if (this.accessory.context.cachedTargetDoorState !== target) {
+            this.accessory.context.cachedTargetDoorState = target;
+            if (this.characteristicTargetDoorState) this.characteristicTargetDoorState.updateValue(target);
+        }
         if (this.characteristicPartialOpen) {
-            this.characteristicPartialOpen.updateValue(
-                state === this.hap.Characteristic.CurrentDoorState.OPEN
-            );
-        }
-        this._wakeCurrentChangeWaiters();
-    }
-
-    _waitForCurrentChange() {
-        if (!this._currentChangePending) {
-            this._currentChangePending = new Promise(resolve => {
-                this._currentChangeResolve = resolve;
-            });
-        }
-        return this._currentChangePending;
-    }
-
-    _wakeCurrentChangeWaiters() {
-        if (this._currentChangeResolve) {
-            const resolve = this._currentChangeResolve;
-            this._currentChangeResolve = null;
-            this._currentChangePending = null;
-            resolve();
+            this.characteristicPartialOpen.updateValue(isOpen);
         }
     }
 
     setTargetDoorState(value) {
+        // A direct open/close (the GarageDoorOpener target, a Force switch, or
+        // the partial switch tapped OFF) is manual control: cancel any pending
+        // partial-open auto-stop so it can't halt this movement part-way.
+        this._cancelPartialStop();
+        this._applyTarget(value);
+    }
+
+    // Optimistically reflects the requested target in HomeKit and fires the
+    // matching action on the device. CurrentDoorState is intentionally left to
+    // catch up from the status DP. The device echoes the action DP back to
+    // false on its own; we don't wait for it.
+    _applyTarget(value) {
+        const {Characteristic} = this.hap;
+        const open = value === Characteristic.TargetDoorState.OPEN;
+        this.accessory.context.cachedTargetDoorState = value;
+        if (this.characteristicTargetDoorState) this.characteristicTargetDoorState.updateValue(value);
+        const dp = open ? this.dpOpen : this.dpClose;
+        this.log.info(`[SimpleGarageDoor] ${this.device.context.name}: ${open ? 'open' : 'close'} (dp${dp})`);
+        this.setMultiStateLegacyAsync({[dp]: true});
+    }
+
+    // Partial open: fire the open action, then after partialOpenMs fire a stop
+    // so the gate ends up parked part-way. Anchored to the button press (the
+    // controller starts moving and reports state within ~1s), which is all the
+    // user asked for.
+    _handlePartialOpen() {
+        const {Characteristic} = this.hap;
         const name = this.device.context.name;
-        // If a partial-open flow is in progress (waiting for OPEN or armed
-        // with a pending stop) and the incoming value matches the target
-        // the partial already set, treat this as a HomeKit/iOS resync (the
-        // accessory's TargetDoorState characteristic wasn't notified of
-        // the partial-induced target change, so iOS may write the value
-        // back to "confirm" the state it observed via CurrentDoorState).
-        // A no-op resync must not cancel the partial's auto-stop —
-        // otherwise the gate runs all the way open.
-        if ((this._partialPending || this.partialStopTimer)
-            && value === this.desiredTarget) {
-            this.log.info(`[SimpleGarageDoor] ${name}: setTargetDoorState(${value}) ignored as same-value resync during partial`);
+        if (!this.partialOpenMs) return;
+        if (this.partialStopTimer) {
+            // Re-entrant press while a partial is already armed (e.g. a
+            // HomeKit/iOS WRITE retransmit) — ignore so the stop isn't pushed
+            // out, which would let the gate run further than intended.
+            this.log.info(`[SimpleGarageDoor] ${name}: partial press ignored — a partial open is already running`);
             return;
         }
-        this.log.info(`[SimpleGarageDoor] ${name}: setTargetDoorState(${value}); was desiredTarget=${this.desiredTarget}, partialStopTimer=${this.partialStopTimer ? 'armed' : 'null'}, _partialPending=${this._partialPending}`);
-        // Public path: a direct user toggle cancels any pending partial-stop
-        // timer and supersedes any in-flight partial-open wait — once the
-        // user takes manual control, the auto-stop shouldn't fire later, and
-        // the partial flow's open-wait should bail out rather than hanging
-        // forever in case currentDoorState never reaches OPEN.
+
+        this.log.info(`[SimpleGarageDoor] ${name}: partial open — opening, will stop in ${this.partialOpenMs}ms`);
+        this._applyTarget(Characteristic.TargetDoorState.OPEN);
+        this.partialStopTimer = setTimeout(() => {
+            this.partialStopTimer = null;
+            this.log.info(`[SimpleGarageDoor] ${name}: partial open — firing stop (dp${this.dpStop})`);
+            this.setMultiStateLegacyAsync({[this.dpStop]: true});
+        }, this.partialOpenMs);
+    }
+
+    _cancelPartialStop() {
         if (this.partialStopTimer) {
             clearTimeout(this.partialStopTimer);
             this.partialStopTimer = null;
         }
-        this._partialPending = false;
-        this.partialOpenId++;
-        this._wakeCurrentChangeWaiters();
-        this._setTarget(value);
-    }
-
-    _setTarget(value) {
-        this.accessory.context.cachedTargetDoorState = value;
-        this.desiredTarget = value;
-        // Mirror the target through the characteristic so HomeKit's view of
-        // TargetDoorState stays in sync with what we actually want — without
-        // this, HAP's internal value stays at whatever was last written by a
-        // client (e.g. CLOSED) and a hub may push a resync write trying to
-        // reconcile it with the new CurrentDoorState we just emitted.
-        if (this.characteristicTargetDoorState) {
-            this.characteristicTargetDoorState.updateValue(value);
-        }
-        // If a worker is already running it will pick up the new target at
-        // its next decision point — no need to debounce again. Otherwise
-        // (re)start the debounce so a burst of taps coalesces into one
-        // cycle on the final target.
-        if (this.worker) return;
-        this._scheduleWorker();
-    }
-
-    // Drives the partial-open flow: STOP+OPEN through the normal queue, wait
-    // until CurrentDoorState reaches OPEN (so the timer is anchored to the
-    // device actually receiving the open rather than to the button press —
-    // otherwise a short partialOpenMs would land mid-cycle and a stop fired
-    // then could land before the open even reaches the device), then after
-    // partialOpenMs send a raw STOP to halt the gate mid-opening so it ends
-    // up partially open.
-    //
-    // Idempotent against re-invocation while a flow is already in progress
-    // (waiting for OPEN or armed with a pending stop): HomeKit/iOS will
-    // retransmit a WRITE if the 204 response is delayed or dropped, and
-    // each retry firing through onSet would otherwise cancel the original
-    // stop timer and push it out by another partialOpenMs — eventually
-    // letting the gate run all the way open. A direct toggle on the main
-    // GarageDoorOpener target or a Force switch still supersedes this flow
-    // through setTargetDoorState.
-    async _handlePartialOpen() {
-        const {Characteristic} = this.hap;
-        const name = this.device.context.name;
-        if (!this.partialOpenMs) return;
-        if (this._partialPending || this.partialStopTimer) {
-            this.log.info(`[SimpleGarageDoor] ${name}: partial press ignored — flow already in progress (_partialPending=${this._partialPending}, partialStopTimer=${this.partialStopTimer ? 'armed' : 'null'})`);
-            return;
-        }
-
-        this._partialPending = true;
-        const myId = ++this.partialOpenId;
-        this.log.info(`[SimpleGarageDoor] ${name}: partial press accepted (myId=${myId}); driving target to OPEN`);
-
-        this._setTarget(Characteristic.TargetDoorState.OPEN);
-
-        try {
-            while (this.currentDoorState !== Characteristic.CurrentDoorState.OPEN) {
-                await this._waitForCurrentChange();
-                // A direct toggle (which clears _partialPending) supersedes
-                // this flow.
-                if (myId !== this.partialOpenId) {
-                    this.log.info(`[SimpleGarageDoor] ${name}: partial flow superseded mid-wait (myId=${myId} vs ${this.partialOpenId})`);
-                    return;
-                }
-            }
-        } finally {
-            this._partialPending = false;
-        }
-
-        this.log.info(`[SimpleGarageDoor] ${name}: CurrentDoorState reached OPEN; arming partial-stop in ${this.partialOpenMs}ms`);
-        this.partialStopTimer = setTimeout(() => {
-            this.partialStopTimer = null;
-            if (myId !== this.partialOpenId) {
-                this.log.info(`[SimpleGarageDoor] ${name}: partial-stop timer fired but flow superseded (myId=${myId} vs ${this.partialOpenId})`);
-                return;
-            }
-            // Send the raw stop several times spread over ~1s. The device's
-            // command queue can drop back-to-back writes, and brief WiFi
-            // dropouts silently lose individual writes — re-sending a few
-            // times defends against both. A stop on an already-stopped gate
-            // is a no-op on the device side.
-            this.log.info(`[SimpleGarageDoor] ${name}: firing partial-stop (dp${this.dpStop}=true) with retries`);
-            const send = (attempt) => {
-                if (myId !== this.partialOpenId) return;
-                this.log.info(`[SimpleGarageDoor] ${name}: partial-stop attempt ${attempt} (device.connected=${this.device.connected})`);
-                this.setMultiStateLegacyAsync({[this.dpStop]: true});
-            };
-            send(1);
-            setTimeout(() => send(2), 250);
-            setTimeout(() => send(3), 600);
-            setTimeout(() => send(4), 1200);
-        }, this.partialOpenMs);
-    }
-
-    _scheduleWorker() {
-        if (this.scheduleTimer) clearTimeout(this.scheduleTimer);
-        this.scheduleTimer = setTimeout(() => {
-            this.scheduleTimer = null;
-            this._spawnWorker();
-        }, SETTLE_MS);
-    }
-
-    _spawnWorker() {
-        if (this.worker) return;
-        if (this._currentMatchesTarget(this.desiredTarget)) return;
-        this.worker = this._runWorker().finally(() => {
-            this.worker = null;
-            // If the target shifted while the cycle was running and still
-            // differs from where we landed, debounce again before the next
-            // cycle so another spam burst coalesces.
-            if (!this._currentMatchesTarget(this.desiredTarget)) {
-                this._scheduleWorker();
-            }
-        });
-    }
-
-    // One stop + direction cycle. The worker re-reads this.desiredTarget at
-    // each decision point so a toggle that lands during the cycle is honoured;
-    // if the target has reverted to the current state, the direction is
-    // skipped and the worker exits.
-    async _runWorker() {
-        const {Characteristic} = this.hap;
-        if (this._currentMatchesTarget(this.desiredTarget)) return;
-
-        await this._sendAndAwaitReset(this.dpStop, STOP_RESET_TIMEOUT_MS);
-        await sleep(POST_RESET_DELAY_MS);
-
-        if (this._currentMatchesTarget(this.desiredTarget)) return;
-
-        const target = this.desiredTarget;
-        const directionDp = target === Characteristic.TargetDoorState.OPEN
-            ? this.dpOpen
-            : this.dpClose;
-        await this._sendAndAwaitReset(directionDp, DIRECTION_RESET_TIMEOUT_MS);
-        // Belt-and-braces: the persistent change listener will already have
-        // flipped this on the echo, but force-mirror in case the echo was
-        // missed so the next loop check exits cleanly.
-        this._setCurrentDoorState(target === Characteristic.TargetDoorState.OPEN
-            ? Characteristic.CurrentDoorState.OPEN
-            : Characteristic.CurrentDoorState.CLOSED);
-    }
-
-    _currentMatchesTarget(target) {
-        const {Characteristic} = this.hap;
-        if (target === Characteristic.TargetDoorState.OPEN) {
-            return this.currentDoorState === Characteristic.CurrentDoorState.OPEN;
-        }
-        return this.currentDoorState === Characteristic.CurrentDoorState.CLOSED;
-    }
-
-    // Writes the DP and resolves when the device echoes it back to false
-    // (signalling the action completed) or the timeout fires.
-    async _sendAndAwaitReset(dp, timeoutMs) {
-        const wait = this._waitForDpReset(dp, timeoutMs);
-        this.setMultiStateLegacyAsync({[dp]: true});
-        await wait;
-    }
-
-    _waitForDpReset(dp, timeoutMs) {
-        return new Promise(resolve => {
-            const cleanup = () => {
-                this.device.removeListener('change', onChange);
-                clearTimeout(timer);
-            };
-            const onChange = changes => {
-                if (changes && changes[dp] === false) {
-                    cleanup();
-                    resolve();
-                }
-            };
-            const timer = setTimeout(() => {
-                cleanup();
-                resolve();
-            }, timeoutMs);
-            this.device.on('change', onChange);
-        });
     }
 }
 

--- a/test/SimpleGarageDoorAccessory.test.js
+++ b/test/SimpleGarageDoorAccessory.test.js
@@ -5,10 +5,10 @@ const { HAP, makeInstance } = require('./support/mocks');
 
 const { CurrentDoorState: CDS, TargetDoorState: TDS } = HAP.Characteristic;
 
-const POST_RESET_DELAY_MS = 500;
-const STOP_RESET_TIMEOUT_MS = 3000;
-const DIRECTION_RESET_TIMEOUT_MS = 3000;
-const SETTLE_MS = 1000;
+// Raw status DP values reported by the controller (DP 105).
+const STATE_STOPPED = 11;
+const STATE_OPENING_OR_OPEN = 12;
+const STATE_CLOSING_OR_CLOSED = 13;
 
 // Give the device's `on`/`removeListener` mocks real subscription semantics
 // so the accessory can wait for `change` events the way it does in production.
@@ -44,32 +44,26 @@ function makeSimpleGarage(initialContext = {}) {
     // call it directly because the mock service shares a single mock
     // characteristic across calls — wiring each role manually keeps the
     // assertions untangled.
-    instance.dpOpen = '1';
-    instance.dpStop = '2';
-    instance.dpClose = '3';
+    instance.dpOpen = '101';
+    instance.dpClose = '102';
+    instance.dpStop = '103';
+    instance.dpState = '105';
     instance.partialOpenMs = 0;
-    instance.currentDoorState = CDS.OPEN;
-    instance.desiredTarget = TDS.OPEN;
-    instance.worker = null;
-    instance.scheduleTimer = null;
     instance.partialStopTimer = null;
-    instance.partialOpenId = 0;
-    instance._partialPending = false;
-    instance._currentChangePending = null;
-    instance._currentChangeResolve = null;
+    instance.currentDoorState = CDS.CLOSED;
     instance.characteristicCurrentDoorState = {
-        value: CDS.OPEN,
+        value: CDS.CLOSED,
         updateValue: jest.fn().mockImplementation(function(v) { this.value = v; return this; }),
     };
     instance.characteristicTargetDoorState = {
-        value: TDS.OPEN,
+        value: TDS.CLOSED,
         updateValue: jest.fn().mockImplementation(function(v) { this.value = v; return this; }),
     };
     instance.characteristicPartialOpen = {
-        value: true,
+        value: false,
         updateValue: jest.fn().mockImplementation(function(v) { this.value = v; return this; }),
     };
-    accessory.context.cachedTargetDoorState = TDS.OPEN;
+    accessory.context.cachedTargetDoorState = TDS.CLOSED;
 
     // Mirror the persistent change listener registered in production.
     device.on('change', changes => instance._onDeviceChange(changes));
@@ -77,318 +71,161 @@ function makeSimpleGarage(initialContext = {}) {
     return { instance, device, accessory, platform };
 }
 
-// Simulate the device echoing a DP back to false (its "command consumed"
-// signal). Drives both the worker's per-step listener and the persistent
-// CurrentDoorState listener.
-function emitReset(device, dp) {
-    device.emit('change', { [dp]: false }, { [dp]: false });
+// Simulate the controller reporting a new value on its status DP.
+function emitState(device, value) {
+    device.emit('change', { '105': value });
 }
 
 // ---------------------------------------------------------------------------
-// _onDeviceChange — the persistent listener that drives CurrentDoorState
+// State DP -> door state mapping (the heart of the new behaviour)
 // ---------------------------------------------------------------------------
 describe('SimpleGarageDoorAccessory._onDeviceChange', () => {
-    test('Open DP resetting to false sets CurrentDoorState to OPEN', () => {
+    test('State 12 (opening/open) drives Current and Target to OPEN', () => {
+        const { instance, accessory } = makeSimpleGarage();
+        instance.currentDoorState = CDS.CLOSED;
+        instance.characteristicCurrentDoorState.value = CDS.CLOSED;
+        accessory.context.cachedTargetDoorState = TDS.CLOSED;
+
+        instance._onDeviceChange({ '105': STATE_OPENING_OR_OPEN });
+
+        expect(instance.currentDoorState).toBe(CDS.OPEN);
+        expect(instance.characteristicCurrentDoorState.value).toBe(CDS.OPEN);
+        expect(instance.characteristicTargetDoorState.value).toBe(TDS.OPEN);
+        expect(accessory.context.cachedTargetDoorState).toBe(TDS.OPEN);
+    });
+
+    test('State 11 (stopped) is treated as OPEN', () => {
         const { instance } = makeSimpleGarage();
         instance.currentDoorState = CDS.CLOSED;
         instance.characteristicCurrentDoorState.value = CDS.CLOSED;
 
-        instance._onDeviceChange({ '1': false });
+        instance._onDeviceChange({ '105': STATE_STOPPED });
 
         expect(instance.currentDoorState).toBe(CDS.OPEN);
         expect(instance.characteristicCurrentDoorState.value).toBe(CDS.OPEN);
     });
 
-    test('Close DP resetting to false sets CurrentDoorState to CLOSED', () => {
-        const { instance } = makeSimpleGarage();
+    test('State 13 (closing/closed) drives Current and Target to CLOSED', () => {
+        const { instance, accessory } = makeSimpleGarage();
         instance.currentDoorState = CDS.OPEN;
         instance.characteristicCurrentDoorState.value = CDS.OPEN;
+        instance.characteristicTargetDoorState.value = TDS.OPEN;
+        accessory.context.cachedTargetDoorState = TDS.OPEN;
 
-        instance._onDeviceChange({ '3': false });
+        instance._onDeviceChange({ '105': STATE_CLOSING_OR_CLOSED });
 
         expect(instance.currentDoorState).toBe(CDS.CLOSED);
         expect(instance.characteristicCurrentDoorState.value).toBe(CDS.CLOSED);
+        expect(instance.characteristicTargetDoorState.value).toBe(TDS.CLOSED);
+        expect(accessory.context.cachedTargetDoorState).toBe(TDS.CLOSED);
     });
 
-    test('Open DP echoing back to true does not change CurrentDoorState', () => {
+    test('String DP values are coerced', () => {
         const { instance } = makeSimpleGarage();
         instance.currentDoorState = CDS.CLOSED;
 
-        instance._onDeviceChange({ '1': true });
+        instance._onDeviceChange({ '105': '12' });
 
-        expect(instance.currentDoorState).toBe(CDS.CLOSED);
+        expect(instance.currentDoorState).toBe(CDS.OPEN);
     });
 
-    test('Stop DP resets do not change CurrentDoorState', () => {
+    test('Unknown DP values are ignored', () => {
         const { instance } = makeSimpleGarage();
         instance.currentDoorState = CDS.CLOSED;
 
-        instance._onDeviceChange({ '2': false });
+        instance._onDeviceChange({ '105': 99 });
 
         expect(instance.currentDoorState).toBe(CDS.CLOSED);
-    });
-
-    test('No characteristic write when CurrentDoorState already matches', () => {
-        const { instance } = makeSimpleGarage();
-        instance.currentDoorState = CDS.OPEN;
-
-        instance._onDeviceChange({ '1': false });
-
         expect(instance.characteristicCurrentDoorState.updateValue).not.toHaveBeenCalled();
     });
+
+    test('Changes that do not include the state DP are ignored', () => {
+        const { instance } = makeSimpleGarage();
+        instance.currentDoorState = CDS.CLOSED;
+
+        // The action DPs echoing back are irrelevant — only the state DP matters.
+        instance._onDeviceChange({ '101': false });
+        instance._onDeviceChange({ '103': true });
+
+        expect(instance.currentDoorState).toBe(CDS.CLOSED);
+        expect(instance.characteristicCurrentDoorState.updateValue).not.toHaveBeenCalled();
+    });
+
+    test('No characteristic write when the state already matches', () => {
+        const { instance } = makeSimpleGarage();
+        instance.currentDoorState = CDS.OPEN;
+        instance.characteristicCurrentDoorState.value = CDS.OPEN;
+        instance.accessory.context.cachedTargetDoorState = TDS.OPEN;
+
+        instance._onDeviceChange({ '105': STATE_OPENING_OR_OPEN });
+
+        expect(instance.characteristicCurrentDoorState.updateValue).not.toHaveBeenCalled();
+        expect(instance.characteristicTargetDoorState.updateValue).not.toHaveBeenCalled();
+    });
 });
 
 // ---------------------------------------------------------------------------
-// setTargetDoorState — single command (target differs from current)
+// setTargetDoorState — fires the matching action, no stop-first dance
 // ---------------------------------------------------------------------------
-describe('SimpleGarageDoorAccessory.setTargetDoorState — single command', () => {
-    beforeEach(() => jest.useFakeTimers());
-    afterEach(() => jest.useRealTimers());
+describe('SimpleGarageDoorAccessory.setTargetDoorState', () => {
+    test('OPEN fires the open action immediately (no stop first)', () => {
+        const { instance, device, accessory } = makeSimpleGarage();
 
-    test('OPEN debounces for SETTLE_MS then sends stop, waits for reset+500ms, then sends open', async () => {
+        instance.setTargetDoorState(TDS.OPEN);
+
+        expect(device.update).toHaveBeenCalledTimes(1);
+        expect(device.update).toHaveBeenCalledWith({ '101': true });
+        expect(accessory.context.cachedTargetDoorState).toBe(TDS.OPEN);
+        expect(instance.characteristicTargetDoorState.value).toBe(TDS.OPEN);
+    });
+
+    test('CLOSE fires the close action immediately (no stop first)', () => {
+        const { instance, device, accessory } = makeSimpleGarage();
+        instance.currentDoorState = CDS.OPEN;
+
+        instance.setTargetDoorState(TDS.CLOSED);
+
+        expect(device.update).toHaveBeenCalledTimes(1);
+        expect(device.update).toHaveBeenCalledWith({ '102': true });
+        expect(accessory.context.cachedTargetDoorState).toBe(TDS.CLOSED);
+        expect(instance.characteristicTargetDoorState.value).toBe(TDS.CLOSED);
+    });
+
+    test('CurrentDoorState is not touched until the device reports it', () => {
         const { instance, device } = makeSimpleGarage();
         instance.currentDoorState = CDS.CLOSED;
         instance.characteristicCurrentDoorState.value = CDS.CLOSED;
 
         instance.setTargetDoorState(TDS.OPEN);
-        await jest.advanceTimersByTimeAsync(SETTLE_MS - 1);
-        expect(device.update).not.toHaveBeenCalled();
+        // Target updated, but Current waits for the status DP.
+        expect(instance.characteristicCurrentDoorState.updateValue).not.toHaveBeenCalled();
+        expect(instance.currentDoorState).toBe(CDS.CLOSED);
 
-        await jest.advanceTimersByTimeAsync(1);
-        expect(device.update).toHaveBeenNthCalledWith(1, { '2': true });
-
-        emitReset(device, '2');
-        await jest.advanceTimersByTimeAsync(POST_RESET_DELAY_MS);
-        expect(device.update).toHaveBeenNthCalledWith(2, { '1': true });
-
-        emitReset(device, '1');
-        await jest.advanceTimersByTimeAsync(0);
-        expect(instance.characteristicCurrentDoorState.value).toBe(CDS.OPEN);
-        expect(instance.worker).toBeNull();
-        expect(instance.scheduleTimer).toBeNull();
-    });
-
-    test('CLOSE debounces then sends stop, waits, then sends close; CurrentDoorState flips on close reset', async () => {
-        const { instance, device } = makeSimpleGarage();
-        instance.currentDoorState = CDS.OPEN;
-        instance.characteristicCurrentDoorState.value = CDS.OPEN;
-
-        instance.setTargetDoorState(TDS.CLOSED);
-        await jest.advanceTimersByTimeAsync(SETTLE_MS);
-        expect(device.update).toHaveBeenNthCalledWith(1, { '2': true });
-
-        emitReset(device, '2');
-        await jest.advanceTimersByTimeAsync(POST_RESET_DELAY_MS);
-        expect(device.update).toHaveBeenNthCalledWith(2, { '3': true });
-
-        emitReset(device, '3');
-        await jest.advanceTimersByTimeAsync(0);
-        expect(instance.characteristicCurrentDoorState.value).toBe(CDS.CLOSED);
-        expect(instance.worker).toBeNull();
-    });
-
-    test('Target matching current produces no commands', async () => {
-        const { instance, device } = makeSimpleGarage();
-        instance.currentDoorState = CDS.OPEN;
-        instance.desiredTarget = TDS.OPEN;
-
-        instance.setTargetDoorState(TDS.OPEN);
-        await jest.advanceTimersByTimeAsync(
-            SETTLE_MS + STOP_RESET_TIMEOUT_MS + POST_RESET_DELAY_MS + DIRECTION_RESET_TIMEOUT_MS
-        );
-
-        expect(device.update).not.toHaveBeenCalled();
-        expect(instance.worker).toBeNull();
-    });
-
-    test('Custom DPs are respected', async () => {
-        const { instance, device } = makeSimpleGarage();
-        instance.dpOpen = '101';
-        instance.dpStop = '102';
-        instance.dpClose = '103';
-        instance.currentDoorState = CDS.CLOSED;
-
-        instance.setTargetDoorState(TDS.OPEN);
-        await jest.advanceTimersByTimeAsync(SETTLE_MS);
-        expect(device.update).toHaveBeenNthCalledWith(1, { '102': true });
-
-        emitReset(device, '102');
-        await jest.advanceTimersByTimeAsync(POST_RESET_DELAY_MS);
-        expect(device.update).toHaveBeenNthCalledWith(2, { '101': true });
-
-        emitReset(device, '101');
-        await jest.advanceTimersByTimeAsync(0);
+        // ~1s later the controller reports it is opening.
+        emitState(device, STATE_OPENING_OR_OPEN);
+        expect(instance.currentDoorState).toBe(CDS.OPEN);
         expect(instance.characteristicCurrentDoorState.value).toBe(CDS.OPEN);
     });
-});
 
-// ---------------------------------------------------------------------------
-// Spam / debounce
-// ---------------------------------------------------------------------------
-describe('SimpleGarageDoorAccessory.setTargetDoorState — spam debounce', () => {
-    beforeEach(() => jest.useFakeTimers());
-    afterEach(() => jest.useRealTimers());
-
-    test('Rapid presses within the debounce window coalesce into one cycle on the final target', async () => {
+    test('Custom DPs are respected', () => {
         const { instance, device } = makeSimpleGarage();
-        instance.currentDoorState = CDS.OPEN;
+        instance.dpOpen = '1';
+        instance.dpClose = '2';
 
-        // 5 presses across ~800ms, all within SETTLE_MS of each other.
-        instance.setTargetDoorState(TDS.CLOSED);
-        await jest.advanceTimersByTimeAsync(200);
         instance.setTargetDoorState(TDS.OPEN);
-        await jest.advanceTimersByTimeAsync(200);
+        expect(device.update).toHaveBeenCalledWith({ '1': true });
+
         instance.setTargetDoorState(TDS.CLOSED);
-        await jest.advanceTimersByTimeAsync(200);
-        instance.setTargetDoorState(TDS.OPEN);
-        await jest.advanceTimersByTimeAsync(200);
-        instance.setTargetDoorState(TDS.CLOSED);
-
-        // Nothing should have fired yet — debounce keeps resetting.
-        expect(device.update).not.toHaveBeenCalled();
-
-        await jest.advanceTimersByTimeAsync(SETTLE_MS);
-        expect(device.update).toHaveBeenNthCalledWith(1, { '2': true });
-
-        emitReset(device, '2');
-        await jest.advanceTimersByTimeAsync(POST_RESET_DELAY_MS);
-        expect(device.update).toHaveBeenNthCalledWith(2, { '3': true });
-        expect(device.update).toHaveBeenCalledTimes(2);
-
-        emitReset(device, '3');
-        await jest.advanceTimersByTimeAsync(0);
-        expect(instance.characteristicCurrentDoorState.value).toBe(CDS.CLOSED);
-        expect(instance.worker).toBeNull();
+        expect(device.update).toHaveBeenCalledWith({ '2': true });
     });
 
-    test('Presses that settle on the current state produce no commands at all', async () => {
+    test('Stop is never fired by a normal open/close', () => {
         const { instance, device } = makeSimpleGarage();
-        instance.currentDoorState = CDS.OPEN;
-
-        instance.setTargetDoorState(TDS.CLOSED);
-        await jest.advanceTimersByTimeAsync(200);
-        instance.setTargetDoorState(TDS.OPEN);
-        await jest.advanceTimersByTimeAsync(200);
-        instance.setTargetDoorState(TDS.CLOSED);
-        await jest.advanceTimersByTimeAsync(200);
-        instance.setTargetDoorState(TDS.OPEN);
-
-        await jest.advanceTimersByTimeAsync(SETTLE_MS);
-        // Final target matches current — no work to do.
-        expect(device.update).not.toHaveBeenCalled();
-        expect(instance.worker).toBeNull();
-    });
-
-    test('Reverting to current while a worker is running suppresses the direction command', async () => {
-        const { instance, device } = makeSimpleGarage();
-        instance.currentDoorState = CDS.OPEN;
-
-        instance.setTargetDoorState(TDS.CLOSED);
-        await jest.advanceTimersByTimeAsync(SETTLE_MS);
-        expect(device.update).toHaveBeenNthCalledWith(1, { '2': true });
-
-        // User reverts mid-stop.
-        instance.setTargetDoorState(TDS.OPEN);
-
-        emitReset(device, '2');
-        await jest.advanceTimersByTimeAsync(POST_RESET_DELAY_MS);
-        // Only stop went out — no direction, because target reverted to OPEN.
-        expect(device.update).toHaveBeenCalledTimes(1);
-        expect(instance.worker).toBeNull();
-        expect(instance.scheduleTimer).toBeNull();
-    });
-
-    test('Pressing the opposite during the direction wait triggers a follow-up cycle after the debounce', async () => {
-        const { instance, device } = makeSimpleGarage();
-        instance.currentDoorState = CDS.OPEN;
-        instance.characteristicCurrentDoorState.value = CDS.OPEN;
-
-        instance.setTargetDoorState(TDS.CLOSED);
-        await jest.advanceTimersByTimeAsync(SETTLE_MS);
-        emitReset(device, '2');
-        await jest.advanceTimersByTimeAsync(POST_RESET_DELAY_MS);
-        expect(device.update).toHaveBeenNthCalledWith(2, { '3': true });
-
-        // User reverses while close is in flight.
-        instance.setTargetDoorState(TDS.OPEN);
-        emitReset(device, '3');
-        await jest.advanceTimersByTimeAsync(0);
-        // Close reset flipped UI to CLOSED. Worker exited, finally queued
-        // another cycle behind the debounce.
-        expect(instance.characteristicCurrentDoorState.value).toBe(CDS.CLOSED);
-        expect(device.update).toHaveBeenCalledTimes(2);
-
-        await jest.advanceTimersByTimeAsync(SETTLE_MS);
-        expect(device.update).toHaveBeenNthCalledWith(3, { '2': true });
-
-        emitReset(device, '2');
-        await jest.advanceTimersByTimeAsync(POST_RESET_DELAY_MS);
-        expect(device.update).toHaveBeenNthCalledWith(4, { '1': true });
-
-        emitReset(device, '1');
-        await jest.advanceTimersByTimeAsync(0);
-        expect(instance.characteristicCurrentDoorState.value).toBe(CDS.OPEN);
-        expect(instance.worker).toBeNull();
-    });
-
-    test('Only one worker is active at a time across rapid toggles', async () => {
-        const { instance, device } = makeSimpleGarage();
-        instance.currentDoorState = CDS.OPEN;
-
-        instance.setTargetDoorState(TDS.CLOSED);
-        await jest.advanceTimersByTimeAsync(SETTLE_MS);
-        const workerA = instance.worker;
-        expect(workerA).not.toBeNull();
 
         instance.setTargetDoorState(TDS.OPEN);
         instance.setTargetDoorState(TDS.CLOSED);
-        expect(instance.worker).toBe(workerA);
 
-        emitReset(device, '2');
-        await jest.advanceTimersByTimeAsync(POST_RESET_DELAY_MS);
-        emitReset(device, '3');
-        await jest.advanceTimersByTimeAsync(0);
-        expect(instance.worker).toBeNull();
-    });
-});
-
-// ---------------------------------------------------------------------------
-// Timeout fallbacks
-// ---------------------------------------------------------------------------
-describe('SimpleGarageDoorAccessory — timeout fallbacks', () => {
-    beforeEach(() => jest.useFakeTimers());
-    afterEach(() => jest.useRealTimers());
-
-    test('Falls back to sending the direction after STOP_RESET_TIMEOUT_MS if no echo arrives', async () => {
-        const { instance, device } = makeSimpleGarage();
-        instance.currentDoorState = CDS.CLOSED;
-
-        instance.setTargetDoorState(TDS.OPEN);
-        await jest.advanceTimersByTimeAsync(SETTLE_MS);
-        expect(device.update).toHaveBeenCalledTimes(1);
-
-        await jest.advanceTimersByTimeAsync(STOP_RESET_TIMEOUT_MS + POST_RESET_DELAY_MS);
-        expect(device.update).toHaveBeenNthCalledWith(2, { '1': true });
-
-        emitReset(device, '1');
-        await jest.advanceTimersByTimeAsync(0);
-        expect(instance.worker).toBeNull();
-    });
-
-    test('Worker exits and force-flips CurrentDoorState after DIRECTION_RESET_TIMEOUT_MS when the echo is missed', async () => {
-        const { instance, device } = makeSimpleGarage();
-        instance.currentDoorState = CDS.CLOSED;
-        instance.characteristicCurrentDoorState.value = CDS.CLOSED;
-
-        instance.setTargetDoorState(TDS.OPEN);
-        await jest.advanceTimersByTimeAsync(SETTLE_MS);
-        emitReset(device, '2');
-        await jest.advanceTimersByTimeAsync(POST_RESET_DELAY_MS);
-        expect(device.update).toHaveBeenNthCalledWith(2, { '1': true });
-
-        await jest.advanceTimersByTimeAsync(DIRECTION_RESET_TIMEOUT_MS);
-        expect(instance.characteristicCurrentDoorState.value).toBe(CDS.OPEN);
-        expect(instance.worker).toBeNull();
+        expect(device.update).not.toHaveBeenCalledWith({ '103': true });
     });
 });
 
@@ -396,18 +233,12 @@ describe('SimpleGarageDoorAccessory — timeout fallbacks', () => {
 // Disconnect handling
 // ---------------------------------------------------------------------------
 describe('SimpleGarageDoorAccessory — disconnected', () => {
-    beforeEach(() => jest.useFakeTimers());
-    afterEach(() => jest.useRealTimers());
-
-    test('Skips writes when the device is disconnected', async () => {
+    test('Skips writes when the device is disconnected', () => {
         const { instance, device } = makeSimpleGarage();
         device.connected = false;
-        instance.currentDoorState = CDS.CLOSED;
 
         instance.setTargetDoorState(TDS.OPEN);
-        await jest.advanceTimersByTimeAsync(
-            SETTLE_MS + STOP_RESET_TIMEOUT_MS + POST_RESET_DELAY_MS + DIRECTION_RESET_TIMEOUT_MS
-        );
+
         expect(device.update).not.toHaveBeenCalled();
     });
 });
@@ -416,400 +247,140 @@ describe('SimpleGarageDoorAccessory — disconnected', () => {
 // Persistence
 // ---------------------------------------------------------------------------
 describe('SimpleGarageDoorAccessory persistence', () => {
-    beforeEach(() => jest.useFakeTimers());
-    afterEach(() => jest.useRealTimers());
-
-    test('Stores the latest target on the accessory context', async () => {
-        const { instance, device, accessory } = makeSimpleGarage();
-        instance.currentDoorState = CDS.OPEN;
-
-        instance.setTargetDoorState(TDS.CLOSED);
-        expect(accessory.context.cachedTargetDoorState).toBe(TDS.CLOSED);
+    test('Stores the latest target on the accessory context', () => {
+        const { instance, accessory } = makeSimpleGarage();
 
         instance.setTargetDoorState(TDS.OPEN);
         expect(accessory.context.cachedTargetDoorState).toBe(TDS.OPEN);
 
-        // Drain so any spawned worker resolves cleanly.
-        await jest.advanceTimersByTimeAsync(SETTLE_MS);
-        if (device.update.mock.calls.length > 0) {
-            emitReset(device, '2');
-            await jest.advanceTimersByTimeAsync(POST_RESET_DELAY_MS);
-        }
+        instance.setTargetDoorState(TDS.CLOSED);
+        expect(accessory.context.cachedTargetDoorState).toBe(TDS.CLOSED);
     });
 });
 
 // ---------------------------------------------------------------------------
-// Partial-open switch
+// Partial open
 // ---------------------------------------------------------------------------
 describe('SimpleGarageDoorAccessory._handlePartialOpen', () => {
     beforeEach(() => jest.useFakeTimers());
     afterEach(() => jest.useRealTimers());
 
-    test('Opens the gate, waits partialOpenMs after current=OPEN, then sends a raw STOP', async () => {
+    test('Fires open, then fires stop after partialOpenMs', () => {
         const { instance, device } = makeSimpleGarage();
         instance.partialOpenMs = 2000;
-        instance.currentDoorState = CDS.CLOSED;
-        instance.characteristicCurrentDoorState.value = CDS.CLOSED;
-        instance.desiredTarget = TDS.CLOSED;
 
         instance._handlePartialOpen();
 
-        // Open cycle is queued through the regular debounce + worker.
-        await jest.advanceTimersByTimeAsync(SETTLE_MS);
-        expect(device.update).toHaveBeenNthCalledWith(1, { '2': true });
-        emitReset(device, '2');
-        await jest.advanceTimersByTimeAsync(POST_RESET_DELAY_MS);
-        expect(device.update).toHaveBeenNthCalledWith(2, { '1': true });
-
-        // Until the open echo lands the stop timer is not scheduled.
-        // (Stay short of DIRECTION_RESET_TIMEOUT_MS so the belt-and-braces
-        // current-state flip doesn't run yet.)
-        await jest.advanceTimersByTimeAsync(1000);
-        expect(device.update).toHaveBeenCalledTimes(2);
-
-        // Open echo flips CurrentDoorState, partial-open flow then starts
-        // its 2 s timer.
-        emitReset(device, '1');
-        await jest.advanceTimersByTimeAsync(0);
-        expect(instance.currentDoorState).toBe(CDS.OPEN);
-
-        await jest.advanceTimersByTimeAsync(2000 - 1);
-        expect(device.update).toHaveBeenCalledTimes(2);
-
-        // Timer fires: raw STOP write goes straight to the device, no queue,
-        // no debounce, no follow-up direction. The stop is re-sent a few
-        // times spread over ~1.2 s to defend against dropped writes.
-        await jest.advanceTimersByTimeAsync(1);
-        expect(device.update).toHaveBeenCalledTimes(3);
-        expect(device.update).toHaveBeenNthCalledWith(3, { '2': true });
-
-        await jest.advanceTimersByTimeAsync(1200);
-        expect(device.update).toHaveBeenCalledTimes(6);
-        expect(device.update).toHaveBeenNthCalledWith(4, { '2': true });
-        expect(device.update).toHaveBeenNthCalledWith(5, { '2': true });
-        expect(device.update).toHaveBeenNthCalledWith(6, { '2': true });
-
-        await jest.advanceTimersByTimeAsync(10_000);
-        expect(device.update).toHaveBeenCalledTimes(6);
-        // Gate is now partially open — CurrentDoorState stays OPEN.
-        expect(instance.currentDoorState).toBe(CDS.OPEN);
-    });
-
-    test('Sends only the raw STOP if the gate is already OPEN', async () => {
-        const { instance, device } = makeSimpleGarage();
-        instance.partialOpenMs = 2000;
-        instance.currentDoorState = CDS.OPEN;
-
-        instance._handlePartialOpen();
-
-        await jest.advanceTimersByTimeAsync(0);
-        // No open cycle needed — desiredTarget==current already.
-        expect(device.update).not.toHaveBeenCalled();
-
-        await jest.advanceTimersByTimeAsync(2000);
-        // Four stop sends spread over ~1.2 s; first one fires immediately at
-        // partialOpenMs.
+        // Open goes out immediately.
         expect(device.update).toHaveBeenCalledTimes(1);
-        expect(device.update).toHaveBeenNthCalledWith(1, { '2': true });
-        await jest.advanceTimersByTimeAsync(1200);
-        expect(device.update).toHaveBeenCalledTimes(4);
-    });
+        expect(device.update).toHaveBeenNthCalledWith(1, { '101': true });
+        expect(instance.characteristicTargetDoorState.value).toBe(TDS.OPEN);
 
-    test('Pressing partial again while the stop timer is armed is ignored (idempotent)', async () => {
-        // HomeKit/iOS retransmit a WRITE if the 204 response is delayed or
-        // dropped, which fires onSet again. The retry must not cancel the
-        // armed stop and push it out — otherwise repeated retries can
-        // delay the auto-stop indefinitely and the gate runs all the way
-        // open. The retry should be ignored; the original timer fires at
-        // its original deadline.
-        const { instance, device } = makeSimpleGarage();
-        instance.partialOpenMs = 2000;
-        instance.currentDoorState = CDS.OPEN;
+        // Nothing happens until the timer elapses.
+        jest.advanceTimersByTime(2000 - 1);
+        expect(device.update).toHaveBeenCalledTimes(1);
 
-        instance._handlePartialOpen();
-        await jest.advanceTimersByTimeAsync(0);
+        // Then a single stop is fired.
+        jest.advanceTimersByTime(1);
+        expect(device.update).toHaveBeenCalledTimes(2);
+        expect(device.update).toHaveBeenNthCalledWith(2, { '103': true });
 
-        await jest.advanceTimersByTimeAsync(1500);
-        // 1.5 s in, retry — should be ignored.
-        instance._handlePartialOpen();
-        await jest.advanceTimersByTimeAsync(0);
-        expect(device.update).not.toHaveBeenCalled();
-
-        // Original timer fires at the original 2000 ms deadline.
-        await jest.advanceTimersByTimeAsync(499);
-        expect(device.update).not.toHaveBeenCalled();
-
-        await jest.advanceTimersByTimeAsync(1);
-        expect(device.update).toHaveBeenNthCalledWith(1, { '2': true });
-    });
-
-    test('Pressing partial again while the open wait is pending is ignored (idempotent)', async () => {
-        const { instance, device } = makeSimpleGarage();
-        instance.partialOpenMs = 2000;
-        instance.currentDoorState = CDS.CLOSED;
-        instance.characteristicCurrentDoorState.value = CDS.CLOSED;
-        instance.desiredTarget = TDS.CLOSED;
-
-        instance._handlePartialOpen();
-        await jest.advanceTimersByTimeAsync(SETTLE_MS);
-        expect(device.update).toHaveBeenNthCalledWith(1, { '2': true });
-
-        // Retry lands while we're still waiting for the stop reset / open
-        // echo. The retry should not bump the generation token or restart
-        // anything — the original flow should complete normally.
-        const idBefore = instance.partialOpenId;
-        instance._handlePartialOpen();
-        expect(instance.partialOpenId).toBe(idBefore);
-
-        emitReset(device, '2');
-        await jest.advanceTimersByTimeAsync(POST_RESET_DELAY_MS);
-        emitReset(device, '1');
-        await jest.advanceTimersByTimeAsync(0);
-
-        await jest.advanceTimersByTimeAsync(2000);
-        expect(device.update).toHaveBeenNthCalledWith(3, { '2': true });
-    });
-
-    test('A same-value setTargetDoorState while the partial stop is armed does not cancel it', async () => {
-        // HomeKit / iOS Home may write TargetDoorState=OPEN back to the
-        // accessory after observing CurrentDoorState flip to OPEN (a
-        // resync). desiredTarget is already OPEN from the partial flow's
-        // own _setTarget, so this is a no-op write — but the public
-        // setTargetDoorState path would still cancel the armed partial
-        // stop and the auto-stop would never fire, leaving the gate to
-        // run all the way open. The no-op write should be ignored.
-        const { instance, device } = makeSimpleGarage();
-        instance.partialOpenMs = 2000;
-        instance.currentDoorState = CDS.CLOSED;
-        instance.characteristicCurrentDoorState.value = CDS.CLOSED;
-        instance.desiredTarget = TDS.CLOSED;
-
-        instance._handlePartialOpen();
-        await jest.advanceTimersByTimeAsync(SETTLE_MS);
-        emitReset(device, '2');
-        await jest.advanceTimersByTimeAsync(POST_RESET_DELAY_MS);
-        emitReset(device, '1');
-        await jest.advanceTimersByTimeAsync(0);
-        expect(instance.partialStopTimer).not.toBeNull();
-
-        // Simulate the HomeKit-side resync write.
-        instance.setTargetDoorState(TDS.OPEN);
-        expect(instance.partialStopTimer).not.toBeNull();
-
-        await jest.advanceTimersByTimeAsync(2000);
-        expect(device.update).toHaveBeenNthCalledWith(3, { '2': true });
-    });
-
-    test('A same-value setTargetDoorState during the open wait does not supersede the partial flow', async () => {
-        const { instance, device } = makeSimpleGarage();
-        instance.partialOpenMs = 2000;
-        instance.currentDoorState = CDS.CLOSED;
-        instance.characteristicCurrentDoorState.value = CDS.CLOSED;
-        instance.desiredTarget = TDS.CLOSED;
-
-        instance._handlePartialOpen();
-        await jest.advanceTimersByTimeAsync(SETTLE_MS);
-        expect(device.update).toHaveBeenNthCalledWith(1, { '2': true });
-
-        // HomeKit pushes a TargetDoorState=OPEN write mid-cycle. The partial
-        // flow's _setTarget already set desiredTarget=OPEN, so this is
-        // redundant — it should not disturb the in-flight partial.
-        const idBefore = instance.partialOpenId;
-        instance.setTargetDoorState(TDS.OPEN);
-        expect(instance.partialOpenId).toBe(idBefore);
-        expect(instance._partialPending).toBe(true);
-
-        emitReset(device, '2');
-        await jest.advanceTimersByTimeAsync(POST_RESET_DELAY_MS);
-        emitReset(device, '1');
-        await jest.advanceTimersByTimeAsync(0);
-
-        await jest.advanceTimersByTimeAsync(2000);
-        expect(device.update).toHaveBeenNthCalledWith(3, { '2': true });
-    });
-
-    test('External setTargetDoorState with a different target cancels the armed auto-stop', async () => {
-        const { instance, device } = makeSimpleGarage();
-        instance.partialOpenMs = 2000;
-        instance.currentDoorState = CDS.CLOSED;
-        instance.characteristicCurrentDoorState.value = CDS.CLOSED;
-        instance.desiredTarget = TDS.CLOSED;
-
-        instance._handlePartialOpen();
-
-        // Run the open cycle.
-        await jest.advanceTimersByTimeAsync(SETTLE_MS);
-        emitReset(device, '2');
-        await jest.advanceTimersByTimeAsync(POST_RESET_DELAY_MS);
-        emitReset(device, '1');
-        await jest.advanceTimersByTimeAsync(0);
-        expect(instance.currentDoorState).toBe(CDS.OPEN);
-        expect(instance.partialStopTimer).not.toBeNull();
-
-        // Stop timer is now armed (fires in 2 s). User toggles to a real
-        // different target (CLOSED) — auto-stop should be cancelled.
-        await jest.advanceTimersByTimeAsync(500);
-        instance.setTargetDoorState(TDS.CLOSED);
+        // And nothing more after that.
+        jest.advanceTimersByTime(10_000);
+        expect(device.update).toHaveBeenCalledTimes(2);
         expect(instance.partialStopTimer).toBeNull();
     });
 
-    test('External setTargetDoorState with a different target during the open wait supersedes the partial flow', async () => {
+    test('Re-entrant press while armed is ignored (idempotent)', () => {
         const { instance, device } = makeSimpleGarage();
         instance.partialOpenMs = 2000;
-        instance.currentDoorState = CDS.CLOSED;
-        instance.characteristicCurrentDoorState.value = CDS.CLOSED;
-        instance.desiredTarget = TDS.CLOSED;
 
         instance._handlePartialOpen();
-        await jest.advanceTimersByTimeAsync(SETTLE_MS);
-        emitReset(device, '2');
-        await jest.advanceTimersByTimeAsync(POST_RESET_DELAY_MS);
-        emitReset(device, '1');
-        // Before the loop notices and arms the stop timer, the user toggles
-        // to a real different target (CLOSED — the partial intended OPEN).
-        instance.setTargetDoorState(TDS.CLOSED);
-        await jest.advanceTimersByTimeAsync(0);
+        expect(device.update).toHaveBeenCalledTimes(1);
 
-        // partialOpenId got bumped — the partial flow's wait returns silently.
-        expect(instance.partialStopTimer).toBeNull();
+        // A retransmit 1.5s in must not re-open or push the stop out.
+        jest.advanceTimersByTime(1500);
+        instance._handlePartialOpen();
+        expect(device.update).toHaveBeenCalledTimes(1);
+
+        // Original timer still fires at its original 2000ms deadline.
+        jest.advanceTimersByTime(499);
+        expect(device.update).toHaveBeenCalledTimes(1);
+        jest.advanceTimersByTime(1);
+        expect(device.update).toHaveBeenNthCalledWith(2, { '103': true });
     });
 
-    test('Does nothing when partialOpenMs is not configured', async () => {
+    test('A direct open/close cancels the armed auto-stop', () => {
+        const { instance, device } = makeSimpleGarage();
+        instance.partialOpenMs = 2000;
+
+        instance._handlePartialOpen();
+        expect(instance.partialStopTimer).not.toBeNull();
+
+        // User takes manual control before the auto-stop fires.
+        jest.advanceTimersByTime(500);
+        instance.setTargetDoorState(TDS.CLOSED);
+        expect(instance.partialStopTimer).toBeNull();
+        expect(device.update).toHaveBeenLastCalledWith({ '102': true });
+
+        // The stop must never fire now.
+        jest.advanceTimersByTime(5000);
+        expect(device.update).not.toHaveBeenCalledWith({ '103': true });
+    });
+
+    test('Does nothing when partialOpenMs is not configured', () => {
         const { instance, device } = makeSimpleGarage();
         instance.partialOpenMs = 0;
-        instance.currentDoorState = CDS.OPEN;
 
         instance._handlePartialOpen();
-        await jest.advanceTimersByTimeAsync(10_000);
+        jest.advanceTimersByTime(10_000);
 
         expect(device.update).not.toHaveBeenCalled();
         expect(instance.partialStopTimer).toBeNull();
-    });
-});
-
-// ---------------------------------------------------------------------------
-// Force open/close switches (just verify they route through setTargetDoorState
-// — the queue/debounce behaviour is already covered by the earlier suites)
-// ---------------------------------------------------------------------------
-describe('SimpleGarageDoorAccessory — force switches', () => {
-    beforeEach(() => jest.useFakeTimers());
-    afterEach(() => jest.useRealTimers());
-
-    test('Force Open routes through the public setTargetDoorState path', async () => {
-        const { instance, device, accessory } = makeSimpleGarage();
-        instance.currentDoorState = CDS.CLOSED;
-        instance.characteristicCurrentDoorState.value = CDS.CLOSED;
-        instance.desiredTarget = TDS.CLOSED;
-
-        instance.setTargetDoorState(TDS.OPEN);
-        expect(accessory.context.cachedTargetDoorState).toBe(TDS.OPEN);
-        expect(instance.desiredTarget).toBe(TDS.OPEN);
-
-        await jest.advanceTimersByTimeAsync(SETTLE_MS);
-        expect(device.update).toHaveBeenNthCalledWith(1, { '2': true });
-        emitReset(device, '2');
-        await jest.advanceTimersByTimeAsync(POST_RESET_DELAY_MS);
-        expect(device.update).toHaveBeenNthCalledWith(2, { '1': true });
-        emitReset(device, '1');
-        await jest.advanceTimersByTimeAsync(0);
-        expect(instance.currentDoorState).toBe(CDS.OPEN);
-    });
-
-    test('Force Close routes through the public setTargetDoorState path', async () => {
-        const { instance, device, accessory } = makeSimpleGarage();
-        instance.currentDoorState = CDS.OPEN;
-
-        instance.setTargetDoorState(TDS.CLOSED);
-        expect(accessory.context.cachedTargetDoorState).toBe(TDS.CLOSED);
-
-        await jest.advanceTimersByTimeAsync(SETTLE_MS);
-        emitReset(device, '2');
-        await jest.advanceTimersByTimeAsync(POST_RESET_DELAY_MS);
-        expect(device.update).toHaveBeenNthCalledWith(2, { '3': true });
-        emitReset(device, '3');
-        await jest.advanceTimersByTimeAsync(0);
-        expect(instance.currentDoorState).toBe(CDS.CLOSED);
-    });
-
-    test('A force action with a different target cancels the in-flight partial', async () => {
-        const { instance, device } = makeSimpleGarage();
-        instance.partialOpenMs = 2000;
-        instance.currentDoorState = CDS.OPEN;
-        instance.characteristicCurrentDoorState.value = CDS.OPEN;
-
-        // Partial press while already open: just schedules the stop timer.
-        instance._handlePartialOpen();
-        await jest.advanceTimersByTimeAsync(0);
-        expect(instance.partialStopTimer).not.toBeNull();
-
-        // Force Close pressed before the auto-stop fires. The different
-        // target indicates a real user override — cancel the partial.
-        instance.setTargetDoorState(TDS.CLOSED);
-        expect(instance.partialStopTimer).toBeNull();
-
-        // The new target (CLOSED) is acted on through the regular queue.
-        await jest.advanceTimersByTimeAsync(SETTLE_MS);
-        expect(device.update).toHaveBeenNthCalledWith(1, { '2': true });
     });
 });
 
 // ---------------------------------------------------------------------------
 // Partial-open switch is stateful: mirrors CurrentDoorState (ON when the gate
-// is open) and toggling it OFF triggers a standard close cycle.
+// is open) via the status DP.
 // ---------------------------------------------------------------------------
 describe('SimpleGarageDoorAccessory — partial-open switch state', () => {
-    beforeEach(() => jest.useFakeTimers());
-    afterEach(() => jest.useRealTimers());
-
-    test('_setCurrentDoorState mirrors OPEN/CLOSED to the switch', () => {
+    test('Reported OPEN/CLOSED is mirrored onto the switch', () => {
         const { instance } = makeSimpleGarage();
         instance.partialOpenMs = 2000;
-        instance.currentDoorState = CDS.CLOSED;
         instance.characteristicPartialOpen.value = false;
 
-        instance._setCurrentDoorState(CDS.OPEN);
+        instance._onDeviceChange({ '105': STATE_OPENING_OR_OPEN });
         expect(instance.characteristicPartialOpen.value).toBe(true);
 
-        instance._setCurrentDoorState(CDS.CLOSED);
+        instance._onDeviceChange({ '105': STATE_CLOSING_OR_CLOSED });
         expect(instance.characteristicPartialOpen.value).toBe(false);
-    });
 
-    test('After the partial open cycle the switch reads ON', async () => {
-        const { instance, device } = makeSimpleGarage();
-        instance.partialOpenMs = 2000;
-        instance.currentDoorState = CDS.CLOSED;
-        instance.characteristicCurrentDoorState.value = CDS.CLOSED;
-        instance.characteristicPartialOpen.value = false;
-        instance.desiredTarget = TDS.CLOSED;
-
-        instance._handlePartialOpen();
-        await jest.advanceTimersByTimeAsync(SETTLE_MS);
-        emitReset(device, '2');
-        await jest.advanceTimersByTimeAsync(POST_RESET_DELAY_MS);
-        emitReset(device, '1');
-        await jest.advanceTimersByTimeAsync(0);
-
-        expect(instance.currentDoorState).toBe(CDS.OPEN);
+        // A stop mid-travel (state 11) leaves the gate parked open.
+        instance._onDeviceChange({ '105': STATE_STOPPED });
         expect(instance.characteristicPartialOpen.value).toBe(true);
     });
+});
 
-    test('A subsequent close cycle flips the switch back to OFF', async () => {
-        const { instance, device } = makeSimpleGarage();
-        instance.partialOpenMs = 2000;
-        instance.currentDoorState = CDS.OPEN;
-        instance.characteristicCurrentDoorState.value = CDS.OPEN;
-        instance.characteristicPartialOpen.value = true;
+// ---------------------------------------------------------------------------
+// Force open/close switches route through setTargetDoorState
+// ---------------------------------------------------------------------------
+describe('SimpleGarageDoorAccessory — force switches', () => {
+    test('Force Open fires the open action', () => {
+        const { instance, device, accessory } = makeSimpleGarage();
 
-        // Simulate the user tapping the switch OFF — close cycle queued.
+        instance.setTargetDoorState(TDS.OPEN);
+
+        expect(device.update).toHaveBeenCalledWith({ '101': true });
+        expect(accessory.context.cachedTargetDoorState).toBe(TDS.OPEN);
+    });
+
+    test('Force Close fires the close action', () => {
+        const { instance, device, accessory } = makeSimpleGarage();
+
         instance.setTargetDoorState(TDS.CLOSED);
-        await jest.advanceTimersByTimeAsync(SETTLE_MS);
-        emitReset(device, '2');
-        await jest.advanceTimersByTimeAsync(POST_RESET_DELAY_MS);
-        expect(device.update).toHaveBeenNthCalledWith(2, { '3': true });
-        emitReset(device, '3');
-        await jest.advanceTimersByTimeAsync(0);
 
-        expect(instance.currentDoorState).toBe(CDS.CLOSED);
-        expect(instance.characteristicPartialOpen.value).toBe(false);
+        expect(device.update).toHaveBeenCalledWith({ '102': true });
+        expect(accessory.context.cachedTargetDoorState).toBe(TDS.CLOSED);
     });
 });

--- a/wiki/Supported-Device-Types.md
+++ b/wiki/Supported-Device-Types.md
@@ -18,7 +18,7 @@ If you are looking for verified configurations for your specific device, please 
 |WLED Dimmer|`WledDimmer` (or legacy `SimpleDimmer`)<sup>[8](#simple-dimmers)</sup>|Dimmer switches with power control, with optional WLED sync <small>([instructions](#simple-dimmers))</small>|
 |Simple Heater|`SimpleHeater`<sup>[9](#simple-heaters)</sup>|Heating solutions with only temperature control <small>([instructions](#simple-heaters))</small>|
 |Garage Door|`GarageDoor`<sup>[10](#garage-doors)</sup>|Smart garage doors or garage door openers <small>([instructions](#garage-doors))</small>|
-|Simple Garage Door|`SimpleGarageDoor`<sup>[10](#simple-garage-doors)</sup>|Garage doors and sliding gate openers that expose only three momentary action DPs: open, stop, close <small>([instructions](#simple-garage-doors))</small>|
+|Simple Garage Door|`SimpleGarageDoor`<sup>[10](#simple-garage-doors)</sup>|Sliding gate openers and garage door controllers with open/stop/close action DPs and a simple three-value status DP <small>([instructions](#simple-garage-doors))</small>|
 |Simple Blinds|`SimpleBlinds`<sup>[11](#simple-blinds)</sup>|Smart blinds and smart switches that control blinds <small>([instructions](#simple-blinds))</small>|
 |Simple Blinds2|`SimpleBlinds2`<sup>[11](#simple-blinds)</sup>|Smart blinds and smart switches that control blinds(Use if simple Blinds (1) doesn't work for you. <small>([instructions](#simple-blinds))</small>|
 |Vertical Blinds with Tilt|`VerticalBlindsWithTilt`<sup>[11](#vertical-blinds-with-tilt)</sup>|Smart vertical blinds with open/close and panel rotation <small>([instructions](#vertical-blinds-with-tilt))</small>|
@@ -419,7 +419,18 @@ While still in early testing, you can use this to open and close the garage door
 ```
 
 ### Simple Garage Doors
-For very basic garage door openers and sliding gate controllers that expose only three momentary action DPs — one to open, one to stop, one to close — with no position or status feedback. The plugin tracks the target state locally and persists it across restarts, so HomeKit always reflects whatever was last requested. Triggering a change sends the stop command first (so reversing direction mid-motion works; it is a no-op when the gate is idle) and then the open or close command. There is no obstruction detection.
+For sliding gate openers and garage door controllers that expose momentary
+open/stop/close action DPs plus a single status DP that reports the gate's
+movement. The controller only distinguishes three states — `11` (stopped),
+`12` (opening or open) and `13` (closing or closed) — so the plugin collapses
+them for HomeKit: `11`/`12` are treated as **OPEN** and `13` as **CLOSED**.
+Both the current and target door state are mirrored straight from this DP, so
+HomeKit stays in sync however the gate was operated (Home app, a physical
+remote, the Tuya app, ...).
+
+A HomeKit toggle simply fires the matching action — the controller reverses
+direction on its own, so no stop-first command is needed. There is no
+obstruction detection.
 
 ```json5
 {
@@ -433,28 +444,33 @@ For very basic garage door openers and sliding gate controllers that expose only
     /* Additional parameters to override defaults only if needed */
 
     /* Override the default datapoint identifier for the open action */
-    "dpOpen": 1,
-
-    /* Override the default datapoint identifier for the stop action */
-    "dpStop": 2,
+    "dpOpen": 101,
 
     /* Override the default datapoint identifier for the close action */
-    "dpClose": 3,
+    "dpClose": 102,
+
+    /* Override the default datapoint identifier for the stop action
+       (only used by the partial-open feature) */
+    "dpStop": 103,
+
+    /* Override the default datapoint identifier for the reported state.
+       11 (stopped) and 12 (opening/open) are treated as OPEN; 13
+       (closing/closed) is treated as CLOSED. */
+    "dpState": 105,
 
     /* Optional. If set, exposes an extra stateful switch that mirrors
        whether the gate is currently open in HomeKit's view. Tapping it
        ON triggers a partial-open: the gate opens and then stops itself
-       this many milliseconds after the device acknowledges the open,
-       leaving the gate partially open. Tapping it OFF triggers a
-       standard full close. Useful for letting someone pass through
-       briefly. Leave unset to skip the switch. */
+       this many milliseconds later, leaving the gate partially open.
+       Tapping it OFF triggers a standard full close. Useful for letting
+       someone pass through briefly. Leave unset to skip the switch. */
     "partialOpenMs": 2000,
 
     /* Optional. Exposes extra Force Open and Force Close momentary
-       switches alongside the main GarageDoorOpener. They drive the gate
-       through the same queue as the main toggle, but being plain
-       switches they can be used in HomeKit automations (which won't
-       accept GarageDoorOpener targets directly). Default false. */
+       switches alongside the main GarageDoorOpener. They fire the same
+       open/close actions as the main toggle, but being plain switches
+       they can be used in HomeKit automations (which won't accept
+       GarageDoorOpener targets directly). Default false. */
     "forceSwitches": true
 }
 ```


### PR DESCRIPTION
## Context

`SimpleGarageDoor` was added for my own use, and I'm its only user — so although this rewrite changes the type's behavior and default DPs, I don't expect it to break anything for anyone else.

## Summary

The newer Tuya gate controller (e.g. model `e1myzdww`) reports its movement on a status DP and reverses direction on its own, so the old stop-first dance and locally-guessed state are no longer needed. This rewrites the `SimpleGarageDoor` accessory around that controller.

- **A HomeKit toggle now just fires the matching open/close action** — no stop-first command, since the controller reverses direction itself even while moving.
- **`CurrentDoorState` and `TargetDoorState` are both mirrored from the status DP** (`11`/`12` → OPEN, `13` → CLOSED). Driving the target from the DP too keeps HomeKit in sync when the gate is operated outside HomeKit (physical remote, Tuya app, ...).
- **`partialOpenMs`** fires the open action and then a single stop after the configured delay; a direct open/close cancels a pending auto-stop so it can't halt a real movement.
- Defaults updated to the new controller's DPs (open `101`, close `102`, stop `103`) and a new configurable **`dpState`** (`105`) was added.

The Partial Open and Force Open/Close switches are preserved.

## Notes

The controller only distinguishes three states, so `12` covers both "opening" and "open" (and `13` both "closing" and "closed"). HomeKit therefore shows the gate as fully Open/Closed the moment it starts moving in that direction rather than a live "Opening…/Closing…" — an inherent limit of the 3-value status DP.

## Testing

Rewrote the unit tests (21 passing) covering state mapping (incl. string coercion and unknown-value ignore), fire-the-action behavior, no-stop-first, partial open + auto-stop cancellation/idempotency, disconnect, persistence, and switch state mirroring. Refreshed the config schema and wiki docs to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tujhvzr6VSH5qsmcPFy4JU