### PR TITLE
Add secure OIDC-based dev channel publishing to npm

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Changes to CI/release automation require the maintainer's review.
+# Enforced only when branch protection on `main` has
+# "Require review from Code Owners" enabled.
+/.github/workflows/ @adrianjagielak
+/.github/CODEOWNERS  @adrianjagielak

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -1,0 +1,91 @@
+name: Publish dev to npm
+
+# Publishes every commit on `main` to npm under the `dev` dist-tag.
+#
+# Security model (why a malicious PR cannot steal publishing rights):
+#   * No npm token is stored anywhere. Publishing uses npm Trusted
+#     Publishing (OIDC): GitHub mints a short-lived, cryptographically
+#     signed token that npm only accepts when its claims match THIS repo +
+#     THIS workflow file. There is no durable credential to exfiltrate.
+#   * This workflow never runs on `pull_request`, only on pushes to `main`
+#     (post-merge) and manual dispatch — so fork PRs get nothing.
+#   * The privileged `publish` job is minimal and isolated: it does not
+#     run `npm ci`, a build, or tests, and uses `--ignore-scripts`, so no
+#     repo/dependency code executes while the OIDC permission is present.
+#     Tests run in a separate, unprivileged job that gates publishing.
+#
+# One-time setup required for this to succeed (see PR/commit notes):
+#   1. npmjs.com -> package Settings -> Trusted Publisher:
+#        Publisher: GitHub Actions
+#        Organization/user: adrianjagielak
+#        Repository:        homebridge-tuya-plus
+#        Workflow filename: publish-dev.yml
+#        Environment:       npm-dev
+#   2. GitHub repo Settings -> Environments -> create `npm-dev`,
+#      restrict deployment branches to `main` (optional: required reviewer).
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Least privilege by default; only the publish job opts into id-token.
+permissions:
+  contents: read
+
+# Don't cancel an in-flight publish; let each commit publish its version.
+concurrency:
+  group: publish-dev
+  cancel-in-progress: false
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run test
+
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+    # Bind this environment in repo Settings to the `main` branch so that
+    # only main can ever reach the publish step.
+    environment: npm-dev
+    permissions:
+      contents: read # checkout
+      id-token: write # OIDC -> npm Trusted Publishing (no stored token)
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      # Trusted Publishing (OIDC) requires npm >= 11.5.1.
+      - name: Ensure OIDC-capable npm
+        run: npm install -g npm@latest
+
+      - name: Compute dev version
+        id: ver
+        run: |
+          NEXT="$(node -e "const v=require('./package.json').version.split('.'); v[2]=Number(v[2])+1; console.log(v.join('.'))")"
+          VERSION="${NEXT}-dev.${GITHUB_RUN_NUMBER}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Will publish $VERSION"
+
+      # Writes package.json on the runner only; nothing is committed.
+      - name: Set version
+        run: npm version "${{ steps.ver.outputs.version }}" --no-git-tag-version --allow-same-version --ignore-scripts
+
+      # No NODE_AUTH_TOKEN: npm exchanges the OIDC id-token for a
+      # short-lived, package-scoped credential at publish time.
+      # --ignore-scripts ensures no lifecycle script runs with that credential.
+      # --provenance attaches a signed build attestation (needs a public repo).
+      - name: Publish (dev tag)
+        run: npm publish --tag dev --provenance --ignore-scripts

--- a/Readme.MD
+++ b/Readme.MD
@@ -81,6 +81,19 @@ Search for "Tuya" in [homebridge-config-ui-x](https://github.com/oznu/homebridge
 sudo npm install -g homebridge-tuya-plus
 ```
 
+#### Bleeding-edge (`dev`) builds:
+
+Every commit to `main` is automatically published to npm under the `dev` tag — a
+separate, unstable channel. The stable release always stays on `latest`, so this
+won't affect normal installs. To try the latest in-development build:
+
+```
+sudo npm install -g homebridge-tuya-plus@dev
+```
+
+These are versioned like `3.13.1-dev.<n>` and may be unstable; use the default
+install above for production.
+
 ## Configuration
 > UI
 


### PR DESCRIPTION
Publishes every commit on `main` to npm under the `dev` dist-tag, with no long-lived npm token stored anywhere.

## Why this is safe against credential theft

The thing to be paranoid about — a malicious PR leaking a token to publish as you — is designed out:

- **No stored secret to steal.** Publishing uses **npm Trusted Publishing (OIDC)**. GitHub mints a short-lived, cryptographically signed token that npm accepts only when its claims match *this repo + this workflow file + the `npm-dev` environment*. Forging it = forging GitHub's signature (not feasible).
- **PRs get nothing.** The workflow runs only on `push` to `main` (post-merge) and manual dispatch — never on `pull_request`. Fork PRs receive no secrets and cannot trigger publishing.
- **The privileged job is minimal and isolated.** Tests/lint run in a separate **unprivileged** job that gates publishing. The publish job has `id-token: write` only, does **no `npm ci`/build**, and uses `--ignore-scripts`, so no repo or dependency code executes while the OIDC permission is present.
- **Low blast radius even in a worst case.** The minted token is ephemeral and scoped to this single package, so the worst outcome is a bad `dev` build during a short window — never account/token compromise.

## Changes

- **`.github/workflows/publish-dev.yml`** — unprivileged `test` gate → minimal OIDC `publish` job. Versions as `<next-patch>-dev.<run_number>` (e.g. `3.13.1-dev.42`), published under the `dev` tag with `--provenance`.
- **`.github/CODEOWNERS`** — workflow changes require maintainer review.
- **`Readme.MD`** — documents `npm i homebridge-tuya-plus@dev`.

## One-time setup required (workflow fails harmlessly until done)

1. **npmjs.com** → `homebridge-tuya-plus` → **Settings → Trusted Publisher → GitHub Actions**:
   - Organization/user: `adrianjagielak` · Repository: `homebridge-tuya-plus`
   - Workflow filename: `publish-dev.yml` · Environment: `npm-dev`
2. **GitHub** → **Settings → Environments → New environment** `npm-dev`, restrict deployment branches to `main` (optionally add a required reviewer).

Optional hardening: enable "Require review from Code Owners" branch protection on `main`, and pin `actions/*` to commit SHAs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAEPwM4oLHnGZ3RkTAefp7

---
_Generated by [Claude Code](https://claude.ai/code/session_01DAEPwM4oLHnGZ3RkTAefp7)_