### PR TITLE
SimpleGarageDoor: stop-before-close for the asymmetric controller

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -579,6 +579,14 @@
                 "functionBody": "return model.devices && model.devices[arrayIndices] && ['SimpleGarageDoor'].includes(model.devices[arrayIndices].type);"
               }
             },
+            "stopBeforeCloseMs": {
+              "type": "integer",
+              "placeholder": "1500",
+              "description": "Optional. The controller ignores a close command while the gate is actively moving, so unless the state DP already reads 11 (stopped) the plugin sends stop, waits this many milliseconds, then sends close. Tune to roughly how long the gate takes to halt after a stop. Default 1500.",
+              "condition": {
+                "functionBody": "return model.devices && model.devices[arrayIndices] && ['SimpleGarageDoor'].includes(model.devices[arrayIndices].type);"
+              }
+            },
             "partialOpenMs": {
               "type": "integer",
               "placeholder": "2000",

--- a/lib/SimpleGarageDoorAccessory.js
+++ b/lib/SimpleGarageDoorAccessory.js
@@ -13,13 +13,20 @@ const BaseAccessory = require('./BaseAccessory');
 // sync no matter how the gate was triggered (Home app, a physical remote, the
 // Tuya app, ...).
 //
-// Unlike the original open/stop/close-only gates, this controller switches
-// direction on its own — sending open while it is closing (or vice versa)
-// just reverses it — so there is no stop-first dance: a HomeKit toggle simply
-// fires the matching action.
+// Opening is symmetric and forgiving: the controller reverses on its own, so
+// an open command works directly even while the gate is closing — we just fire
+// it. Closing is asymmetric, though: the controller IGNORES a close command
+// while the gate is actively moving. The one exception is when the status DP
+// reads exactly 11 (stopped) — e.g. after a partial-open or an external stop —
+// where the gate is idle and accepts close immediately. So unless we can see
+// it's already stopped, a close is sent as stop -> wait -> close.
 const STATE_STOPPED = 11;
 const STATE_OPENING_OR_OPEN = 12;
 const STATE_CLOSING_OR_CLOSED = 13;
+
+// How long to wait between the stop and the close in the stop-before-close
+// path. Overridable per-device via the `stopBeforeCloseMs` config option.
+const DEFAULT_STOP_BEFORE_CLOSE_MS = 1500;
 
 class SimpleGarageDoorAccessory extends BaseAccessory {
     static getCategory(Categories) {
@@ -82,8 +89,15 @@ class SimpleGarageDoorAccessory extends BaseAccessory {
         const partialOpenMs = parseInt(this.device.context.partialOpenMs, 10);
         this.partialOpenMs = Number.isFinite(partialOpenMs) && partialOpenMs > 0 ? partialOpenMs : 0;
 
-        // The only pending side effect we track is the partial-open auto-stop.
+        const stopBeforeCloseMs = parseInt(this.device.context.stopBeforeCloseMs, 10);
+        this.stopBeforeCloseMs = Number.isFinite(stopBeforeCloseMs) && stopBeforeCloseMs >= 0
+            ? stopBeforeCloseMs
+            : DEFAULT_STOP_BEFORE_CLOSE_MS;
+
+        // Pending side effects we may need to cancel: the partial-open auto-stop
+        // and the close that trails a stop in the stop-before-close path.
         this.partialStopTimer = null;
+        this.pendingCloseTimer = null;
 
         // Seed the initial state from whatever the device has already reported.
         // If it hasn't reported yet, fall back to the persisted target, then to
@@ -177,6 +191,10 @@ class SimpleGarageDoorAccessory extends BaseAccessory {
 
     _onDeviceChange(changes) {
         if (!changes || !changes.hasOwnProperty(this.dpState)) return;
+        // Mid stop-before-close: the stop we just issued can briefly report 11
+        // (=OPEN), which would fight the close we're about to send. Ignore
+        // status reports until the close has gone out.
+        if (this.pendingCloseTimer) return;
         const isOpen = this._mapDpState(changes[this.dpState]);
         if (isOpen === null) {
             this.log.info(`[SimpleGarageDoor] ${this.device.context.name}: ignoring unknown state DP value ${JSON.stringify(changes[this.dpState])}`);
@@ -228,9 +246,56 @@ class SimpleGarageDoorAccessory extends BaseAccessory {
         const open = value === Characteristic.TargetDoorState.OPEN;
         this.accessory.context.cachedTargetDoorState = value;
         if (this.characteristicTargetDoorState) this.characteristicTargetDoorState.updateValue(value);
-        const dp = open ? this.dpOpen : this.dpClose;
-        this.log.info(`[SimpleGarageDoor] ${this.device.context.name}: ${open ? 'open' : 'close'} (dp${dp})`);
-        this.setMultiStateLegacyAsync({[dp]: true});
+        if (open) this._sendOpen();
+        else this._sendClose();
+    }
+
+    // Open is always safe to fire directly — the controller reverses on its
+    // own, even mid-close. Abandon any pending stop-before-close.
+    _sendOpen() {
+        this._cancelPendingClose();
+        this.log.info(`[SimpleGarageDoor] ${this.device.context.name}: open (dp${this.dpOpen})`);
+        this.setMultiStateLegacyAsync({[this.dpOpen]: true});
+    }
+
+    // Close is ignored while the gate is actively moving, so fire it directly
+    // only when the status DP shows the gate is already stopped (11). Otherwise
+    // stop first, wait stopBeforeCloseMs, then close.
+    _sendClose() {
+        const name = this.device.context.name;
+        if (this.pendingCloseTimer) {
+            // A stop-before-close is already running — don't restart it (and
+            // push the close out) on a duplicate or retransmitted request.
+            this.log.info(`[SimpleGarageDoor] ${name}: close ignored — a stop-before-close is already running`);
+            return;
+        }
+        if (this._isStopped()) {
+            this.log.info(`[SimpleGarageDoor] ${name}: close (dp${this.dpClose}) — gate already stopped`);
+            this.setMultiStateLegacyAsync({[this.dpClose]: true});
+            return;
+        }
+        this.log.info(`[SimpleGarageDoor] ${name}: stop-before-close — stop (dp${this.dpStop}) now, close (dp${this.dpClose}) in ${this.stopBeforeCloseMs}ms`);
+        this.setMultiStateLegacyAsync({[this.dpStop]: true});
+        this.pendingCloseTimer = setTimeout(() => {
+            this.pendingCloseTimer = null;
+            this.log.info(`[SimpleGarageDoor] ${name}: stop-before-close — firing close (dp${this.dpClose})`);
+            this.setMultiStateLegacyAsync({[this.dpClose]: true});
+        }, this.stopBeforeCloseMs);
+    }
+
+    // True only when the controller reports the gate is stopped (11) — the one
+    // state where it will accept a close without a stop first.
+    _isStopped() {
+        const raw = this.device.state ? this.device.state[this.dpState] : undefined;
+        const value = typeof raw === 'string' ? parseInt(raw, 10) : raw;
+        return value === STATE_STOPPED;
+    }
+
+    _cancelPendingClose() {
+        if (this.pendingCloseTimer) {
+            clearTimeout(this.pendingCloseTimer);
+            this.pendingCloseTimer = null;
+        }
     }
 
     // Partial open: fire the open action, then after partialOpenMs fire a stop

--- a/test/SimpleGarageDoorAccessory.test.js
+++ b/test/SimpleGarageDoorAccessory.test.js
@@ -49,7 +49,9 @@ function makeSimpleGarage(initialContext = {}) {
     instance.dpStop = '103';
     instance.dpState = '105';
     instance.partialOpenMs = 0;
+    instance.stopBeforeCloseMs = 1500;
     instance.partialStopTimer = null;
+    instance.pendingCloseTimer = null;
     instance.currentDoorState = CDS.CLOSED;
     instance.characteristicCurrentDoorState = {
         value: CDS.CLOSED,
@@ -77,7 +79,7 @@ function emitState(device, value) {
 }
 
 // ---------------------------------------------------------------------------
-// State DP -> door state mapping (the heart of the new behaviour)
+// State DP -> door state mapping
 // ---------------------------------------------------------------------------
 describe('SimpleGarageDoorAccessory._onDeviceChange', () => {
     test('State 12 (opening/open) drives Current and Target to OPEN', () => {
@@ -165,39 +167,37 @@ describe('SimpleGarageDoorAccessory._onDeviceChange', () => {
 });
 
 // ---------------------------------------------------------------------------
-// setTargetDoorState — fires the matching action, no stop-first dance
+// Open — always fired directly, even mid-motion
 // ---------------------------------------------------------------------------
-describe('SimpleGarageDoorAccessory.setTargetDoorState', () => {
-    test('OPEN fires the open action immediately (no stop first)', () => {
-        const { instance, device, accessory } = makeSimpleGarage();
+describe('SimpleGarageDoorAccessory.setTargetDoorState — open', () => {
+    test('OPEN fires the open action immediately, even while the gate is closing', () => {
+        const { instance, device } = makeSimpleGarage();
+        device.state['105'] = STATE_CLOSING_OR_CLOSED;
 
         instance.setTargetDoorState(TDS.OPEN);
 
         expect(device.update).toHaveBeenCalledTimes(1);
         expect(device.update).toHaveBeenCalledWith({ '101': true });
-        expect(accessory.context.cachedTargetDoorState).toBe(TDS.OPEN);
-        expect(instance.characteristicTargetDoorState.value).toBe(TDS.OPEN);
     });
 
-    test('CLOSE fires the close action immediately (no stop first)', () => {
-        const { instance, device, accessory } = makeSimpleGarage();
-        instance.currentDoorState = CDS.OPEN;
-
-        instance.setTargetDoorState(TDS.CLOSED);
-
-        expect(device.update).toHaveBeenCalledTimes(1);
-        expect(device.update).toHaveBeenCalledWith({ '102': true });
-        expect(accessory.context.cachedTargetDoorState).toBe(TDS.CLOSED);
-        expect(instance.characteristicTargetDoorState.value).toBe(TDS.CLOSED);
-    });
-
-    test('CurrentDoorState is not touched until the device reports it', () => {
+    test('OPEN never fires a stop first', () => {
         const { instance, device } = makeSimpleGarage();
+        device.state['105'] = STATE_OPENING_OR_OPEN;
+
+        instance.setTargetDoorState(TDS.OPEN);
+
+        expect(device.update).not.toHaveBeenCalledWith({ '103': true });
+        expect(device.update).toHaveBeenCalledWith({ '101': true });
+    });
+
+    test('Target + persistence update optimistically; Current waits for the DP', () => {
+        const { instance, device, accessory } = makeSimpleGarage();
         instance.currentDoorState = CDS.CLOSED;
         instance.characteristicCurrentDoorState.value = CDS.CLOSED;
 
         instance.setTargetDoorState(TDS.OPEN);
-        // Target updated, but Current waits for the status DP.
+        expect(accessory.context.cachedTargetDoorState).toBe(TDS.OPEN);
+        expect(instance.characteristicTargetDoorState.value).toBe(TDS.OPEN);
         expect(instance.characteristicCurrentDoorState.updateValue).not.toHaveBeenCalled();
         expect(instance.currentDoorState).toBe(CDS.CLOSED);
 
@@ -207,25 +207,165 @@ describe('SimpleGarageDoorAccessory.setTargetDoorState', () => {
         expect(instance.characteristicCurrentDoorState.value).toBe(CDS.OPEN);
     });
 
-    test('Custom DPs are respected', () => {
+    test('Custom open DP is respected', () => {
         const { instance, device } = makeSimpleGarage();
         instance.dpOpen = '1';
-        instance.dpClose = '2';
 
         instance.setTargetDoorState(TDS.OPEN);
+
         expect(device.update).toHaveBeenCalledWith({ '1': true });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Close — direct only when already stopped (state 11), otherwise stop-first
+// ---------------------------------------------------------------------------
+describe('SimpleGarageDoorAccessory.setTargetDoorState — close (stop-before-close)', () => {
+    beforeEach(() => jest.useFakeTimers());
+    afterEach(() => jest.useRealTimers());
+
+    test('CLOSE fires immediately when the gate is already stopped (state 11)', () => {
+        const { instance, device, accessory } = makeSimpleGarage();
+        device.state['105'] = STATE_STOPPED;
 
         instance.setTargetDoorState(TDS.CLOSED);
-        expect(device.update).toHaveBeenCalledWith({ '2': true });
+
+        expect(device.update).toHaveBeenCalledTimes(1);
+        expect(device.update).toHaveBeenCalledWith({ '102': true });
+        expect(instance.pendingCloseTimer).toBeNull();
+        expect(accessory.context.cachedTargetDoorState).toBe(TDS.CLOSED);
+        expect(instance.characteristicTargetDoorState.value).toBe(TDS.CLOSED);
     });
 
-    test('Stop is never fired by a normal open/close', () => {
+    test('CLOSE while opening (state 12) fires stop, then close after stopBeforeCloseMs', () => {
         const { instance, device } = makeSimpleGarage();
+        instance.stopBeforeCloseMs = 1500;
+        device.state['105'] = STATE_OPENING_OR_OPEN;
 
-        instance.setTargetDoorState(TDS.OPEN);
         instance.setTargetDoorState(TDS.CLOSED);
 
-        expect(device.update).not.toHaveBeenCalledWith({ '103': true });
+        // Stop goes out immediately, close is deferred.
+        expect(device.update).toHaveBeenCalledTimes(1);
+        expect(device.update).toHaveBeenNthCalledWith(1, { '103': true });
+
+        jest.advanceTimersByTime(1500 - 1);
+        expect(device.update).toHaveBeenCalledTimes(1);
+
+        jest.advanceTimersByTime(1);
+        expect(device.update).toHaveBeenCalledTimes(2);
+        expect(device.update).toHaveBeenNthCalledWith(2, { '102': true });
+        expect(instance.pendingCloseTimer).toBeNull();
+    });
+
+    test('CLOSE while closing (state 13) also uses stop-before-close', () => {
+        const { instance, device } = makeSimpleGarage();
+        instance.stopBeforeCloseMs = 1500;
+        device.state['105'] = STATE_CLOSING_OR_CLOSED;
+
+        instance.setTargetDoorState(TDS.CLOSED);
+        expect(device.update).toHaveBeenNthCalledWith(1, { '103': true });
+
+        jest.advanceTimersByTime(1500);
+        expect(device.update).toHaveBeenNthCalledWith(2, { '102': true });
+    });
+
+    test('CLOSE with no reported state yet uses stop-before-close', () => {
+        const { instance, device } = makeSimpleGarage();
+        instance.stopBeforeCloseMs = 1500;
+        // device.state['105'] intentionally left undefined
+
+        instance.setTargetDoorState(TDS.CLOSED);
+        expect(device.update).toHaveBeenNthCalledWith(1, { '103': true });
+
+        jest.advanceTimersByTime(1500);
+        expect(device.update).toHaveBeenNthCalledWith(2, { '102': true });
+    });
+
+    test('A duplicate CLOSE during the wait does not restart or double-fire', () => {
+        const { instance, device } = makeSimpleGarage();
+        instance.stopBeforeCloseMs = 1500;
+        device.state['105'] = STATE_OPENING_OR_OPEN;
+
+        instance.setTargetDoorState(TDS.CLOSED);
+        expect(device.update).toHaveBeenCalledTimes(1); // stop
+
+        jest.advanceTimersByTime(1000);
+        instance.setTargetDoorState(TDS.CLOSED); // retransmit / second tap
+        expect(device.update).toHaveBeenCalledTimes(1); // no extra stop, timer not pushed out
+
+        jest.advanceTimersByTime(500);
+        expect(device.update).toHaveBeenCalledTimes(2);
+        expect(device.update).toHaveBeenNthCalledWith(2, { '102': true });
+    });
+
+    test('OPEN during the wait cancels the pending close and opens instead', () => {
+        const { instance, device } = makeSimpleGarage();
+        instance.stopBeforeCloseMs = 1500;
+        device.state['105'] = STATE_OPENING_OR_OPEN;
+
+        instance.setTargetDoorState(TDS.CLOSED);
+        expect(device.update).toHaveBeenNthCalledWith(1, { '103': true }); // stop
+
+        jest.advanceTimersByTime(500);
+        instance.setTargetDoorState(TDS.OPEN);
+        expect(instance.pendingCloseTimer).toBeNull();
+        expect(device.update).toHaveBeenNthCalledWith(2, { '101': true }); // open
+
+        // The trailing close must never fire.
+        jest.advanceTimersByTime(5000);
+        expect(device.update).toHaveBeenCalledTimes(2);
+    });
+
+    test('Status reports are ignored during the stop-before-close window', () => {
+        const { instance, device, accessory } = makeSimpleGarage();
+        instance.stopBeforeCloseMs = 1500;
+        device.state['105'] = STATE_OPENING_OR_OPEN;
+        instance.currentDoorState = CDS.OPEN;
+        instance.characteristicCurrentDoorState.value = CDS.OPEN;
+
+        instance.setTargetDoorState(TDS.CLOSED);
+        expect(accessory.context.cachedTargetDoorState).toBe(TDS.CLOSED);
+
+        // The stop makes the controller momentarily report 11 (=OPEN). That
+        // must be ignored, or it would bounce Target back to OPEN mid-close.
+        emitState(device, STATE_STOPPED);
+        expect(accessory.context.cachedTargetDoorState).toBe(TDS.CLOSED);
+        expect(instance.currentDoorState).toBe(CDS.OPEN);
+
+        // Close fires, then the controller reports 13 and we resume mirroring.
+        jest.advanceTimersByTime(1500);
+        expect(device.update).toHaveBeenNthCalledWith(2, { '102': true });
+        emitState(device, STATE_CLOSING_OR_CLOSED);
+        expect(instance.currentDoorState).toBe(CDS.CLOSED);
+        expect(accessory.context.cachedTargetDoorState).toBe(TDS.CLOSED);
+    });
+
+    test('stopBeforeCloseMs is configurable', () => {
+        const { instance, device } = makeSimpleGarage();
+        instance.stopBeforeCloseMs = 300;
+        device.state['105'] = STATE_OPENING_OR_OPEN;
+
+        instance.setTargetDoorState(TDS.CLOSED);
+        expect(device.update).toHaveBeenNthCalledWith(1, { '103': true });
+
+        jest.advanceTimersByTime(299);
+        expect(device.update).toHaveBeenCalledTimes(1);
+        jest.advanceTimersByTime(1);
+        expect(device.update).toHaveBeenNthCalledWith(2, { '102': true });
+    });
+
+    test('Custom stop/close DPs are respected in the stop-before-close path', () => {
+        const { instance, device } = makeSimpleGarage();
+        instance.dpClose = '2';
+        instance.dpStop = '4';
+        instance.stopBeforeCloseMs = 1000;
+        device.state['105'] = STATE_OPENING_OR_OPEN;
+
+        instance.setTargetDoorState(TDS.CLOSED);
+        expect(device.update).toHaveBeenNthCalledWith(1, { '4': true });
+
+        jest.advanceTimersByTime(1000);
+        expect(device.update).toHaveBeenNthCalledWith(2, { '2': true });
     });
 });
 
@@ -248,7 +388,9 @@ describe('SimpleGarageDoorAccessory — disconnected', () => {
 // ---------------------------------------------------------------------------
 describe('SimpleGarageDoorAccessory persistence', () => {
     test('Stores the latest target on the accessory context', () => {
-        const { instance, accessory } = makeSimpleGarage();
+        const { instance, device, accessory } = makeSimpleGarage();
+        // Already stopped, so the close fires immediately (no dangling timer).
+        device.state['105'] = STATE_STOPPED;
 
         instance.setTargetDoorState(TDS.OPEN);
         expect(accessory.context.cachedTargetDoorState).toBe(TDS.OPEN);
@@ -310,22 +452,28 @@ describe('SimpleGarageDoorAccessory._handlePartialOpen', () => {
         expect(device.update).toHaveBeenNthCalledWith(2, { '103': true });
     });
 
-    test('A direct open/close cancels the armed auto-stop', () => {
+    test('A direct close cancels the partial auto-stop and runs stop-before-close', () => {
         const { instance, device } = makeSimpleGarage();
         instance.partialOpenMs = 2000;
+        instance.stopBeforeCloseMs = 1500;
+        device.state['105'] = STATE_OPENING_OR_OPEN; // gate is moving during the partial
 
         instance._handlePartialOpen();
         expect(instance.partialStopTimer).not.toBeNull();
+        expect(device.update).toHaveBeenNthCalledWith(1, { '101': true }); // open
 
-        // User takes manual control before the auto-stop fires.
+        // User closes before the partial auto-stop fires.
         jest.advanceTimersByTime(500);
         instance.setTargetDoorState(TDS.CLOSED);
-        expect(instance.partialStopTimer).toBeNull();
-        expect(device.update).toHaveBeenLastCalledWith({ '102': true });
+        expect(instance.partialStopTimer).toBeNull(); // partial auto-stop cancelled
+        expect(device.update).toHaveBeenNthCalledWith(2, { '103': true }); // stop-before-close stop
 
-        // The stop must never fire now.
+        jest.advanceTimersByTime(1500);
+        expect(device.update).toHaveBeenNthCalledWith(3, { '102': true }); // close
+
+        // The cancelled partial stop never fires a stray write.
         jest.advanceTimersByTime(5000);
-        expect(device.update).not.toHaveBeenCalledWith({ '103': true });
+        expect(device.update).toHaveBeenCalledTimes(3);
     });
 
     test('Does nothing when partialOpenMs is not configured', () => {
@@ -375,8 +523,9 @@ describe('SimpleGarageDoorAccessory — force switches', () => {
         expect(accessory.context.cachedTargetDoorState).toBe(TDS.OPEN);
     });
 
-    test('Force Close fires the close action', () => {
+    test('Force Close fires the close action (immediately when already stopped)', () => {
         const { instance, device, accessory } = makeSimpleGarage();
+        device.state['105'] = STATE_STOPPED;
 
         instance.setTargetDoorState(TDS.CLOSED);
 

--- a/wiki/Supported-Device-Types.md
+++ b/wiki/Supported-Device-Types.md
@@ -428,9 +428,12 @@ Both the current and target door state are mirrored straight from this DP, so
 HomeKit stays in sync however the gate was operated (Home app, a physical
 remote, the Tuya app, ...).
 
-A HomeKit toggle simply fires the matching action — the controller reverses
-direction on its own, so no stop-first command is needed. There is no
-obstruction detection.
+Opening is direct: the controller reverses on its own, so an open command is
+fired straight away even while the gate is closing. Closing is asymmetric — the
+controller ignores a close command while the gate is actively moving. So unless
+the status DP already reads `11` (stopped, e.g. after a partial-open or an
+external stop, where close is accepted immediately), a close is sent as
+**stop → wait `stopBeforeCloseMs` → close**. There is no obstruction detection.
 
 ```json5
 {
@@ -450,13 +453,19 @@ obstruction detection.
     "dpClose": 102,
 
     /* Override the default datapoint identifier for the stop action
-       (only used by the partial-open feature) */
+       (used by the partial-open feature and the stop-before-close) */
     "dpStop": 103,
 
     /* Override the default datapoint identifier for the reported state.
        11 (stopped) and 12 (opening/open) are treated as OPEN; 13
        (closing/closed) is treated as CLOSED. */
     "dpState": 105,
+
+    /* Optional. The controller ignores a close while the gate is moving,
+       so unless the state DP already reads 11 (stopped) the plugin sends
+       stop, waits this many milliseconds, then sends close. Tune to about
+       how long the gate takes to halt after a stop. Default 1500. */
+    "stopBeforeCloseMs": 1500,
 
     /* Optional. If set, exposes an extra stateful switch that mirrors
        whether the gate is currently open in HomeKit's view. Tapping it


### PR DESCRIPTION
## Context

`SimpleGarageDoor` was made for my own use and I'm its only user, so this isn't expected to break anything for anyone else.

Follow-up to #51. Testing the newer controller on the real gate surfaced an asymmetry that the rewrite didn't account for.

## The asymmetry

- **Open works mid-motion.** Sending open while the gate is closing makes the controller stop and open — so open is always fired directly.
- **Close is ignored while the gate is actively moving.** You have to send stop, wait, then send close.
- **Exception:** when the status DP (`105`) reads exactly `11` (stopped) — e.g. right after a partial-open or an external stop — the gate is idle and accepts close immediately.

## Changes

`_sendClose` now branches:
- **state `11` (stopped):** fire close directly.
- **otherwise:** fire stop, wait **`stopBeforeCloseMs`** (new config option, default `1500`), then fire close.

Open stays direct. A few edge cases handled along the way:
- Status reports are ignored during the stop-before-close window, so the stop's transient `11` (=OPEN) report doesn't bounce TargetDoorState back to OPEN mid-close.
- An open (or the partial switch) during the window cancels the pending close and opens instead.
- A duplicate/retransmitted close during the window is ignored rather than restarting the timer (which would push the close out).

`stopBeforeCloseMs` should be tuned to roughly how long the gate takes to halt after a stop. The common "close from fully open" case can't be distinguished from "actively opening" on this 3-value DP, so it also waits this duration before closing.

## Testing

Unit tests extended to 29 (stopped→immediate close, moving→stop-before-close for states 12/13/unknown, duplicate-close ignore, open-cancels-pending-close, status-reports-ignored-during-window, configurable delay, custom DPs). Config schema and wiki docs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tujhvzr6VSH5qsmcPFy4JU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tujhvzr6VSH5qsmcPFy4JU)_