### PR TITLE
feat: split useStrings into useStringsFan and useStringsLight in SimpleFanLightAccessory

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -576,6 +576,22 @@
                 "functionBody": "return model.devices && model.devices[arrayIndices] && ['Fan', 'FanLight'].includes(model.devices[arrayIndices].type);"
               }
             },
+            "useStringsFan": {
+              "title": "Send fan speed as text",
+              "description": "Overrides \"useStrings\" for the fan only. Set this when the fan's speed data point wants a different value type than the light's brightness and colour temperature. Defaults to whatever \"useStrings\" is.",
+              "type": "boolean",
+              "condition": {
+                "functionBody": "return model.devices && model.devices[arrayIndices] && ['FanLight'].includes(model.devices[arrayIndices].type);"
+              }
+            },
+            "useStringsLight": {
+              "title": "Send brightness and colour temperature as text",
+              "description": "Overrides \"useStrings\" for the light only. Set this when the light's data points want a different value type than the fan's speed. Defaults to whatever \"useStrings\" is.",
+              "type": "boolean",
+              "condition": {
+                "functionBody": "return model.devices && model.devices[arrayIndices] && ['FanLight'].includes(model.devices[arrayIndices].type);"
+              }
+            },
             "singleDpWrites": {
               "title": "Send fan commands one DP at a time",
               "description": "Enable if turning the fan on or changing its speed is silently ignored. Some fan firmwares reject LAN packets that carry more than one data point, so the fan on/off and speed are sent as separate packets instead of combined.",

--- a/lib/SimpleFanLightAccessory.js
+++ b/lib/SimpleFanLightAccessory.js
@@ -76,6 +76,8 @@ class SimpleFanLightAccessory extends BaseAccessory {
         this.fanCurrentSpeed = 0;
         this.useStrings = this._coerceBoolean(this.device.context.useStrings, true);
         this.singleDpWrites = this._coerceBoolean(this.device.context.singleDpWrites, false);
+        this.useStringsFan = this._coerceBoolean(this.device.context.useStringsFan, this.useStrings);
+        this.useStringsLight = this._coerceBoolean(this.device.context.useStringsLight, this.useStrings);
 
         const characteristicFanOn = serviceFan.getCharacteristic(Characteristic.On)
             .updateValue(this._getFanOn(dps[this.dpFanOn]))
@@ -184,7 +186,7 @@ class SimpleFanLightAccessory extends BaseAccessory {
             const target = this.fanCurrentSpeed === 0 ? this.fanDefaultSpeed : this.fanCurrentSpeed;
             const payload = {
                 [this.dpFanOn]: true,
-                [this.dpRotationSpeed]: this.useStrings ? target.toString() : target
+                [this.dpRotationSpeed]: this.useStringsFan ? target.toString() : target
             };
             return this._writeFanState(payload);
         }
@@ -198,7 +200,7 @@ class SimpleFanLightAccessory extends BaseAccessory {
         if (value === 0) {
             const payload = {
                 [this.dpFanOn]: false,
-                [this.dpRotationSpeed]: this.useStrings ? this.fanDefaultSpeed.toString() : this.fanDefaultSpeed
+                [this.dpRotationSpeed]: this.useStringsFan ? this.fanDefaultSpeed.toString() : this.fanDefaultSpeed
             };
             return this._writeFanState(payload);
         } else {
@@ -206,7 +208,7 @@ class SimpleFanLightAccessory extends BaseAccessory {
             this.fanCurrentSpeed = tuya;
             const payload = {
                 [this.dpFanOn]: true,
-                [this.dpRotationSpeed]: this.useStrings ? tuya.toString() : tuya
+                [this.dpRotationSpeed]: this.useStringsFan ? tuya.toString() : tuya
             };
             return this._writeFanState(payload);
         }
@@ -250,7 +252,7 @@ class SimpleFanLightAccessory extends BaseAccessory {
 
     setBrightness(value) {
         const tuya = this.convertBrightnessFromHomeKitToTuya(value);
-        return this.setStateAsync(this.dpBrightness, this.useStrings ? tuya.toString() : tuya);
+        return this.setStateAsync(this.dpBrightness, this.useStringsLight ? tuya.toString() : tuya);
     }
 
     getColorTemp() {
@@ -259,7 +261,7 @@ class SimpleFanLightAccessory extends BaseAccessory {
 
     setColorTemp(value) {
         const tuya = this.convertColorTempFromHomeKitToTuya(value);
-        return this.setStateAsync(this.dpColorTemp, this.useStrings ? tuya.toString() : tuya);
+        return this.setStateAsync(this.dpColorTemp, this.useStringsLight ? tuya.toString() : tuya);
     }
 
     convertRotationSpeedFromTuyaToHomeKit(value) {

--- a/test/SimpleFanLightAccessory.test.js
+++ b/test/SimpleFanLightAccessory.test.js
@@ -21,6 +21,8 @@ function makeFanLight(state = {}, context = {}) {
     instance.fanDefaultSpeed = parseInt(device.context.fanDefaultSpeed) || 1;
     instance.fanCurrentSpeed = 0;
     instance.useStrings = instance._coerceBoolean(device.context.useStrings, true);
+    instance.useStringsFan = instance._coerceBoolean(device.context.useStringsFan, instance.useStrings);
+    instance.useStringsLight = instance._coerceBoolean(device.context.useStringsLight, instance.useStrings);
     instance.singleDpWrites = instance._coerceBoolean(device.context.singleDpWrites, false);
     instance.lightUseEnum = instance._coerceBoolean(device.context.lightUseEnum, false);
     instance.lightOnCommand = device.context.lightOnCommand || 'On';
@@ -415,4 +417,19 @@ describe('SimpleFanLightAccessory.getColorTemp / setColorTemp', () => {
         await expect(instance.setColorTemp(370)).rejects.toBeInstanceOf(HAP.HapStatusError);
         expect(device.update).not.toHaveBeenCalled();
     });
+
+    test('setColorTemp respects useStringsLight: false independently of useStrings', () => {
+        const { instance, device } = makeFanLight({ '23': 500 }, { useStrings: true, useStringsLight: false });
+        instance.setColorTemp(154); // cool end -> Tuya 1000
+        expect(device.update).toHaveBeenCalledWith({ '23': 1000 });
+    });
 });
+
+describe('SimpleFanLightAccessory — useStringsFan / useStringsLight independent config', () => {
+    test('setSpeed respects useStringsFan: false independently of useStrings', () => {
+        const { instance, device } = makeFanLight({ '60': false, '62': 1 }, { useStrings: true, useStringsFan: false });
+        instance.setSpeed(100);
+        expect(device.update).toHaveBeenCalledWith({ '60': true, '62': 6 });
+    });
+});
+

--- a/test/SimpleFanLightAccessory.test.js
+++ b/test/SimpleFanLightAccessory.test.js
@@ -16,6 +16,7 @@ function makeFanLight(state = {}, context = {}) {
     instance.dpRotationSpeed = '62';
     instance.dpFanDirection = device.context.dpFanDirection || '63';
     instance.dpLightOn = device.context.dpLightOn || '20';
+    instance.dpBrightness = '22';
     instance.dpColorTemp = '23';
     instance.maxSpeed = parseInt(device.context.maxSpeed) || 6;
     instance.fanDefaultSpeed = parseInt(device.context.fanDefaultSpeed) || 1;
@@ -418,18 +419,71 @@ describe('SimpleFanLightAccessory.getColorTemp / setColorTemp', () => {
         expect(device.update).not.toHaveBeenCalled();
     });
 
-    test('setColorTemp respects useStringsLight: false independently of useStrings', () => {
-        const { instance, device } = makeFanLight({ '23': 500 }, { useStrings: true, useStringsLight: false });
-        instance.setColorTemp(154); // cool end -> Tuya 1000
-        expect(device.update).toHaveBeenCalledWith({ '23': 1000 });
-    });
 });
 
-describe('SimpleFanLightAccessory — useStringsFan / useStringsLight independent config', () => {
-    test('setSpeed respects useStringsFan: false independently of useStrings', () => {
-        const { instance, device } = makeFanLight({ '60': false, '62': 1 }, { useStrings: true, useStringsFan: false });
+// ---------------------------------------------------------------------------
+// useStringsFan / useStringsLight override useStrings per side, and inherit it
+// when unset so configs written before the split keep their old behaviour.
+// ---------------------------------------------------------------------------
+describe('SimpleFanLightAccessory — useStringsFan / useStringsLight', () => {
+    test('both sides inherit useStrings: false when neither override is set', () => {
+        const fan = makeFanLight({ '60': false, '62': 1 }, { useStrings: false });
+        fan.instance.setSpeed(100);
+        expect(fan.device.update).toHaveBeenCalledWith({ '60': true, '62': 6 });
+
+        const light = makeFanLight({ '22': 500, '23': 500 }, { useStrings: false });
+        light.instance.setBrightness(100);
+        light.instance.setColorTemp(154);
+        expect(payloads(light.device)).toEqual([{ '22': 1000 }, { '23': 1000 }]);
+    });
+
+    test('both sides inherit the useStrings default (strings) when nothing is set', () => {
+        const fan = makeFanLight({ '60': false, '62': 1 });
+        fan.instance.setSpeed(100);
+        expect(fan.device.update).toHaveBeenCalledWith({ '60': true, '62': '6' });
+
+        const light = makeFanLight({ '22': 500, '23': 500 });
+        light.instance.setBrightness(100);
+        light.instance.setColorTemp(154);
+        expect(payloads(light.device)).toEqual([{ '22': '1000' }, { '23': '1000' }]);
+    });
+
+    test('useStringsFan overrides the fan only, leaving the light on useStrings', () => {
+        const { instance, device } = makeFanLight(
+            { '60': false, '62': 1, '22': 500, '23': 500 },
+            { useStrings: true, useStringsFan: false }
+        );
         instance.setSpeed(100);
-        expect(device.update).toHaveBeenCalledWith({ '60': true, '62': 6 });
+        instance.setBrightness(100);
+        instance.setColorTemp(154);
+        expect(payloads(device)).toEqual([{ '60': true, '62': 6 }, { '22': '1000' }, { '23': '1000' }]);
+    });
+
+    test('useStringsLight overrides the light only, leaving the fan on useStrings', () => {
+        const { instance, device } = makeFanLight(
+            { '60': false, '62': 1, '22': 500, '23': 500 },
+            { useStrings: false, useStringsLight: true }
+        );
+        instance.setSpeed(100);
+        instance.setBrightness(100);
+        instance.setColorTemp(154);
+        expect(payloads(device)).toEqual([{ '60': true, '62': 6 }, { '22': '1000' }, { '23': '1000' }]);
+    });
+
+    test('accepts the string form of the overrides, as hand-written configs produce', () => {
+        const { instance, device } = makeFanLight(
+            { '60': false, '62': 1, '23': 500 },
+            { useStrings: 'true', useStringsFan: 'false', useStringsLight: 'true' }
+        );
+        instance.setSpeed(100);
+        instance.setColorTemp(154);
+        expect(payloads(device)).toEqual([{ '60': true, '62': 6 }, { '23': '1000' }]);
+    });
+
+    test('setFanOn from off applies useStringsFan to the default speed', () => {
+        const { instance, device } = makeFanLight({ '60': false, '62': 1 }, { useStrings: true, useStringsFan: false });
+        instance.setFanOn(true);
+        expect(device.update).toHaveBeenCalledWith({ '60': true, '62': 1 });
     });
 });
 

--- a/wiki/Supported-Device-Types.md
+++ b/wiki/Supported-Device-Types.md
@@ -877,8 +877,13 @@ These are accessories that combine fan and lighting control in one device. Suppo
     /* Speed used when the fan is switched on from off. Default: 1 */
     "fanDefaultSpeed": 1,
 
-    /* Send the speed value as a string rather than a number. Default: true */
+    /* Send values as strings rather than numbers, for both the fan speed and
+       the light's brightness / colour temperature. Default: true */
     "useStrings": true,
+
+    /* Override "useStrings" for the fan speed alone. Defaults to "useStrings"
+       (see the note below on fans that want a different type per side) */
+    "useStringsFan": true,
 
     /* Send each data point in its own packet instead of combining fan
        power + speed into one. Default: false (see note below) */
@@ -908,7 +913,27 @@ These are accessories that combine fan and lighting control in one device. Suppo
     "minWhiteColor": 154,
 
     /* Warmest colour temperature, in mireds (~2700 K). Default: 370 */
-    "maxWhiteColor": 370
+    "maxWhiteColor": 370,
+
+    /* Override "useStrings" for the light alone. Defaults to "useStrings" */
+    "useStringsLight": true
+}
+```
+
+#### When the fan and the light want different value types
+
+On most fans a single `useStrings` covers the whole device. Some (e.g. the **Treatlife DS03**) disagree between the two halves — the speed data point takes one type and the light's brightness / colour-temperature data points take the other — which shows up as one half of the accessory working while the other silently ignores commands. Set `useStringsFan` and/or `useStringsLight` to override `useStrings` for just that side; whichever you leave out keeps following `useStrings`, so existing configs are unaffected.
+
+```json5
+{
+    "type": "FanLight",
+    "name": "My Fan with Light",
+    "id": "032000123456789abcde",
+    "key": "0123456789abcdef",
+
+    /* Speed wants a plain number, brightness and colour temperature want strings */
+    "useStringsFan": false,
+    "useStringsLight": true
 }
 ```
 


### PR DESCRIPTION
Allows independent configuration of string/integer values for the fan and light components on devices where their support differs (e.g. Treatlife DS03).