### PR TITLE
Reconnect promptly when a Tuya device closes the LAN connection

### DIFF
--- a/lib/TuyaAccessory.js
+++ b/lib/TuyaAccessory.js
@@ -226,9 +226,21 @@ class TuyaAccessory extends EventEmitter {
             }
         });
 
-        this._socket.on('close', err => {
+        this._socket.on('close', () => {
             this.connected = false;
             this.session_key = null;
+
+            // A heartbeat timer must never outlive its socket. The pinger
+            // callbacks act on `this._socket`, so a stale timer left over from a
+            // dead socket would later fire against a freshly reconnected one and
+            // trip a spurious ERR_PING_TIMED_OUT. Clearing it here covers every
+            // teardown path (error-driven destroy as well as the graceful end
+            // below).
+            if (this._socket._pinger) {
+                clearTimeout(this._socket._pinger);
+                this._socket._pinger = null;
+            }
+
             //this.log.info('Closed connection with', this.context.name);
         });
 
@@ -236,6 +248,32 @@ class TuyaAccessory extends EventEmitter {
             this.connected = false;
             this.session_key = null;
             this.log.info('Disconnected from', this.context.name);
+
+            // The device closed the connection on its own. This is routine for
+            // many Tuya devices (e.g. LED ceiling lights) that recycle their
+            // long-lived LAN sockets every few minutes. Previously nothing here
+            // tore the socket down or reconnected: the heartbeat timer kept
+            // running and, because `connected` is now false, its pings went
+            // nowhere until the full ping timeout elapsed and emitted a
+            // misleading "ERR_PING_TIMED_OUT" ~30s later - which was the only
+            // thing that ultimately triggered a reconnect. Tear down and
+            // reconnect promptly instead, so recovery is quick and the logs
+            // reflect what actually happened (a clean disconnect, not a ping
+            // failure).
+            if (this._socket._pinger) {
+                clearTimeout(this._socket._pinger);
+                this._socket._pinger = null;
+            }
+
+            // Destroying first means a trailing RST can't resurface as an
+            // 'error' and schedule a second, competing reconnect.
+            this._socket.destroy();
+
+            if (!this._socket._errorReconnect) {
+                this._socket._errorReconnect = setTimeout(() => {
+                    process.nextTick(this._connect.bind(this));
+                }, 5000);
+            }
         });
     }
 

--- a/test/TuyaAccessory.protocol.test.js
+++ b/test/TuyaAccessory.protocol.test.js
@@ -10,6 +10,7 @@
 // mix of legacy paths.
 
 const crypto = require('crypto');
+const EventEmitter = require('events');
 const TuyaAccessory = require('../lib/TuyaAccessory');
 const TuyaDiscovery = require('../lib/TuyaDiscovery');
 
@@ -524,5 +525,102 @@ describe('discovery of 3.5+/3.6 devices', () => {
         expect(found[0].id).toBe('bf9999999999999999ff');
         expect(found[0].ip).toBe('192.168.1.99');
         expect(found[0].version).toBe('3.6');
+    });
+});
+
+// Many Tuya devices (e.g. LED ceiling lights) recycle their long-lived LAN
+// sockets every few minutes, closing the connection with a TCP FIN ('end').
+// The handler must tear that connection down and reconnect promptly instead of
+// leaving a half-dead socket whose stale heartbeat timer later fires a
+// misleading ERR_PING_TIMED_OUT - which used to be the only thing that
+// triggered a reconnect.
+describe('graceful disconnect handling', () => {
+    const net = require('net');
+    let realNetSocket;
+    let createdSockets;
+
+    const makeFakeSocket = () => {
+        const s = new EventEmitter();
+        s.destroyed = false;
+        s.setKeepAlive = () => {};
+        s.setNoDelay = () => {};
+        s.connect = jest.fn();
+        s.write = jest.fn(() => true);
+        s.destroy = jest.fn(function destroy() { this.destroyed = true; });
+        return s;
+    };
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        createdSockets = [];
+        realNetSocket = net.Socket;
+        // TuyaAccessory calls net.Socket() dynamically, so swapping the property
+        // is enough to hand it a controllable fake (no real network I/O).
+        net.Socket = function FakeSocket() {
+            const s = makeFakeSocket();
+            createdSockets.push(s);
+            return s;
+        };
+    });
+
+    afterEach(() => {
+        net.Socket = realNetSocket;
+        jest.clearAllTimers();
+        jest.useRealTimers();
+    });
+
+    // Bring a device up to a steady, connected state on a fake socket.
+    const establish = device => {
+        device._connect();
+        const socket = device._socket;
+        // An established connection has already cleared its connect watchdog.
+        clearTimeout(socket._connTimeout);
+        socket._connTimeout = null;
+        device.connected = true;
+        return socket;
+    };
+
+    test("a device-initiated 'end' clears the heartbeat, tears down, and schedules a reconnect without a spurious ping timeout", () => {
+        const device = makeDevice('3.5');
+        const socket = establish(device);
+
+        // A heartbeat retry timer is in flight. With the old handler it survived
+        // the disconnect and later emitted a misleading ERR_PING_TIMED_OUT.
+        const pingErrors = [];
+        socket.on('error', err => {
+            if (err && err.message === 'ERR_PING_TIMED_OUT') pingErrors.push(err);
+        });
+        socket._pinger = setTimeout(
+            () => device._socket.emit('error', new Error('ERR_PING_TIMED_OUT')),
+            50
+        );
+
+        // The device closes the LAN connection on its own (TCP FIN -> 'end').
+        socket.emit('end');
+
+        expect(device.connected).toBe(false);
+        expect(socket._pinger).toBeNull();             // stale timer cleared
+        expect(socket.destroy).toHaveBeenCalledTimes(1); // socket torn down
+        expect(socket._errorReconnect).toBeTruthy();     // a reconnect is scheduled
+
+        // Advance well past where the leaked timer would have fired: it must not.
+        jest.advanceTimersByTime(1000);
+        expect(pingErrors).toHaveLength(0);
+
+        // The log reflects a clean disconnect, never a ping failure.
+        expect(device.log.info).toHaveBeenCalledWith('Disconnected from', device.context.name);
+        const logged = device.log.info.mock.calls.flat().join(' ');
+        expect(logged).not.toMatch(/ERR_PING_TIMED_OUT/);
+    });
+
+    test("the 'close' teardown clears any lingering heartbeat timer", () => {
+        const device = makeDevice('3.5');
+        const socket = establish(device);
+
+        socket._pinger = setTimeout(() => {}, 10000);
+        socket.emit('close');
+
+        expect(socket._pinger).toBeNull();
+        expect(device.connected).toBe(false);
     });
 });


### PR DESCRIPTION
## Problem

Users see a repeating disconnect loop in the logs for devices like LED ceiling lights:

```
[Tuya LAN 27A] Disconnected from Plafon LED 42 cm 3000lm
[Tuya LAN 27A] Socket had a problem and will reconnect to Plafon LED 42 cm 3000lm (Error: ERR_PING_TIMED_OUT)
```

The tell-tale signature is `Disconnected` → **~14s later** → `ERR_PING_TIMED_OUT … will reconnect`, repeating every 1–12 minutes.

## Root cause

The `ERR_PING_TIMED_OUT` is **not** a genuine ping/network failure — it's the plugin reacting slowly and indirectly to a *clean* disconnect.

1. **The device closes the connection itself.** Many Tuya devices recycle their long-lived LAN sockets every few minutes, closing with a TCP FIN → Node's `'end'` event (the `Disconnected` log line). This is normal firmware behavior.
2. **The old `'end'` handler did almost nothing.** It set `connected = false` and logged "Disconnected", but never cleared the heartbeat timer, destroyed the socket, or reconnected. So the connection sat dead, and the *only* thing that eventually recovered it was the leftover heartbeat timer firing — but since `connected` was already false, its pings went nowhere until the full `pingTimeout` (~30s) elapsed and emitted a **misleading `ERR_PING_TIMED_OUT`**, which finally triggered a reconnect (after another 5s delay).

There was also a latent bug: the heartbeat timer was never cleared on teardown. Its callbacks act on `this._socket`, so a stale timer from a dead socket could fire against a freshly reconnected one and trip *another* false `ERR_PING_TIMED_OUT`.

## Fix (`lib/TuyaAccessory.js`)

- **Treat `'end'` as a real disconnect:** clear the heartbeat timer, destroy the socket, and schedule a prompt reconnect — guarded against the existing error path so the two can't both fire. (Destroying first also prevents a trailing RST from scheduling a competing reconnect.)
- **Clear the heartbeat timer on `'close'`** too, so a timer from a dead socket can never fire against a new one.

**Result:** after the device drops the connection you get a clean `Disconnected` followed by a quick (~5s) reconnect, with no misleading `ERR_PING_TIMED_OUT` spam, and the accessory stays responsive in HomeKit instead of going dark for 30s+ each cycle.

> Note: this does not stop the device from disconnecting (that's the bulb deciding to drop the socket, often tied to Wi-Fi signal or the Tuya app/cloud grabbing the connection) — it makes the plugin recover gracefully and quietly instead of looking like a ping failure.

## Tests

Adds regression tests in `test/TuyaAccessory.protocol.test.js` covering both the `'end'` and `'close'` teardown paths (heartbeat timer cleared, socket torn down, reconnect scheduled, no spurious `ERR_PING_TIMED_OUT`, clean log output).

Local `node_modules` wasn't available in the dev environment (blocked registry), so the handler logic was also verified directly against the real `TuyaAccessory` code via standalone Node scripts; CI runs the jest suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMjcWB44NwAJajr3FwXAwA

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMjcWB44NwAJajr3FwXAwA)_