### PR TITLE
Add opt-in Tuya Cloud support for devices that can't be controlled over LAN

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. This project uses [semantic versioning](https://semver.org/).
 
+## Unreleased
+
+* [+] **Tuya Cloud support for devices that can't be reached over the LAN** — most notably battery-powered "sleepy" irrigation/sprinkler timers, which sleep almost all the time and only ever talk to Tuya's cloud, so the local protocol can never reach them. The plugin stays LAN-first: cloud is strictly opt-in. Add a top-level `cloud` credentials block (or a per-device `cloud` object) and set `"cloud": true` on the device.
+  * Realtime updates arrive over Tuya's **MQTT** message service (via the optional `mqtt` dependency, installed automatically); initial state and control use the Tuya OpenAPI. There is no polling.
+  * Works with both **Custom** and **Smart Home** Cloud projects (the latter via app-account login).
+  * The existing **IrrigationSystem** accessory works unchanged over the cloud — its data-points are simply addressed by Tuya "code" (e.g. `switch_1`, `battery_percentage`) instead of a numeric id; the device logs its codes on startup. Battery-only controllers with no rain sensor: set `"noRainSensor": true`.
+  * See the wiki: **[Tuya Cloud Setup](https://github.com/adrianjagielak/homebridge-tuya-plus/blob/main/wiki/Tuya-Cloud-Setup.md)**.
+
 ## 2.0.1 (2021-03-25)
 This update includes the following changes:
 

--- a/Readme.MD
+++ b/Readme.MD
@@ -69,6 +69,14 @@ Protocol **3.5** is currently the newest Tuya LAN protocol in existence: it is t
 
 This plugin is nevertheless **3.6-ready**: if a device reports a newer protocol version (e.g. `3.6`) in its broadcast, the plugin automatically talks to it using the newest (3.5/GCM) protocol stack while tagging payloads with the device's reported version — the same forward-compatibility strategy used by tinytuya. Should such a device misbehave, you can pin it to a specific protocol with the `forceVersion` device option (e.g. `"forceVersion": "3.5"`), or use `version` to set a protocol for devices that can't be discovered (e.g. on another subnet).
 
+## Cloud devices (for hardware that can't be controlled locally)
+
+This is a **LAN-first** plugin — virtually every Tuya device is controlled locally, which is faster, more private, and keeps working without internet. A few devices, though, simply **can't** be reached over the LAN: battery-powered "sleepy" devices — most notably the multi-zone **irrigation / faucet timers** — sleep almost all the time and only ever connect out to Tuya's cloud, so they never answer on the local network (Tuya's own docs confirm LAN control is unavailable for these low-power devices).
+
+For exactly these cases the plugin can talk to a device through the **Tuya Cloud** instead — strictly **opt-in, per device**. You add your Tuya Cloud project credentials once and set `"cloud": true` on the device; everything else (including the full Irrigation System accessory — all zones, durations, battery) works the same. Live updates arrive instantly over Tuya's MQTT message service.
+
+👉 **[Tuya Cloud Setup guide](https://github.com/adrianjagielak/homebridge-tuya-plus/blob/main/wiki/Tuya-Cloud-Setup.md)** — how to get credentials and configure a cloud device.
+
 ## Installation Instructions
 
 #### Option 1: Install via Homebridge Config UI X:

--- a/config.schema.json
+++ b/config.schema.json
@@ -19,12 +19,71 @@
         "placeholder": "Timeout (millisecond) for device IP address discovery",
         "default": 60000
       },
+      "cloud": {
+        "type": "object",
+        "title": "Tuya Cloud (optional — only for devices that can't be reached over the LAN)",
+        "description": "This plugin is LAN-first. A few devices — notably battery-powered 'sleepy' irrigation timers — sleep most of the time and only ever talk to Tuya's cloud, so they cannot be controlled locally. Create a free Cloud project at iot.tuya.com, enter its credentials here, then tick 'Control via Tuya Cloud' on each such device. See the wiki for step-by-step setup.",
+        "properties": {
+          "accessId": {
+            "type": "string",
+            "title": "Access ID / Client ID"
+          },
+          "accessKey": {
+            "type": "string",
+            "title": "Access Secret / Client Secret"
+          },
+          "region": {
+            "type": "string",
+            "title": "Data center / region",
+            "default": "us",
+            "description": "Must match the region your Tuya / Smart Life app account is registered in.",
+            "oneOf": [
+              { "title": "Central Europe", "enum": ["eu"] },
+              { "title": "Western Europe (Azure)", "enum": ["eu-w"] },
+              { "title": "Western America", "enum": ["us"] },
+              { "title": "Eastern America (Azure)", "enum": ["us-e"] },
+              { "title": "China", "enum": ["cn"] },
+              { "title": "India", "enum": ["in"] },
+              { "title": "Singapore", "enum": ["sg"] }
+            ]
+          },
+          "username": {
+            "type": "string",
+            "title": "App account email/phone (Smart Home projects only)",
+            "description": "For 'Smart Home' Cloud projects: the Tuya / Smart Life app account that owns the devices. Leave blank for 'Custom' projects (which link devices by QR scan)."
+          },
+          "password": {
+            "type": "string",
+            "title": "App account password (Smart Home projects only)"
+          },
+          "countryCode": {
+            "type": "string",
+            "title": "Country calling code (Smart Home projects only)",
+            "placeholder": "e.g. 1, 44, 48"
+          },
+          "schema": {
+            "type": "string",
+            "title": "App (Smart Home projects only)",
+            "default": "tuyaSmart",
+            "oneOf": [
+              { "title": "Tuya Smart", "enum": ["tuyaSmart"] },
+              { "title": "Smart Life", "enum": ["smartlife"] }
+            ]
+          },
+          "realtime": {
+            "type": "boolean",
+            "title": "Realtime updates (MQTT)",
+            "default": true,
+            "description": "Receive instant updates over Tuya's MQTT message service (uses the 'mqtt' package, installed automatically). If disabled, devices stay controllable and show their state at startup, but external changes (physical buttons, the device's own timers) won't be reflected until restart."
+          }
+        }
+      },
       "devices": {
         "type": "array",
         "orderable": false,
         "items": {
           "type": "object",
-          "required": ["type", "name", "id", "key"],
+          "required": ["type", "name", "id"],
           "properties": {
             "type": {
               "type": "string",
@@ -136,8 +195,18 @@
               }
             },
             "key": {
-              "title": "Tuya Key",
+              "title": "Tuya Key (local key — required for LAN devices)",
               "type": "string",
+              "description": "The device's local key. Required for normal (LAN) devices. Not needed for cloud devices (tick 'Control via Tuya Cloud' below).",
+              "condition": {
+                "functionBody": "return model.devices && model.devices[arrayIndices].type !== 'null';"
+              }
+            },
+            "cloud": {
+              "type": ["boolean", "object"],
+              "title": "Control via Tuya Cloud (instead of the LAN)",
+              "default": false,
+              "description": "Enable for devices that can't be reached locally (e.g. battery-powered irrigation timers). Uses the platform-level 'cloud' credentials above. Advanced: instead of a checkbox you can set this to an object with per-device { accessId, accessKey, region, … } to use different credentials for this one device.",
               "condition": {
                 "functionBody": "return model.devices && model.devices[arrayIndices].type !== 'null';"
               }
@@ -648,7 +717,7 @@
               "type": "integer",
               "title": "Number of Valves / Zones",
               "placeholder": 4,
-              "description": "How many valves/zones the controller has. They are assumed to be on data-points 1, 2, 3, … For non-sequential data-points use the 'valves' list instead.",
+              "description": "How many valves/zones the controller has. They are assumed to be on data-points 1, 2, 3, … (or, for cloud devices, on the codes switch_1, switch_2, …). For non-sequential data-points use the 'valves' list instead.",
               "condition": {
                 "functionBody": "return model.devices && model.devices[arrayIndices] && ['IrrigationSystem'].includes(model.devices[arrayIndices].type);"
               }
@@ -662,7 +731,7 @@
                 "type": "object",
                 "properties": {
                   "name": { "type": "string", "title": "Zone name", "placeholder": "Lawn" },
-                  "dp": { "type": "integer", "title": "Data-point", "placeholder": 1 },
+                  "dp": { "type": ["integer", "string"], "title": "Data-point (numeric id, or cloud code)", "placeholder": "1 or switch_1" },
                   "defaultDuration": { "type": "integer", "title": "Default run time (seconds, 0 = run indefinitely)", "placeholder": 600 }
                 }
               },
@@ -724,9 +793,9 @@
               }
             },
             "dpBattery": {
-              "type": "integer",
-              "placeholder": 46,
-              "title": "Battery data-point",
+              "type": ["integer", "string"],
+              "placeholder": "46 or battery_percentage",
+              "title": "Battery data-point (numeric id, or cloud code)",
               "condition": {
                 "functionBody": "return model.devices && model.devices[arrayIndices] && ['IrrigationSystem'].includes(model.devices[arrayIndices].type) && !model.devices[arrayIndices].noBattery;"
               }
@@ -741,9 +810,9 @@
               }
             },
             "dpCharging": {
-              "type": "integer",
-              "placeholder": 101,
-              "title": "Charging-status data-point",
+              "type": ["integer", "string"],
+              "placeholder": "101 or charge_state",
+              "title": "Charging-status data-point (numeric id, or cloud code)",
               "description": "Boolean data-point reporting whether the battery is charging (e.g. solar / USB-C units). HomeKit shows Charging / Not Charging; if your controller doesn't report this, it shows Not Chargeable.",
               "condition": {
                 "functionBody": "return model.devices && model.devices[arrayIndices] && ['IrrigationSystem'].includes(model.devices[arrayIndices].type) && !model.devices[arrayIndices].noBattery;"
@@ -778,9 +847,9 @@
               }
             },
             "dpRain": {
-              "type": "integer",
-              "placeholder": 49,
-              "title": "Rain sensor data-point",
+              "type": ["integer", "string"],
+              "placeholder": "49 or rain_sensor_state",
+              "title": "Rain sensor data-point (numeric id, or cloud code)",
               "condition": {
                 "functionBody": "return model.devices && model.devices[arrayIndices] && ['IrrigationSystem'].includes(model.devices[arrayIndices].type) && !model.devices[arrayIndices].noRainSensor;"
               }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,8 @@
 const TuyaAccessory = require('./lib/TuyaAccessory');
 const TuyaDiscovery = require('./lib/TuyaDiscovery');
+const TuyaCloudApi = require('./lib/TuyaCloudApi');
+const TuyaCloudDevice = require('./lib/TuyaCloudDevice');
+const TuyaCloudMessaging = require('./lib/TuyaCloudMessaging');
 
 const OutletAccessory = require('./lib/OutletAccessory');
 const SimpleLightAccessory = require('./lib/SimpleLightAccessory');
@@ -35,6 +38,13 @@ const PLATFORM_NAME = 'TuyaLan';
 // rooms, automations).
 const UUID_SEED = 'homebridge-tuya';
 const DEFAULT_DISCOVER_TIMEOUT = 60000;
+
+// Lenient boolean coercion (matches BaseAccessory._coerceBoolean) so config
+// values like true / "true" / 1 all read as true.
+const coerceBoolean = (b, df = false) =>
+    typeof b === 'boolean' ? b :
+    typeof b === 'string' ? b.toLowerCase().trim() === 'true' :
+    typeof b === 'number' ? b !== 0 : df;
 
 const CLASS_DEF = {
     outlet: OutletAccessory,
@@ -82,6 +92,11 @@ class TuyaLan {
         [this.log, this.config, this.api] = [...props];
 
         this.cachedAccessories = new Map();
+        // Shared Tuya Cloud clients, keyed by credential set, so several
+        // cloud devices on the same project share one token + one realtime
+        // (MQTT) connection. Empty unless cloud devices are configured.
+        this.cloudApis = new Map();
+        this.cloudMessagers = new Map();
         this.api.hap.EnergyCharacteristics = require('./lib/EnergyCharacteristics')(this.api.hap);
 
         if(!this.config || !this.config.devices) {
@@ -100,10 +115,12 @@ class TuyaLan {
         const devices = {};
         const connectedDevices = [];
         const fakeDevices = [];
+        const cloudDevices = [];
         this.config.devices.forEach(device => {
             try {
                 device.id = ('' + device.id).trim();
-                device.key = ('' + device.key).trim();
+                // Cloud devices don't need a local key; only trim when present.
+                if (device.key != null) device.key = ('' + device.key).trim();
                 device.type = ('' + device.type).trim();
 
                 device.ip = ('' + (device.ip || '')).trim();
@@ -112,12 +129,20 @@ class TuyaLan {
             if (!device.type) return this.log.error('%s (%s) doesn\'t have a type defined.', device.name || 'Unnamed device', device.id);
             if (!CLASS_DEF[device.type.toLowerCase()]) return this.log.error('%s (%s) doesn\'t have a valid type defined.', device.name || 'Unnamed device', device.id);
 
-            if (device.fake) fakeDevices.push({name: device.id.slice(8), ...device});
+            if (this._isCloudDevice(device)) cloudDevices.push({name: device.id.slice(8), ...device});
+            else if (device.fake) fakeDevices.push({name: device.id.slice(8), ...device});
             else devices[device.id] = {name: device.id.slice(8), ...device};
         });
 
+        // Cloud devices are reached over the internet, not the LAN, so they need
+        // no discovery — wire them up right away.
+        cloudDevices.forEach(config => this._addCloudAccessory(config));
+
         const deviceIds = Object.keys(devices);
-        if (deviceIds.length === 0) return this.log.error('No valid configured devices found.');
+        if (deviceIds.length === 0) {
+            if (cloudDevices.length === 0) this.log.error('No valid configured devices found.');
+            return; // cloud-only (or empty) configuration: nothing to discover over LAN
+        }
 
         this.log.info('Starting discovery...');
 
@@ -174,6 +199,70 @@ class TuyaLan {
                 }
             });
         }, this.config.discoverTimeout ?? DEFAULT_DISCOVER_TIMEOUT);
+    }
+
+    /* ------------------------------------------------------------------ *
+     *  Tuya Cloud helpers (for devices that can't be reached over the LAN,
+     *  e.g. battery-powered "sleepy" irrigation timers). This plugin stays
+     *  LAN-first; these paths are only exercised by devices opting in with
+     *  `cloud: true` (or a per-device `cloud` credentials object).
+     * ------------------------------------------------------------------ */
+
+    _isCloudDevice(device) {
+        return !!(device && (device.cloud === true || (typeof device.cloud === 'object' && device.cloud)));
+    }
+
+    // Effective cloud credentials/options for a device: the platform-level
+    // `cloud` block, overlaid with any per-device `cloud` object.
+    _resolveCloudConfig(device) {
+        const platform = (this.config.cloud && typeof this.config.cloud === 'object') ? this.config.cloud : {};
+        const perDevice = (typeof device.cloud === 'object' && device.cloud) ? device.cloud : {};
+        return {...platform, ...perDevice};
+    }
+
+    // One TuyaCloudApi per credential set, so multiple cloud devices on the
+    // same Tuya project share a single token.
+    _getCloudApi(cloudCfg) {
+        const key = TuyaCloudApi.keyFor(cloudCfg);
+        if (!this.cloudApis.has(key)) {
+            this.cloudApis.set(key, new TuyaCloudApi({...cloudCfg, log: this.log}));
+        }
+        return this.cloudApis.get(key);
+    }
+
+    // One shared realtime (MQTT) stream per credential set, unless realtime is
+    // disabled. Returns null when realtime is off — the device then shows its
+    // initial state and stays controllable, but won't receive live updates.
+    _getCloudMessaging(api, cloudCfg) {
+        const realtime = cloudCfg.realtime === undefined ? true : coerceBoolean(cloudCfg.realtime, true);
+        if (!realtime) return null;
+        const key = TuyaCloudApi.keyFor(cloudCfg);
+        if (!this.cloudMessagers.has(key)) {
+            this.cloudMessagers.set(key, new TuyaCloudMessaging({api, log: this.log}));
+        }
+        return this.cloudMessagers.get(key);
+    }
+
+    _addCloudAccessory(config) {
+        const cloudCfg = this._resolveCloudConfig(config);
+        if (!cloudCfg.accessId || !cloudCfg.accessKey) {
+            return this.log.error('%s (%s) is configured for the Tuya Cloud, but no credentials were found. Add a top-level "cloud" block (accessId, accessKey, region) or a per-device "cloud" object.', config.name, config.id);
+        }
+
+        const api = this._getCloudApi(cloudCfg);
+        const messaging = this._getCloudMessaging(api, cloudCfg);
+
+        this.log.info('Adding cloud device: %s (%s) via %s', config.name, config.id, api.endpoint);
+
+        this.addAccessory(new TuyaCloudDevice({
+            ...config,
+            cloud: true, // normalise so accessories can detect cloud mode
+            cloudApi: api,
+            messaging,
+            log: this.log,
+            UUID: UUID.generate(UUID_SEED + ':' + config.id),
+            connect: false
+        }));
     }
 
     registerPlatformAccessories(platformAccessories) {

--- a/lib/IrrigationSystemAccessory.js
+++ b/lib/IrrigationSystemAccessory.js
@@ -45,15 +45,20 @@ class IrrigationSystemAccessory extends BaseAccessory {
         // Self-contained (no reliance on instance state) so it is safe to call
         // both during early service reconciliation and later when wiring
         // characteristics.
+        const cloud = this._isCloud();
         const defaultDuration = isFinite(this.device.context.defaultDuration) ? parseInt(this.device.context.defaultDuration) : 600;
 
         if (Array.isArray(this.device.context.valves) && this.device.context.valves.length) {
             return this.device.context.valves.map((valve, i) => {
-                if (!valve || !isFinite(valve.dp) || parseInt(valve.dp) <= 0) {
-                    throw new Error(`The valve definition #${i + 1} is missing a valid 'dp': ${JSON.stringify(valve)}`);
+                // A data-point may be a numeric LAN id (1, 2, …) or a Tuya Cloud
+                // code (e.g. "switch_1"). Accept either; only an empty value is
+                // invalid.
+                const dp = (valve && valve.dp !== undefined && valve.dp !== null) ? ('' + valve.dp).trim() : '';
+                if (!dp) {
+                    throw new Error(`The valve definition #${i + 1} is missing a 'dp': ${JSON.stringify(valve)}`);
                 }
                 return {
-                    dp: String(parseInt(valve.dp)),
+                    dp,
                     name: (('' + (valve.name || '')).trim()) || ('Zone ' + (i + 1)),
                     index: i + 1,
                     duration: isFinite(valve.defaultDuration) ? parseInt(valve.defaultDuration) : defaultDuration
@@ -66,13 +71,30 @@ class IrrigationSystemAccessory extends BaseAccessory {
         const configs = [];
         for (let i = 0; i < count; i++) {
             configs.push({
-                dp: String(i + 1),
+                // Cloud devices address valves by code (switch_1, switch_2, …);
+                // LAN devices by numeric data-point id (1, 2, …).
+                dp: cloud ? ('switch_' + (i + 1)) : String(i + 1),
                 name: 'Valve ' + (letters[i] || (i + 1)),
                 index: i + 1,
                 duration: defaultDuration
             });
         }
         return configs;
+    }
+
+    // True when this device is reached over the Tuya Cloud (data-points keyed by
+    // string code) rather than the LAN (numeric data-point ids).
+    _isCloud() {
+        return this._coerceBoolean(this.device.context.cloud, false);
+    }
+
+    // Resolve a configurable data-point that may be given as a numeric LAN id or
+    // a Tuya Cloud code, falling back to a sensible default for the active
+    // transport.
+    _resolveDP(value, cloudDefault, lanDefault) {
+        const v = (value === undefined || value === null) ? '' : ('' + value).trim();
+        if (v !== '') return v;
+        return this._isCloud() ? cloudDefault : lanDefault;
     }
 
     _hasBattery() {
@@ -186,9 +208,11 @@ class IrrigationSystemAccessory extends BaseAccessory {
         this._cascadeOn = this._coerceBoolean(this.device.context.masterTurnsOnAllZones, true);
         this._cascadeOff = this._coerceBoolean(this.device.context.masterTurnsOffAllZones, true);
 
-        this.dpBattery = this._getCustomDP(this.device.context.dpBattery) || '46';
-        this.dpCharging = this._getCustomDP(this.device.context.dpCharging) || '101';
-        this.dpRain = this._getCustomDP(this.device.context.dpRain) || '49';
+        // Data-points accept a numeric LAN id or a Tuya Cloud code; defaults
+        // differ per transport (cloud uses the standard Tuya codes).
+        this.dpBattery = this._resolveDP(this.device.context.dpBattery, 'battery_percentage', '46');
+        this.dpCharging = this._resolveDP(this.device.context.dpCharging, 'charge_state', '101');
+        this.dpRain = this._resolveDP(this.device.context.dpRain, 'rain_sensor_state', '49');
         this._rainOnValue = ('' + (this.device.context.rainOnValue || 'rain')).trim();
         this._rainInverted = this._coerceBoolean(this.device.context.rainInverted, false);
 

--- a/lib/TuyaCloudApi.js
+++ b/lib/TuyaCloudApi.js
@@ -1,0 +1,290 @@
+'use strict';
+
+/*
+ * TuyaCloudApi
+ * ------------
+ * A tiny, dependency-free client for the Tuya Cloud OpenAPI.
+ *
+ * This plugin is, and remains, a LAN-first plugin: almost every Tuya device is
+ * controlled locally over the network. A small class of devices, however,
+ * simply cannot be reached that way — most notably battery-powered "sleepy"
+ * devices (irrigation/faucet timers, door sensors, …). To save battery they
+ * spend nearly all their time asleep and only ever talk to Tuya's cloud (over
+ * MQTT) for a brief moment when they wake. They never keep the local TCP port
+ * (6668) open and never answer LAN discovery, so the cloud is the ONLY way to
+ * reach them. This client exists exclusively for those devices.
+ *
+ * Only the handful of endpoints the plugin needs are implemented:
+ *   - GET  /v1.0/token?grant_type=1        (auth — also yields the account uid)
+ *   - GET  /v1.0/devices/{id}/status       (read all data-points at once)
+ *   - POST /v1.0/devices/{id}/commands     (write data-points)
+ *   - POST /v1.0/iot-03/open-hub/access-config  (optional realtime MQTT config)
+ *
+ * Everything is signed with the Tuya "new" HMAC-SHA256 signature scheme, using
+ * only Node's built-in `https` + `crypto`, so the plugin gains no new runtime
+ * dependency for the core cloud path.
+ *
+ * Docs:
+ *   Signature : https://developer.tuya.com/en/docs/iot/new-singnature
+ *   Control   : https://developer.tuya.com/en/docs/cloud/device-control
+ *   Regions   : https://developer.tuya.com/en/docs/iot/api-request
+ */
+
+const https = require('https');
+const crypto = require('crypto');
+
+// SHA-256 of an empty string — the Content-SHA256 used for GET / empty-body requests.
+const EMPTY_BODY_SHA256 = crypto.createHash('sha256').update('').digest('hex');
+
+// Data-center base URLs. The region MUST match the one the Tuya / Smart Life
+// app account is registered in (App → Me → Settings → Account → Region);
+// cross-region calls are rejected by Tuya.
+const REGION_ENDPOINTS = {
+    cn: 'https://openapi.tuyacn.com',           // China
+    us: 'https://openapi.tuyaus.com',           // Western America (default)
+    'us-e': 'https://openapi-ueaz.tuyaus.com',  // Eastern America (Azure)
+    eu: 'https://openapi.tuyaeu.com',           // Central Europe
+    'eu-w': 'https://openapi-weaz.tuyaeu.com',  // Western Europe (Azure)
+    in: 'https://openapi.tuyain.com',           // India
+    sg: 'https://openapi-sg.iotbing.com'        // Singapore
+};
+
+// Tuya error codes that mean "the access token is no longer usable"; when we
+// see one we drop the cached token and retry the call once.
+const TOKEN_INVALID_CODES = new Set([1010, 1011, 1004]);
+
+class TuyaCloudApi {
+    constructor({accessId, accessKey, region, endpoint, username, password, countryCode, schema, log} = {}) {
+        this.log = log || console;
+        this.accessId = ('' + (accessId || '')).trim();
+        this.accessKey = ('' + (accessKey || '')).trim();
+
+        // Optional "Smart Home" project credentials. When a username/password
+        // are supplied we authenticate as that app account (so the cloud sees
+        // the devices linked to it); otherwise we use the simpler "Custom"
+        // project token flow (grant_type=1).
+        this.username = ('' + (username || '')).trim();
+        this.password = ('' + (password || '')).trim();
+        this.countryCode = ('' + (countryCode || '')).trim();
+        this.schema = (('' + (schema || '')).trim()) || 'tuyaSmart';
+
+        const r = ('' + (region || 'us')).trim().toLowerCase();
+        this.region = r;
+        this.endpoint = (('' + (endpoint || '')).trim()) || REGION_ENDPOINTS[r] || REGION_ENDPOINTS.us;
+        // Strip a trailing slash so path concatenation is predictable.
+        this.endpoint = this.endpoint.replace(/\/+$/, '');
+
+        this._token = null;        // current access_token
+        this.uid = null;           // linked app-account uid (needed for realtime MQTT)
+        this._tokenExpiry = 0;     // ms epoch when the token must be refreshed
+        this._tokenPromise = null; // in-flight token request (de-dupes concurrent callers)
+    }
+
+    isConfigured() {
+        return !!(this.accessId && this.accessKey);
+    }
+
+    // A stable key identifying this credential+region pair, so several devices
+    // that share the same cloud project can share one client (one token, one
+    // realtime connection).
+    static keyFor({accessId, region, endpoint, username} = {}) {
+        const r = ('' + (region || 'us')).trim().toLowerCase();
+        const e = (('' + (endpoint || '')).trim()) || REGION_ENDPOINTS[r] || REGION_ENDPOINTS.us;
+        return `${('' + (accessId || '')).trim()}:${('' + (username || '')).trim()}@${e.replace(/\/+$/, '')}`;
+    }
+
+    /* ----------------------------- signing ----------------------------- */
+
+    _hmac(str) {
+        return crypto.createHmac('sha256', this.accessKey).update(str, 'utf8').digest('hex').toUpperCase();
+    }
+
+    // Build the signed headers for a request. When `withToken` is true the
+    // current access_token is folded into the signature (business calls);
+    // otherwise the token-request variant is used (the token call itself).
+    // `t` and `nonce` are injectable for deterministic testing.
+    _signedHeaders({method, urlPath, bodyStr, withToken, t, nonce} = {}) {
+        t = t || Date.now().toString();
+        nonce = nonce || crypto.randomUUID();
+
+        const contentSha = bodyStr
+            ? crypto.createHash('sha256').update(bodyStr, 'utf8').digest('hex')
+            : EMPTY_BODY_SHA256;
+
+        // stringToSign = METHOD \n Content-SHA256 \n Signature-Headers \n Url
+        // Signature-Headers is intentionally empty (we fold none into the sign).
+        const stringToSign = [method.toUpperCase(), contentSha, '', urlPath].join('\n');
+        const str = (withToken
+            ? this.accessId + this._token + t + nonce
+            : this.accessId + t + nonce) + stringToSign;
+
+        const headers = {
+            'client_id': this.accessId,
+            'sign': this._hmac(str),
+            't': t,
+            'sign_method': 'HMAC-SHA256',
+            'nonce': nonce,
+            'Content-Type': 'application/json'
+        };
+        if (withToken) headers['access_token'] = this._token;
+        return headers;
+    }
+
+    /* ------------------------------ token ------------------------------ */
+
+    async _ensureToken() {
+        if (this._token && Date.now() < this._tokenExpiry) return this._token;
+        if (this._tokenPromise) return this._tokenPromise;
+
+        this._tokenPromise = (async () => {
+            const res = this._useSmartHomeLogin()
+                ? await this._loginSmartHome()
+                : await this._loginCustom();
+            if (!res || res.success !== true || !res.result || !res.result.access_token) {
+                throw new Error(`token request failed: ${this._describeError(res)}`);
+            }
+            this._token = res.result.access_token;
+            this.uid = res.result.uid || this.uid;
+            // Refresh a minute early so a token never expires mid-request.
+            const ttl = (parseInt(res.result.expire_time) || 7200) * 1000;
+            this._tokenExpiry = Date.now() + Math.max(60000, ttl - 60000);
+            return this._token;
+        })();
+
+        try {
+            return await this._tokenPromise;
+        } finally {
+            this._tokenPromise = null;
+        }
+    }
+
+    _useSmartHomeLogin() {
+        return !!(this.username && this.password);
+    }
+
+    // "Custom" project: GET /v1.0/token?grant_type=1 (token-variant signature).
+    _loginCustom() {
+        const urlPath = '/v1.0/token?grant_type=1';
+        const headers = this._signedHeaders({method: 'GET', urlPath, bodyStr: '', withToken: false});
+        return this._httpsRequest('GET', urlPath, headers, null);
+    }
+
+    // "Smart Home" project: authenticate as the linked app account. The password
+    // is sent as a lowercase hex MD5; the request is signed with the token
+    // (no-access-token) variant since we don't hold a token yet.
+    _loginSmartHome() {
+        const urlPath = '/v1.0/iot-01/associated-users/actions/authorized-login';
+        const body = {
+            country_code: this.countryCode,
+            username: this.username,
+            password: crypto.createHash('md5').update('' + this.password).digest('hex'),
+            schema: this.schema
+        };
+        const bodyStr = JSON.stringify(body);
+        const headers = this._signedHeaders({method: 'POST', urlPath, bodyStr, withToken: false});
+        return this._httpsRequest('POST', urlPath, headers, bodyStr);
+    }
+
+    _invalidateToken() {
+        this._token = null;
+        this._tokenExpiry = 0;
+    }
+
+    /* --------------------------- requests ------------------------------ */
+
+    async request(method, urlPath, body, _retried) {
+        await this._ensureToken();
+        const bodyStr = body ? JSON.stringify(body) : '';
+        const headers = this._signedHeaders({method, urlPath, bodyStr, withToken: true});
+        const res = await this._httpsRequest(method, urlPath, headers, bodyStr || null);
+
+        if (res && res.success === false) {
+            if (!_retried && TOKEN_INVALID_CODES.has(res.code)) {
+                this._invalidateToken();
+                return this.request(method, urlPath, body, true);
+            }
+            throw new Error(`${method} ${urlPath} failed: ${this._describeError(res)}`);
+        }
+        return res;
+    }
+
+    // Read every reported data-point in one call → array of {code, value}.
+    async getStatus(deviceId) {
+        const res = await this.request('GET', `/v1.0/devices/${encodeURIComponent(deviceId)}/status`);
+        return (res && Array.isArray(res.result)) ? res.result : [];
+    }
+
+    // Issue one or more commands: [{code, value}, …].
+    async sendCommands(deviceId, commands) {
+        if (!Array.isArray(commands) || !commands.length) return true;
+        const res = await this.request('POST', `/v1.0/devices/${encodeURIComponent(deviceId)}/commands`, {commands});
+        return !!(res && res.result);
+    }
+
+    // Fetch broker credentials for the realtime MQTT message service. Returns
+    // the raw `result` object (url, client_id, username, password, source_topic,
+    // expire_time, …) or throws. Requires the account uid (from the token call)
+    // and that the project has the "Message Service" API authorized.
+    async getMqttConfig(linkId) {
+        await this._ensureToken();
+        if (!this.uid) throw new Error('no account uid available for MQTT config');
+        const body = {
+            uid: this.uid,
+            link_id: linkId,
+            link_type: 'mqtt',
+            topics: 'device',
+            msg_encrypted_version: '2.0'
+        };
+        const res = await this.request('POST', '/v1.0/iot-03/open-hub/access-config', body);
+        if (!res || res.success !== true || !res.result) {
+            throw new Error(`MQTT config request failed: ${this._describeError(res)}`);
+        }
+        return res.result;
+    }
+
+    _describeError(res) {
+        if (!res) return 'no/empty response';
+        if (res.msg || res.code) return `${res.msg || ''} (code ${res.code})`.trim();
+        return 'unexpected response';
+    }
+
+    /* ------------------------- transport ------------------------------- */
+
+    _httpsRequest(method, urlPath, headers, bodyStr) {
+        return new Promise((resolve, reject) => {
+            let url;
+            try {
+                url = new URL(this.endpoint + urlPath);
+            } catch (ex) {
+                return reject(ex);
+            }
+
+            const req = https.request({
+                hostname: url.hostname,
+                port: url.port || 443,
+                path: url.pathname + url.search,
+                method,
+                headers
+            }, resp => {
+                let data = '';
+                resp.setEncoding('utf8');
+                resp.on('data', chunk => { data += chunk; });
+                resp.on('end', () => {
+                    try {
+                        resolve(JSON.parse(data));
+                    } catch (ex) {
+                        reject(new Error(`Tuya Cloud returned non-JSON (HTTP ${resp.statusCode}): ${('' + data).slice(0, 200)}`));
+                    }
+                });
+            });
+
+            req.on('error', reject);
+            req.setTimeout(20000, () => req.destroy(new Error('request timed out')));
+            if (bodyStr) req.write(bodyStr);
+            req.end();
+        });
+    }
+}
+
+TuyaCloudApi.REGION_ENDPOINTS = REGION_ENDPOINTS;
+module.exports = TuyaCloudApi;

--- a/lib/TuyaCloudDevice.js
+++ b/lib/TuyaCloudDevice.js
@@ -1,0 +1,188 @@
+'use strict';
+
+const EventEmitter = require('events');
+
+/*
+ * TuyaCloudDevice
+ * ---------------
+ * A drop-in replacement for TuyaAccessory (the LAN device class) that talks to
+ * a device through the Tuya Cloud instead of the local network. It deliberately
+ * exposes the exact same minimal contract every accessory relies on, so the
+ * existing accessories (IrrigationSystemAccessory, …) work unchanged on top:
+ *
+ *   - `context`            device config (name, id, type, …)
+ *   - `state`              current data-points  { <code>: value, … }
+ *   - `connected`          boolean
+ *   - `_connect()`         start talking to the device
+ *   - `update(dps)`        write data-points
+ *   - 'connect' / 'change' events  (change → (changes, state))
+ *
+ * The one meaningful difference from the LAN class is the data-point KEY. The
+ * LAN protocol addresses data-points by numeric id (1, 2, …); the cloud speaks
+ * string "codes" (e.g. `switch_1`, `battery_percentage`). So `state` here is
+ * keyed by code, and accessories used over the cloud are configured with codes.
+ * The device logs its codes on connect to make that configuration obvious.
+ *
+ * Updates are delivered by Tuya's realtime MQTT message service (see
+ * TuyaCloudMessaging) — there is no periodic polling. Two REST calls are still
+ * inherent to the cloud, because MQTT only carries *changes* and is
+ * *receive-only*:
+ *   - one `GET /status` to learn the initial state on connect (and again as a
+ *     catch-up whenever the realtime stream (re)connects), and
+ *   - `POST /commands` to actually control the device.
+ */
+
+class TuyaCloudDevice extends EventEmitter {
+    constructor(props = {}) {
+        super();
+        this.log = props.log || console;
+        this.api = props.cloudApi;
+        this.messaging = props.messaging || null; // shared realtime stream
+
+        // Keep a plain config object on `context`, mirroring TuyaAccessory, but
+        // without the live helper objects we were handed.
+        this.context = {...props};
+        delete this.context.cloudApi;
+        delete this.context.messaging;
+        delete this.context.log;
+
+        this.state = {};
+        this.connected = false;
+        this._stopped = false;
+        this._retryTimer = null;
+
+        if (props.connect !== false) this._connect();
+    }
+
+    /* ------------------------------------------------------------------ *
+     *  Connect: read initial state, announce, then let realtime keep it fresh.
+     * ------------------------------------------------------------------ */
+
+    async _connect() {
+        if (!this.api || !this.api.isConfigured()) {
+            return this.log.error(`${this.context.name}: Tuya Cloud is not configured (missing accessId/accessKey).`);
+        }
+
+        try {
+            const status = await this.api.getStatus(this.context.id);
+            this.state = this._statusToState(status);
+            this.connected = true;
+
+            this._logDiscoveredCodes(status);
+
+            this.emit('connect');
+            // Accessories register their characteristics off the first 'change'.
+            this.emit('change', {...this.state}, this.state);
+
+            this._subscribeRealtime();
+        } catch (ex) {
+            this.log.error(`${this.context.name}: failed to connect to Tuya Cloud: ${ex.message}`);
+            // Retry later — credentials/permissions/network may recover.
+            if (!this._stopped) {
+                this._retryTimer = setTimeout(() => this._connect(), 30000);
+            }
+        }
+    }
+
+    /* ------------------------------------------------------------------ *
+     *  Realtime (shared MQTT stream)
+     * ------------------------------------------------------------------ */
+
+    _subscribeRealtime() {
+        if (!this.messaging) {
+            return this.log.warn(`${this.context.name}: realtime updates are unavailable (no MQTT). Control still works, but external changes (physical buttons, the device's own timers) won't be reflected until restart. Ensure the "mqtt" package is installed and realtime isn't disabled in the cloud config.`);
+        }
+        // Register the reconnect catch-up handler before starting, so the very
+        // first 'online' is caught. On any (re)connect we re-read the full state
+        // to recover anything missed while the stream was down.
+        this.messaging.on('online', () => this._refreshState());
+        this.messaging.subscribeDevice(this.context.id, status => this._applyStatus(status));
+    }
+
+    async _refreshState() {
+        if (this._stopped) return;
+        try {
+            const status = await this.api.getStatus(this.context.id);
+            this._applyStatus(status);
+        } catch (ex) {
+            this.log.debug(`${this.context.name}: cloud state refresh failed: ${ex.message}`);
+        }
+    }
+
+    /* ------------------------------------------------------------------ *
+     *  State helpers
+     * ------------------------------------------------------------------ */
+
+    // Convert a Tuya `[{code, value}]` status array into a flat { code: value }.
+    _statusToState(status) {
+        const state = {};
+        (status || []).forEach(item => {
+            if (item && typeof item.code === 'string') state[item.code] = item.value;
+        });
+        return state;
+    }
+
+    // Apply a fresh snapshot (initial / catch-up) or a realtime delta, diff it
+    // against what we hold, and emit only what changed — exactly mirroring
+    // TuyaAccessory._change so accessories behave identically.
+    _applyStatus(status) {
+        const incoming = this._statusToState(status);
+        const changes = {};
+        Object.keys(incoming).forEach(code => {
+            if (incoming[code] !== this.state[code]) changes[code] = incoming[code];
+        });
+        if (Object.keys(changes).length) {
+            this.state = {...this.state, ...incoming};
+            this.emit('change', changes, this.state);
+        }
+        return changes;
+    }
+
+    _logDiscoveredCodes(status) {
+        try {
+            const list = (status || []).map(i => `${i.code}=${JSON.stringify(i.value)}`).join(', ');
+            this.log.info(`${this.context.name}: Tuya Cloud data-point codes → ${list || '(none reported)'}`);
+        } catch (_) { /* logging must never throw */ }
+    }
+
+    /* ------------------------------------------------------------------ *
+     *  Writes
+     * ------------------------------------------------------------------ */
+
+    // Write data-points. `dps` is keyed by code → value (the accessory was
+    // configured with codes). We deliberately do NOT optimistically mutate
+    // `this.state`: the accessory already reflects the user's intent in HomeKit
+    // immediately, and leaving `state` untouched lets the realtime stream
+    // confirm the real device state without a spurious "revert" while a sleepy
+    // device catches up. Returns truthy like TuyaAccessory.update().
+    update(dps) {
+        if (!dps || typeof dps !== 'object') return true;
+
+        const commands = Object.keys(dps).map(code => ({code, value: dps[code]}));
+        if (!commands.length) return true;
+
+        if (!this.connected) {
+            this.log.debug(`${this.context.name}: skipping cloud write, not connected`);
+            return false;
+        }
+
+        this.api.sendCommands(this.context.id, commands)
+            .then(ok => {
+                if (!ok) this.log.warn(`${this.context.name}: Tuya Cloud rejected command ${JSON.stringify(commands)}`);
+            })
+            .catch(ex => this.log.error(`${this.context.name}: cloud command failed: ${ex.message}`));
+
+        return true;
+    }
+
+    /* ------------------------------------------------------------------ *
+     *  Teardown (tidy; Homebridge doesn't strictly require it)
+     * ------------------------------------------------------------------ */
+
+    stop() {
+        this._stopped = true;
+        if (this._retryTimer) { clearTimeout(this._retryTimer); this._retryTimer = null; }
+    }
+}
+
+module.exports = TuyaCloudDevice;

--- a/lib/TuyaCloudMessaging.js
+++ b/lib/TuyaCloudMessaging.js
@@ -1,0 +1,232 @@
+'use strict';
+
+const EventEmitter = require('events');
+const crypto = require('crypto');
+
+/*
+ * TuyaCloudMessaging
+ * ------------------
+ * Optional realtime updates for cloud-backed devices, over Tuya's MQTT message
+ * service. ONE instance is shared by every cloud device on the same Tuya
+ * project (one broker connection delivers status for all of them); messages are
+ * fanned out to the right device by its `devId`.
+ *
+ * This is intentionally a best-effort accelerator layered on top of polling:
+ * if the optional `mqtt` package is missing, or the broker can't be reached, or
+ * a message can't be decrypted, nothing breaks — the devices simply keep
+ * polling. When it IS working, changes (including physical button presses and
+ * the rain sensor) show up in HomeKit within a second or two.
+ *
+ * The connection + AES-GCM message decryption are faithful to the
+ * actively-maintained `0x5e/homebridge-tuya-platform` (`src/core/TuyaOpenMQ.ts`),
+ * re-implemented here with Node's built-in `crypto`.
+ */
+
+const GCM_TAG_LENGTH = 16;
+const PROTOCOL_DEVICE_STATUS = 4;
+
+// `mqtt` is an OPTIONAL dependency: realtime is a bonus, polling is the
+// guarantee. Loading it lazily keeps the plugin LAN-first and lets it run in
+// environments where mqtt isn't (or can't be) installed.
+let mqtt = null;
+let mqttLoadError = null;
+try {
+    mqtt = require('mqtt');
+} catch (ex) {
+    mqttLoadError = ex;
+}
+
+class TuyaCloudMessaging extends EventEmitter {
+    constructor({api, log} = {}) {
+        super();
+        this.api = api;
+        this.log = log || console;
+
+        this.linkId = crypto.randomUUID(); // bare v4 UUID, reused across reconnects
+        this.client = null;
+        this.config = null;
+        this.connected = false;
+
+        this._handlers = new Map(); // devId -> [fn(status)]
+        this._renewTimer = null;
+        this._started = false;
+        this._stopped = false;
+
+        // EventEmitter with many devices listening to 'online'/'offline'.
+        this.setMaxListeners(0);
+    }
+
+    static isAvailable() {
+        return !!mqtt;
+    }
+
+    // Register a device's status handler and lazily start the shared connection.
+    subscribeDevice(devId, handler) {
+        const id = '' + devId;
+        if (!this._handlers.has(id)) this._handlers.set(id, []);
+        this._handlers.get(id).push(handler);
+        if (!this._started) this.start();
+    }
+
+    start() {
+        if (this._stopped || this._started) return;
+        this._started = true;
+
+        if (!mqtt) {
+            this.log.warn(`Tuya Cloud realtime disabled: the optional "mqtt" package is not installed${mqttLoadError ? ` (${mqttLoadError.message})` : ''}. Devices will poll instead. Install it with "npm install mqtt" in the plugin folder to enable instant updates.`);
+            return;
+        }
+
+        this._connect().catch(ex => {
+            this.log.warn(`Tuya Cloud realtime could not start (${ex.message}); devices will poll instead.`);
+            this._scheduleRenew(60);
+        });
+    }
+
+    async _connect() {
+        if (this._stopped) return;
+        this._teardownClient();
+
+        const cfg = await this.api.getMqttConfig(this.linkId);
+        this.config = cfg;
+
+        if (!cfg.url || !cfg.source_topic || !cfg.source_topic.device) {
+            throw new Error('incomplete MQTT config from Tuya');
+        }
+
+        const client = mqtt.connect(cfg.url, {
+            clientId: cfg.client_id,
+            username: cfg.username,
+            password: cfg.password
+        });
+
+        client.on('connect', () => {
+            this.connected = true;
+            client.subscribe(cfg.source_topic.device, err => {
+                if (err) this.log.debug(`Tuya Cloud realtime subscribe error: ${err.message}`);
+            });
+            this.log.info('Tuya Cloud realtime connected (MQTT).');
+            this.emit('online');
+        });
+        client.on('message', (topic, payload) => this._onMessage(topic, payload));
+        client.on('error', err => this.log.debug(`Tuya Cloud realtime error: ${err && err.message}`));
+        client.on('close', () => this._markOffline());
+        client.on('end', () => this._markOffline());
+
+        this.client = client;
+
+        // Broker credentials expire; renew them a minute early (mqtt.js handles
+        // transient drops on its own via auto-reconnect).
+        const ttl = parseInt(cfg.expire_time) || 7200;
+        this._scheduleRenew(Math.max(60, ttl - 60));
+    }
+
+    _markOffline() {
+        if (this.connected) {
+            this.connected = false;
+            this.emit('offline');
+        }
+    }
+
+    _scheduleRenew(seconds) {
+        if (this._renewTimer) clearTimeout(this._renewTimer);
+        if (this._stopped) return;
+        this._renewTimer = setTimeout(() => {
+            this._connect().catch(ex => {
+                this.log.debug(`Tuya Cloud realtime renew failed: ${ex.message}`);
+                this._scheduleRenew(60);
+            });
+        }, seconds * 1000);
+    }
+
+    _onMessage(topic, payload) {
+        let envelope;
+        try {
+            envelope = JSON.parse(payload.toString());
+        } catch (_) { return; }
+
+        const {protocol, data, t} = envelope;
+        if (!data) return;
+
+        let plaintext;
+        try {
+            plaintext = this._decrypt(data, this.config && this.config.password, t);
+        } catch (ex) {
+            this.log.debug(`Tuya Cloud realtime decrypt failed: ${ex.message}`);
+            return;
+        }
+
+        let msg;
+        try {
+            msg = JSON.parse(plaintext);
+        } catch (_) { return; }
+
+        // We only care about device status frames (protocol 4). Some firmwares
+        // omit `protocol`; in that case fall back to "has a status array".
+        if (protocol != null && protocol !== PROTOCOL_DEVICE_STATUS && !(msg && Array.isArray(msg.status))) return;
+
+        const devId = msg && (msg.devId || msg.devid || msg.dev_id);
+        const status = msg && msg.status;
+        if (!devId || !Array.isArray(status)) return;
+
+        const handlers = this._handlers.get('' + devId);
+        if (!handlers || !handlers.length) return;
+        handlers.forEach(fn => {
+            try { fn(status); } catch (ex) { this.log.debug(`Tuya Cloud realtime handler error: ${ex.message}`); }
+        });
+    }
+
+    // Decrypt the MQTT `data` field. msg_encrypted_version 2.0 → AES-128-GCM,
+    // 1.0 → AES-128-ECB. The AES key is the middle 16 chars of the broker
+    // password (NOT the project Access Secret).
+    _decrypt(data, password, t) {
+        const key = Buffer.from(('' + (password || '')).substring(8, 24), 'utf8');
+        const buf = Buffer.from(data, 'base64');
+
+        // GCM (v2.0) layout: [ivLen(4) BE][iv(ivLen)][ciphertext][tag(16)].
+        // Try it first; if the header doesn't look like a sane IV length, or
+        // auth fails, fall back to ECB (v1.0).
+        if (buf.length > 4 + GCM_TAG_LENGTH) {
+            const ivLen = buf.readUIntBE(0, 4);
+            if (ivLen >= 12 && ivLen <= 16 && (4 + ivLen + GCM_TAG_LENGTH) <= buf.length) {
+                try {
+                    const iv = buf.slice(4, 4 + ivLen);
+                    const ciphertext = buf.slice(4 + ivLen, buf.length - GCM_TAG_LENGTH);
+                    const tag = buf.slice(buf.length - GCM_TAG_LENGTH);
+                    const decipher = crypto.createDecipheriv('aes-128-gcm', key, iv);
+                    decipher.setAuthTag(tag);
+                    const aad = Buffer.allocUnsafe(6);
+                    aad.writeUIntBE(Number(t) || 0, 0, 6);
+                    decipher.setAAD(aad);
+                    return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
+                } catch (gcmEx) {
+                    // fall through to ECB
+                }
+            }
+        }
+
+        const decipher = crypto.createDecipheriv('aes-128-ecb', key, null);
+        return Buffer.concat([decipher.update(buf), decipher.final()]).toString('utf8');
+    }
+
+    _teardownClient() {
+        if (this.client) {
+            try {
+                this.client.removeAllListeners();
+                this.client.end(true);
+            } catch (_) { /* ignore */ }
+            this.client = null;
+        }
+        this.connected = false;
+    }
+
+    stop() {
+        this._stopped = true;
+        if (this._renewTimer) { clearTimeout(this._renewTimer); this._renewTimer = null; }
+        this._teardownClient();
+    }
+}
+
+// Expose for unit tests / encryption round-trips.
+TuyaCloudMessaging.GCM_TAG_LENGTH = GCM_TAG_LENGTH;
+module.exports = TuyaCloudMessaging;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-tuya-plus",
-  "version": "3.12.0",
+  "version": "3.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-tuya-plus",
-      "version": "3.12.0",
+      "version": "3.13.0",
       "license": "MIT",
       "dependencies": {
         "async": "^3.2.2",
@@ -14,6 +14,7 @@
         "fs-extra": "^8.1.0",
         "http-mitm-proxy": "^1.1.0",
         "json5": "^2.2.0",
+        "mqtt": "^5.10.1",
         "qrcode": "^1.4.1",
         "yaml": "^1.6.0"
       },
@@ -31,6 +32,9 @@
       "engines": {
         "homebridge": "^1.8.0 || ^2.0.0-beta.0",
         "node": "^20.18.0 || ^22.10.0 || ^24.0.0"
+      },
+      "optionalDependencies": {
+        "mqtt": "^5.15.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -472,6 +476,16 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1476,10 +1490,20 @@
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/readable-stream": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.23.tgz",
+      "integrity": "sha512-wwXrtQvbMHxCbBgjHaMGEmImFTQxxpfMOR/ZoQnXxB1woqkUbdLGFDgauo00Py9IudiaqSeiBiulSV9i6XIPig==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -1488,6 +1512,16 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -1619,9 +1653,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1636,9 +1667,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1653,9 +1681,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1670,9 +1695,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1687,9 +1709,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1704,9 +1723,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1721,9 +1737,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1738,9 +1751,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1805,6 +1815,19 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -2036,6 +2059,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.25",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.25.tgz",
@@ -2049,6 +2093,19 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bl": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-6.1.6.tgz",
+      "integrity": "sha512-jLsPgN/YSvPUg9UX0Kd73CXpm2Psg9FxMeCSXnk3WBO3CMT10JMwijubhGfHCnFu6TPn1ei3b975dxv7K2pWVg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/readable-stream": "^4.0.0",
+        "buffer": "^6.0.3",
+        "inherits": "^2.0.4",
+        "readable-stream": "^4.2.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
@@ -2058,6 +2115,19 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/broker-factory": {
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/broker-factory/-/broker-factory-3.1.15.tgz",
+      "integrity": "sha512-ko+aWvgNuP49meGrdjUu7rC+Y+Wai3cCPxP3xWwHsHfehFjOh5ZQM2yC4gEB2UddeZ/YXhm0K1eG/L6fxym2Og==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.29.7",
+        "fast-unique-numbers": "^9.0.27",
+        "tslib": "^2.8.1",
+        "worker-factory": "^7.0.50"
       }
     },
     "node_modules/browserslist": {
@@ -2104,11 +2174,36 @@
         "node-int64": "^0.4.0"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/callsites": {
@@ -2315,12 +2410,50 @@
       "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
       "license": "MIT"
     },
+    "node_modules/commist": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/commist/-/commist-3.2.0.tgz",
+      "integrity": "sha512-4PIMoPniho+LqXmpS5d3NuGYncG6XWlkBSVGiWycL22dd42OYdUGil2CWuzklaJoNxyxUSpO4MKIBU94viWNAw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -2652,6 +2785,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -2731,6 +2884,20 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-unique-numbers": {
+      "version": "9.0.27",
+      "resolved": "https://registry.npmjs.org/fast-unique-numbers/-/fast-unique-numbers-9.0.27.tgz",
+      "integrity": "sha512-nDA9ADeINN8SA2u2wCtU+siWFTTDqQR37XvgPIDDmboWQeExz7X0mImxuaN+kJddliIqy2FpVRmnvRZ+j8i1/A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.2.0"
+      }
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -2978,6 +3145,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -3016,6 +3190,27 @@
       "engines": {
         "node": ">=10.17.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -3090,8 +3285,18 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -3854,6 +4059,17 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/js-sdsl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
+      "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4079,6 +4295,16 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -4100,6 +4326,58 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/mqtt": {
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-5.15.1.tgz",
+      "integrity": "sha512-V1WnkGuJh3ec9QXzy5Iylw8OOBK+Xu1WhxcQ9mMpLThG+/JZIMV1PgLNRgIiqXhZnvnVLsuyxHl5A/3bHHbcAA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/readable-stream": "^4.0.21",
+        "@types/ws": "^8.18.1",
+        "commist": "^3.2.0",
+        "concat-stream": "^2.0.0",
+        "debug": "^4.4.1",
+        "help-me": "^5.0.0",
+        "lru-cache": "^10.4.3",
+        "minimist": "^1.2.8",
+        "mqtt-packet": "^9.0.2",
+        "number-allocator": "^1.0.14",
+        "readable-stream": "^4.7.0",
+        "rfdc": "^1.4.1",
+        "socks": "^2.8.6",
+        "split2": "^4.2.0",
+        "worker-timers": "^8.0.23",
+        "ws": "^8.18.3"
+      },
+      "bin": {
+        "mqtt": "build/bin/mqtt.js",
+        "mqtt_pub": "build/bin/pub.js",
+        "mqtt_sub": "build/bin/sub.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/mqtt-packet": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-9.0.2.tgz",
+      "integrity": "sha512-MvIY0B8/qjq7bKxdN1eD+nrljoeaai+qjLJgfRn3TiMuz0pamsIWY2bFODPZMSNmabsLANXsLl4EMoWvlaTZWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bl": "^6.0.8",
+        "debug": "^4.3.4",
+        "process-nextick-args": "^2.0.1"
+      }
+    },
+    "node_modules/mqtt/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -4174,6 +4452,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/number-allocator": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/number-allocator/-/number-allocator-1.0.14.tgz",
+      "integrity": "sha512-OrL44UTVAvkKdOdRQZIJpLkAdjXGTRda052sN4sO77bKEzYYqWKMBjQvrJFzqygI99gL6Z4u2xctPW1tB8ErvA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "^4.3.1",
+        "js-sdsl": "4.3.0"
       }
     },
     "node_modules/once": {
@@ -4499,6 +4788,23 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4709,6 +5015,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4756,6 +5079,34 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/semaphore": {
       "version": "1.1.0",
@@ -4827,6 +5178,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -4846,6 +5223,16 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
@@ -4876,6 +5263,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-length": {
@@ -5129,7 +5526,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD",
       "optional": true
     },
@@ -5169,11 +5565,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/undici-types": {
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/universalify": {
@@ -5261,6 +5664,13 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/uuid": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
@@ -5330,6 +5740,57 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/worker-factory": {
+      "version": "7.0.50",
+      "resolved": "https://registry.npmjs.org/worker-factory/-/worker-factory-7.0.50.tgz",
+      "integrity": "sha512-hhwc0G+sFwM4qBuhJIUBn2p1Jf8v/FwmLUANBf/Q+Lt2uI8mfIZQhXaZQACodQD4R7Zp6cn/6702bIvNn2puJQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.29.7",
+        "fast-unique-numbers": "^9.0.27",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/worker-timers": {
+      "version": "8.0.32",
+      "resolved": "https://registry.npmjs.org/worker-timers/-/worker-timers-8.0.32.tgz",
+      "integrity": "sha512-huEv5mB6xIqcadsZ8SuuFQH9Lg9Hq0h0xD9vAZZsLPNw0aLxoDWyjTALAUD3hAA4cuKbKaqrjbBcbEYClwSh3w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.29.7",
+        "tslib": "^2.8.1",
+        "worker-timers-broker": "^8.0.16",
+        "worker-timers-worker": "^9.0.14"
+      }
+    },
+    "node_modules/worker-timers-broker": {
+      "version": "8.0.17",
+      "resolved": "https://registry.npmjs.org/worker-timers-broker/-/worker-timers-broker-8.0.17.tgz",
+      "integrity": "sha512-avGDVB9AP5k5eCAP2AiT/nwCHGCNla7Z+nMZWXpmhbiSTry6A7VwEzlffTO34/5Eo55O+XLbWQu0bBW3uEO0UA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.29.7",
+        "broker-factory": "^3.1.15",
+        "fast-unique-numbers": "^9.0.27",
+        "tslib": "^2.8.1",
+        "worker-timers-worker": "^9.0.14"
+      }
+    },
+    "node_modules/worker-timers-worker": {
+      "version": "9.0.15",
+      "resolved": "https://registry.npmjs.org/worker-timers-worker/-/worker-timers-worker-9.0.15.tgz",
+      "integrity": "sha512-KKUe7lZ/Aignr51H6hOUik8LwTnIgojH/1lwhli8A8qIEIyewogZTpNpMW5B6BF7nmwBOkUoTYgf1H3QShcjSA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.29.7",
+        "tslib": "^2.8.1",
+        "worker-factory": "^7.0.50"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "qrcode": "^1.4.1",
     "yaml": "^1.6.0"
   },
+  "optionalDependencies": {
+    "mqtt": "^5.15.1"
+  },
   "keywords": [
     "homebridge-plugin",
     "homebridge",

--- a/test/IrrigationSystemAccessory.test.js
+++ b/test/IrrigationSystemAccessory.test.js
@@ -444,3 +444,52 @@ describe('IrrigationSystemAccessory — rain mapping', () => {
         expect(instance._rainDetected('no_rain')).toBe(false);
     });
 });
+
+describe('IrrigationSystemAccessory — cloud mode (data-points keyed by code)', () => {
+    // Mirrors a real Tuya "sfkzq" watering controller reached over the cloud:
+    // valves are switch_1..4, battery is battery_percentage, and there is no
+    // rain sensor.
+    const cloudState = () => ({ switch_1: false, switch_2: false, switch_3: false, switch_4: false, battery_percentage: 99 });
+    const cloudCtx = { cloud: true, noRainSensor: true };
+
+    beforeEach(() => jest.useFakeTimers());
+    afterEach(() => { jest.clearAllTimers(); jest.useRealTimers(); });
+
+    test('default valves use Tuya codes switch_1..switch_4 (not numeric ids)', () => {
+        const { accessory } = makeHarness(cloudState(), cloudCtx);
+        ['switch_1', 'switch_2', 'switch_3', 'switch_4'].forEach(code => {
+            expect(valve(accessory, code)).toBeTruthy();
+        });
+        expect(valve(accessory, '1')).toBeFalsy();
+    });
+
+    test('turning a zone on writes the code/value to the device', () => {
+        const { accessory, device } = makeHarness(cloudState(), cloudCtx);
+        valve(accessory, 'switch_1').getCharacteristic(Characteristic.Active).triggerSet(1);
+        jest.advanceTimersByTime(500);
+        expect(device.update).toHaveBeenCalledWith({ switch_1: true });
+    });
+
+    test('battery is read from the battery_percentage code', () => {
+        const { accessory } = makeHarness(cloudState(), cloudCtx);
+        const battery = accessory.getService(Service.Battery);
+        expect(battery.getCharacteristic(Characteristic.BatteryLevel).value).toBe(99);
+    });
+
+    test('a realtime change keyed by code is reflected in HomeKit', () => {
+        const { accessory, device } = makeHarness(cloudState(), cloudCtx);
+        device.emitChange({ switch_2: true });
+        expect(valve(accessory, 'switch_2').getCharacteristic(Characteristic.Active).value).toBe(Characteristic.Active.ACTIVE);
+    });
+
+    test('an explicit valve list may use custom codes', () => {
+        const { accessory, device } = makeHarness(
+            { zone_a: false, zone_b: false, battery_percentage: 50 },
+            { cloud: true, noRainSensor: true, valves: [{ name: 'A', dp: 'zone_a' }, { name: 'B', dp: 'zone_b' }] }
+        );
+        expect(valve(accessory, 'zone_a')).toBeTruthy();
+        valve(accessory, 'zone_b').getCharacteristic(Characteristic.Active).triggerSet(1);
+        jest.advanceTimersByTime(500);
+        expect(device.update).toHaveBeenCalledWith({ zone_b: true });
+    });
+});

--- a/test/TuyaCloudApi.test.js
+++ b/test/TuyaCloudApi.test.js
@@ -1,0 +1,196 @@
+'use strict';
+
+const crypto = require('crypto');
+const TuyaCloudApi = require('../lib/TuyaCloudApi');
+
+const EMPTY_SHA = crypto.createHash('sha256').update('').digest('hex');
+const md5 = s => crypto.createHash('md5').update(s).digest('hex');
+const hmacUpper = (str, key) => crypto.createHmac('sha256', key).update(str, 'utf8').digest('hex').toUpperCase();
+
+const ACCESS_ID = 'aid123';
+const ACCESS_KEY = 'secretKey456';
+
+const makeApi = (extra = {}) => new TuyaCloudApi({accessId: ACCESS_ID, accessKey: ACCESS_KEY, ...extra});
+
+describe('TuyaCloudApi — configuration', () => {
+    test('resolves region to a known endpoint', () => {
+        expect(makeApi({region: 'eu'}).endpoint).toBe('https://openapi.tuyaeu.com');
+        expect(makeApi({region: 'us'}).endpoint).toBe('https://openapi.tuyaus.com');
+        expect(makeApi({region: 'in'}).endpoint).toBe('https://openapi.tuyain.com');
+    });
+
+    test('unknown region falls back to US', () => {
+        expect(makeApi({region: 'nowhere'}).endpoint).toBe('https://openapi.tuyaus.com');
+    });
+
+    test('explicit endpoint wins and trailing slashes are trimmed', () => {
+        expect(makeApi({endpoint: 'https://example.com/'}).endpoint).toBe('https://example.com');
+    });
+
+    test('isConfigured reflects presence of credentials', () => {
+        expect(makeApi().isConfigured()).toBe(true);
+        expect(new TuyaCloudApi({}).isConfigured()).toBe(false);
+    });
+
+    test('keyFor is stable and distinguishes accounts', () => {
+        const a = TuyaCloudApi.keyFor({accessId: 'x', region: 'eu'});
+        const b = TuyaCloudApi.keyFor({accessId: 'x', region: 'eu'});
+        const c = TuyaCloudApi.keyFor({accessId: 'x', region: 'eu', username: 'u'});
+        expect(a).toBe(b);
+        expect(a).not.toBe(c);
+    });
+});
+
+describe('TuyaCloudApi — request signing', () => {
+    test('business signature folds in the access token and sets the header', () => {
+        const api = makeApi({region: 'eu'});
+        api._token = 'TOK';
+        const t = '1700000000000';
+        const nonce = 'nonce-1';
+        const h = api._signedHeaders({method: 'GET', urlPath: '/v1.0/devices/d/status', bodyStr: '', withToken: true, t, nonce});
+
+        const stringToSign = ['GET', EMPTY_SHA, '', '/v1.0/devices/d/status'].join('\n');
+        const expected = hmacUpper(ACCESS_ID + 'TOK' + t + nonce + stringToSign, ACCESS_KEY);
+
+        expect(h.sign).toBe(expected);
+        expect(h.access_token).toBe('TOK');
+        expect(h.client_id).toBe(ACCESS_ID);
+        expect(h.sign_method).toBe('HMAC-SHA256');
+        expect(h.t).toBe(t);
+        expect(h.nonce).toBe(nonce);
+    });
+
+    test('token signature omits the access token entirely', () => {
+        const api = makeApi();
+        api._token = 'SHOULD_NOT_APPEAR';
+        const t = '1700000000000';
+        const nonce = 'nonce-2';
+        const h = api._signedHeaders({method: 'GET', urlPath: '/v1.0/token?grant_type=1', bodyStr: '', withToken: false, t, nonce});
+
+        const stringToSign = ['GET', EMPTY_SHA, '', '/v1.0/token?grant_type=1'].join('\n');
+        const expected = hmacUpper(ACCESS_ID + t + nonce + stringToSign, ACCESS_KEY);
+
+        expect(h.sign).toBe(expected);
+        expect(h.access_token).toBeUndefined();
+    });
+
+    test('a request body changes the Content-SHA256 portion of the signature', () => {
+        const api = makeApi();
+        api._token = 'TOK';
+        const t = '1700000000000';
+        const nonce = 'n';
+        const body = JSON.stringify({commands: [{code: 'switch_1', value: true}]});
+        const h = api._signedHeaders({method: 'POST', urlPath: '/p', bodyStr: body, withToken: true, t, nonce});
+
+        const contentSha = crypto.createHash('sha256').update(body, 'utf8').digest('hex');
+        const stringToSign = ['POST', contentSha, '', '/p'].join('\n');
+        const expected = hmacUpper(ACCESS_ID + 'TOK' + t + nonce + stringToSign, ACCESS_KEY);
+        expect(h.sign).toBe(expected);
+        expect(contentSha).not.toBe(EMPTY_SHA);
+    });
+});
+
+describe('TuyaCloudApi — auth flow selection', () => {
+    test('custom project uses grant_type=1', async () => {
+        const api = makeApi();
+        const calls = [];
+        api._httpsRequest = async (method, path) => {
+            calls.push({method, path});
+            return {success: true, result: {access_token: 'T', uid: 'U', expire_time: 7200}};
+        };
+        const token = await api._ensureToken();
+        expect(token).toBe('T');
+        expect(api.uid).toBe('U');
+        expect(calls[0].path).toBe('/v1.0/token?grant_type=1');
+        expect(calls[0].method).toBe('GET');
+    });
+
+    test('smart-home project posts an MD5 password to authorized-login', async () => {
+        const api = makeApi({username: 'joe@example.com', password: 'pw', countryCode: '48', schema: 'tuyaSmart'});
+        let captured;
+        api._httpsRequest = async (method, path, headers, bodyStr) => {
+            captured = {method, path, bodyStr};
+            return {success: true, result: {access_token: 'T2', uid: 'U2', expire_time: 7200}};
+        };
+        const token = await api._ensureToken();
+        expect(token).toBe('T2');
+        expect(api.uid).toBe('U2');
+        expect(captured.path).toBe('/v1.0/iot-01/associated-users/actions/authorized-login');
+        const body = JSON.parse(captured.bodyStr);
+        expect(body.username).toBe('joe@example.com');
+        expect(body.password).toBe(md5('pw'));
+        expect(body.country_code).toBe('48');
+        expect(body.schema).toBe('tuyaSmart');
+    });
+});
+
+describe('TuyaCloudApi — endpoints', () => {
+    const ready = () => {
+        const api = makeApi();
+        api._token = 'TOK';
+        api._tokenExpiry = Date.now() + 1e6; // skip token fetch
+        return api;
+    };
+
+    test('getStatus returns the result array', async () => {
+        const api = ready();
+        api._httpsRequest = async () => ({success: true, result: [{code: 'switch_1', value: true}]});
+        await expect(api.getStatus('dev')).resolves.toEqual([{code: 'switch_1', value: true}]);
+    });
+
+    test('sendCommands posts the commands and reports success', async () => {
+        const api = ready();
+        let captured;
+        api._httpsRequest = async (method, path, headers, bodyStr) => {
+            captured = {method, path, body: JSON.parse(bodyStr)};
+            return {success: true, result: true};
+        };
+        const ok = await api.sendCommands('dev', [{code: 'switch_1', value: true}]);
+        expect(ok).toBe(true);
+        expect(captured.method).toBe('POST');
+        expect(captured.path).toBe('/v1.0/devices/dev/commands');
+        expect(captured.body).toEqual({commands: [{code: 'switch_1', value: true}]});
+    });
+
+    test('sendCommands short-circuits on an empty command list', async () => {
+        const api = ready();
+        api._httpsRequest = jest.fn();
+        await expect(api.sendCommands('dev', [])).resolves.toBe(true);
+        expect(api._httpsRequest).not.toHaveBeenCalled();
+    });
+
+    test('getMqttConfig posts the expected body and returns the broker config', async () => {
+        const api = ready();
+        api.uid = 'UID';
+        let captured;
+        api._httpsRequest = async (method, path, headers, bodyStr) => {
+            captured = {path, body: JSON.parse(bodyStr)};
+            return {success: true, result: {url: 'ssl://m1:8883', source_topic: {device: 't'}}};
+        };
+        const cfg = await api.getMqttConfig('link-1');
+        expect(captured.path).toBe('/v1.0/iot-03/open-hub/access-config');
+        expect(captured.body).toEqual({uid: 'UID', link_id: 'link-1', link_type: 'mqtt', topics: 'device', msg_encrypted_version: '2.0'});
+        expect(cfg.url).toBe('ssl://m1:8883');
+    });
+
+    test('an invalid-token error refreshes the token and retries once', async () => {
+        const api = ready();
+        let business = 0;
+        api._httpsRequest = async (method, path) => {
+            // The retry re-fetches a token; serve that separately.
+            if (path.startsWith('/v1.0/token')) return {success: true, result: {access_token: 'TOK2', expire_time: 7200}};
+            business++;
+            if (business === 1) return {success: false, code: 1010, msg: 'token invalid'};
+            return {success: true, result: 'ok'};
+        };
+        const res = await api.request('GET', '/x');
+        expect(business).toBe(2);
+        expect(res.result).toBe('ok');
+    });
+
+    test('a non-token error rejects', async () => {
+        const api = ready();
+        api._httpsRequest = async () => ({success: false, code: 28841002, msg: 'no permissions'});
+        await expect(api.request('GET', '/x')).rejects.toThrow(/no permissions/);
+    });
+});

--- a/test/TuyaCloudDevice.test.js
+++ b/test/TuyaCloudDevice.test.js
@@ -1,0 +1,105 @@
+'use strict';
+
+const EventEmitter = require('events');
+const TuyaCloudDevice = require('../lib/TuyaCloudDevice');
+
+const log = {info: () => {}, warn: () => {}, error: () => {}, debug: () => {}};
+
+function makeApi(status = [{code: 'switch_1', value: false}, {code: 'battery_percentage', value: 99}]) {
+    return {
+        isConfigured: () => true,
+        getStatus: jest.fn().mockResolvedValue(status),
+        sendCommands: jest.fn().mockResolvedValue(true)
+    };
+}
+
+function makeDevice(api, messaging = null, extra = {}) {
+    return new TuyaCloudDevice({
+        cloudApi: api, messaging, log,
+        id: 'dev1', name: 'Sprinklers', type: 'irrigationsystem', cloud: true,
+        connect: false, ...extra
+    });
+}
+
+describe('TuyaCloudDevice', () => {
+    test('connect reads status and emits connect then change (state keyed by code)', async () => {
+        const api = makeApi();
+        const dev = makeDevice(api);
+
+        const events = [];
+        dev.on('connect', () => events.push('connect'));
+        dev.on('change', (changes, state) => events.push({changes, state}));
+
+        await dev._connect();
+
+        expect(dev.connected).toBe(true);
+        expect(dev.state).toEqual({switch_1: false, battery_percentage: 99});
+        expect(events[0]).toBe('connect');
+        expect(events[1].state).toEqual({switch_1: false, battery_percentage: 99});
+        expect(api.getStatus).toHaveBeenCalledWith('dev1');
+    });
+
+    test('update sends code/value commands and does NOT mutate local state', async () => {
+        const api = makeApi();
+        const dev = makeDevice(api);
+        await dev._connect();
+
+        const before = {...dev.state};
+        dev.update({switch_1: true});
+
+        expect(api.sendCommands).toHaveBeenCalledWith('dev1', [{code: 'switch_1', value: true}]);
+        expect(dev.state).toEqual(before); // optimism lives in the accessory, not here
+    });
+
+    test('update is a no-op (no throw) before connect', () => {
+        const api = makeApi();
+        const dev = makeDevice(api);
+        expect(dev.connected).toBe(false);
+        expect(() => dev.update({switch_1: true})).not.toThrow();
+        expect(api.sendCommands).not.toHaveBeenCalled();
+    });
+
+    test('applyStatus emits only the changed data-points', async () => {
+        const api = makeApi();
+        const dev = makeDevice(api);
+        await dev._connect();
+
+        const changes = [];
+        dev.on('change', c => changes.push(c));
+
+        dev._applyStatus([{code: 'switch_1', value: true}, {code: 'battery_percentage', value: 99}]);
+        expect(changes).toHaveLength(1);
+        expect(changes[0]).toEqual({switch_1: true}); // battery unchanged → not emitted
+        expect(dev.state.switch_1).toBe(true);
+
+        changes.length = 0;
+        dev._applyStatus([{code: 'switch_1', value: true}]); // nothing changed
+        expect(changes).toHaveLength(0);
+    });
+
+    test('subscribes to realtime and re-reads state when the stream (re)connects', async () => {
+        const api = makeApi();
+        const messaging = Object.assign(new EventEmitter(), {
+            connected: false,
+            subscribeDevice: jest.fn()
+        });
+        const dev = makeDevice(api, messaging);
+        await dev._connect();
+
+        expect(messaging.subscribeDevice).toHaveBeenCalledWith('dev1', expect.any(Function));
+
+        // A realtime message routed back to the device updates its state.
+        const handler = messaging.subscribeDevice.mock.calls[0][1];
+        const changes = [];
+        dev.on('change', c => changes.push(c));
+        handler([{code: 'switch_2', value: true}]);
+        expect(dev.state.switch_2).toBe(true);
+        expect(changes[0]).toEqual({switch_2: true});
+
+        // On 'online' the device re-reads the full state (catch-up).
+        api.getStatus.mockClear();
+        messaging.emit('online');
+        await new Promise(r => setImmediate(r));
+        expect(api.getStatus).toHaveBeenCalledWith('dev1');
+    });
+});

--- a/test/TuyaCloudMessaging.test.js
+++ b/test/TuyaCloudMessaging.test.js
@@ -1,0 +1,94 @@
+'use strict';
+
+const crypto = require('crypto');
+const TuyaCloudMessaging = require('../lib/TuyaCloudMessaging');
+
+const log = {info: () => {}, warn: () => {}, error: () => {}, debug: () => {}};
+
+// Encrypt exactly like Tuya's msg_encrypted_version 2.0 (AES-128-GCM):
+//   [ivLen(4 BE)][iv][ciphertext][tag(16)], key = password[8,24), AAD = 6-byte BE t.
+function encryptGCM(plaintext, password, t) {
+    const key = Buffer.from(('' + password).substring(8, 24), 'utf8');
+    const iv = crypto.randomBytes(12);
+    const c = crypto.createCipheriv('aes-128-gcm', key, iv);
+    const aad = Buffer.allocUnsafe(6); aad.writeUIntBE(Number(t), 0, 6); c.setAAD(aad);
+    const enc = Buffer.concat([c.update(Buffer.from(plaintext, 'utf8')), c.final()]);
+    const tag = c.getAuthTag();
+    const ivLen = Buffer.allocUnsafe(4); ivLen.writeUIntBE(iv.length, 0, 4);
+    return Buffer.concat([ivLen, iv, enc, tag]).toString('base64');
+}
+
+// AES-128-ECB / PKCS7 (msg_encrypted_version 1.0).
+function encryptECB(plaintext, password) {
+    const key = Buffer.from(('' + password).substring(8, 24), 'utf8');
+    const c = crypto.createCipheriv('aes-128-ecb', key, null);
+    return Buffer.concat([c.update(Buffer.from(plaintext, 'utf8')), c.final()]).toString('base64');
+}
+
+// A messaging instance that won't try to open a real connection.
+function makeIdle(password = 'abcdefgh0123456789WXYZ!!') {
+    const mq = new TuyaCloudMessaging({api: {}, log});
+    mq._started = true; // prevent start()
+    mq.config = {password};
+    return mq;
+}
+
+function envelope(payloadObj, password, {protocol = 4, t = Date.now(), mode = 'gcm'} = {}) {
+    const data = mode === 'ecb'
+        ? encryptECB(JSON.stringify(payloadObj), password)
+        : encryptGCM(JSON.stringify(payloadObj), password, t);
+    return Buffer.from(JSON.stringify({protocol, data, t}));
+}
+
+describe('TuyaCloudMessaging — decryption + dispatch', () => {
+    test('decrypts a GCM status frame and delivers it to the subscribed device', () => {
+        const mq = makeIdle();
+        const received = [];
+        mq.subscribeDevice('DEV1', status => received.push(status));
+
+        const t = Date.now();
+        mq._onMessage('topic', envelope(
+            {devId: 'DEV1', status: [{code: 'switch_1', value: true, t}, {code: 'battery_percentage', value: 80, t}]},
+            mq.config.password, {t}
+        ));
+
+        expect(received).toHaveLength(1);
+        expect(received[0]).toEqual([{code: 'switch_1', value: true, t}, {code: 'battery_percentage', value: 80, t}]);
+    });
+
+    test('decrypts a legacy ECB (v1.0) frame too', () => {
+        const mq = makeIdle();
+        const received = [];
+        mq.subscribeDevice('DEV1', status => received.push(status));
+        mq._onMessage('topic', envelope({devId: 'DEV1', status: [{code: 'switch_2', value: true}]}, mq.config.password, {mode: 'ecb'}));
+        expect(received[0]).toEqual([{code: 'switch_2', value: true}]);
+    });
+
+    test('ignores messages for devices we did not subscribe', () => {
+        const mq = makeIdle();
+        const received = [];
+        mq.subscribeDevice('DEV1', status => received.push(status));
+        mq._onMessage('topic', envelope({devId: 'OTHER', status: [{code: 'switch_1', value: true}]}, mq.config.password, {}));
+        expect(received).toHaveLength(0);
+    });
+
+    test('a frame that cannot be decrypted is dropped without throwing', () => {
+        const mq = makeIdle();
+        const received = [];
+        mq.subscribeDevice('DEV1', status => received.push(status));
+        // Encrypted with the wrong password → auth/decrypt fails.
+        expect(() => mq._onMessage('topic', envelope({devId: 'DEV1', status: [{code: 'x', value: 1}]}, 'ZZZZZZZZwrongkeywrongkey', {}))).not.toThrow();
+        expect(received).toHaveLength(0);
+    });
+
+    test('malformed JSON envelope is ignored', () => {
+        const mq = makeIdle();
+        mq.subscribeDevice('DEV1', () => { throw new Error('should not be called'); });
+        expect(() => mq._onMessage('topic', Buffer.from('not json'))).not.toThrow();
+    });
+
+    test('reports whether realtime is available (mqtt installed)', () => {
+        // mqtt is an (optional) dependency of this project, so it should load.
+        expect(typeof TuyaCloudMessaging.isAvailable()).toBe('boolean');
+    });
+});

--- a/wiki/Supported-Device-Types.md
+++ b/wiki/Supported-Device-Types.md
@@ -732,6 +732,20 @@ Multi-valve Tuya irrigation/sprinkler controllers (the battery-powered Wi-Fi "fa
 
 Because these devices are slow to respond, all zone changes that happen close together — turning the whole system on/off, or running a scene that toggles several zones — are merged into a **single** Tuya command instead of a burst of them.
 
+> **⚠️ Can't connect locally?** Most of these are battery-powered **"sleepy"** devices that **cannot be controlled over the LAN at all** — they sleep to save battery and only ever reach Tuya's cloud. If discovery never finds yours (or it won't connect), control it over the **[Tuya Cloud](https://github.com/adrianjagielak/homebridge-tuya-plus/blob/main/wiki/Tuya-Cloud-Setup.md)** instead: add cloud credentials once and set `"cloud": true` on the device. Everything below works the same — data-points are just addressed by their Tuya *code* (e.g. `switch_1`), which the plugin logs on startup.
+
+```json5
+// Cloud example (also needs a top-level "cloud" credentials block — see the Tuya Cloud Setup guide)
+{
+    "name": "Garden Irrigation",
+    "type": "IrrigationSystem",
+    "id": "bfae6739xxxxxxxxxxxxxx",   // the cloud Device ID
+    "cloud": true,
+    "valveCount": 4,
+    "noRainSensor": true              // many battery timers have no rain sensor
+}
+```
+
 #### Minimal Configuration
 
 The defaults match the common 4-zone layout (valves A–D on data-points `1`–`4`, battery on `46`, rain on `49`):

--- a/wiki/Tuya-Cloud-Setup.md
+++ b/wiki/Tuya-Cloud-Setup.md
@@ -1,0 +1,160 @@
+# Tuya Cloud Setup
+
+This plugin is **LAN-first** — almost every Tuya device is controlled locally. But a few devices **cannot** be reached over the LAN at all:
+
+> Battery-powered **"sleepy"** devices — most notably multi-zone **irrigation / faucet timers** — sleep almost all the time to save battery and only ever connect *outbound* to Tuya's cloud (over MQTT) for a brief moment when they wake. They never keep the local port open and never answer LAN discovery, so the local protocol can't reach them. (Tuya's own developer docs state LAN control is unavailable in low-power mode.)
+
+For these devices the plugin can talk to the **Tuya Cloud** instead. It is **opt-in, per device** — your other devices stay 100% local.
+
+* Initial state + control go through the Tuya OpenAPI (signed HTTPS).
+* Live updates (including physical button presses) arrive over Tuya's **MQTT** message service — no polling.
+
+---
+
+## 1. Create a Tuya Cloud project
+
+1. Sign up / log in at **[iot.tuya.com](https://iot.tuya.com/)** (the Tuya IoT Development Platform).
+2. **Cloud → Development → Create Cloud Project.**
+   * **Development Method:** choose **Smart Home**.
+   * **Data Center:** pick the region your **Tuya Smart / Smart Life app account** is in (App → *Me → Settings → Account and Security → Region*). This matters — cross-region API calls are rejected.
+3. After it's created, open the project — the **Overview** tab shows your **Access ID / Client ID** and **Access Secret / Client Secret**. You'll need both.
+
+## 2. Authorize the required API services
+
+In the project, go to **Service API → Go to Authorize** and make sure these are subscribed (all free):
+
+* **IoT Core**
+* **Authorization**
+* **Smart Home Basic Service**
+* **Device Status Notification** ← needed for realtime MQTT updates
+
+> ⚠️ The free trial of *IoT Core* lasts ~6 months, after which you must click **Extend Trial Period** (Cloud → My Services). If it lapses you'll see *"No permissions. Your subscription … has expired."*
+
+## 3. Link your app account (so the project can see your devices)
+
+Still in the project: **Devices → Link App Account → Add App Account**, then in the **Tuya Smart / Smart Life** app go to **Me → ⊞ (scan icon, top-right)** and scan the QR code. Your irrigation timer should now appear under **Devices → All Devices**.
+
+## 4. Find the device ID
+
+**Devices → All Devices** → click your device → copy its **Device ID** (a string like `bfae6739…tfx`). (You can also find it in the Smart Life app: device → ✎/⚙ → *Device Information*.)
+
+---
+
+## 5. Configure the plugin
+
+Add a **top-level `cloud` block** with your credentials, and set **`"cloud": true`** on the device. There are two project styles:
+
+### Smart Home project (recommended — what most people have)
+
+Authenticates as your app account (username/password), so it sees exactly the devices linked in step 3.
+
+```json5
+{
+    "platform": "TuyaLan",
+    "cloud": {
+        "accessId": "your-access-id",
+        "accessKey": "your-access-secret",
+        "region": "eu",                         // eu / us / cn / in / sg / eu-w / us-e
+        "username": "you@example.com",          // your Tuya/Smart Life app login
+        "password": "your-app-password",
+        "countryCode": "48",                    // your phone country code (e.g. 1, 44, 48)
+        "schema": "tuyaSmart"                   // or "smartlife" if you use the Smart Life app
+    },
+    "devices": [
+        {
+            "name": "Garden Irrigation",
+            "type": "IrrigationSystem",
+            "id": "bfae6739xxxxxxxxxxxxxx",      // the cloud Device ID
+            "cloud": true,
+            "valveCount": 4,
+            "noRainSensor": true                 // most battery timers have no rain DP
+        }
+    ]
+}
+```
+
+### Custom project
+
+If you created a **Custom** project (devices linked by QR to the project's asset) just omit `username`/`password`/`countryCode`/`schema`:
+
+```json5
+"cloud": {
+    "accessId": "your-access-id",
+    "accessKey": "your-access-secret",
+    "region": "eu"
+}
+```
+
+### Per-device credentials (optional)
+
+Instead of (or in addition to) the platform block, a device can carry its own credentials — handy if different devices live in different Tuya projects:
+
+```json5
+{
+    "name": "Garden Irrigation",
+    "type": "IrrigationSystem",
+    "id": "bfae6739xxxxxxxxxxxxxx",
+    "cloud": {
+        "accessId": "…",
+        "accessKey": "…",
+        "region": "eu",
+        "username": "…",
+        "password": "…",
+        "countryCode": "48"
+    }
+}
+```
+
+> No local `key` is needed for cloud devices — the cloud authenticates with your project credentials.
+
+---
+
+## Data-points are addressed by "code" on the cloud
+
+Over the LAN, data-points are numbered (1, 2, …). Over the **cloud** they're named **codes** (e.g. `switch_1`, `battery_percentage`). When a cloud device connects, the plugin **logs the exact codes** it reports, e.g.:
+
+```
+Garden Irrigation: Tuya Cloud data-point codes → switch_1=false, switch_2=false, switch_3=false, switch_4=false, countdown_1=0, …, battery_percentage=99
+```
+
+The `IrrigationSystem` defaults already match the common 4-zone layout (`switch_1`…`switch_4`, battery `battery_percentage`). If your device differs, use the logged codes:
+
+```json5
+"valves": [
+    { "name": "Front Lawn", "dp": "switch_1", "defaultDuration": 900 },
+    { "name": "Back Lawn",  "dp": "switch_2", "defaultDuration": 900 }
+],
+"dpBattery": "battery_percentage",
+"noRainSensor": true                  // or: "dpRain": "rain_sensor_state"
+```
+
+See **[Irrigation Systems / Sprinklers](https://github.com/adrianjagielak/homebridge-tuya-plus/blob/main/wiki/Supported-Device-Types.md#irrigation-systems--sprinklers)** for all options (per-zone durations, master switch, etc.).
+
+---
+
+## Realtime updates (MQTT)
+
+Live updates use Tuya's MQTT message service via the **`mqtt`** package, which is an *optional dependency* installed automatically. If it's missing (or `"realtime": false`), cloud devices still work and stay controllable, but external changes (a physical button, the device's own timer) won't show up until Homebridge restarts. To force-install it:
+
+```
+sudo npm install -g mqtt
+```
+
+The realtime stream connects out to Tuya's broker on **port 8883** — make sure your firewall allows that outbound (it's open on normal home networks).
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `failed to connect to Tuya Cloud: token request failed … (code 1004)` | Wrong **Access ID/Secret**, or host clock skew — the signature includes a timestamp, so keep the machine **NTP-synced**. |
+| `… (code 1106) permission deny` / `No permissions` | API service not authorized or **trial expired** (step 2), or **wrong region**, or you logged in with the developer account instead of the **app** account. |
+| Device connects but shows nothing / `0` devices | **Region mismatch**, or the device isn't linked to the project (step 3), or the linked account isn't the device's **owner** (shared/guest access hides devices). |
+| `realtime disabled: the optional "mqtt" package is not installed` | Install `mqtt` (above), or ignore if you don't need live external updates. |
+| Realtime never connects (control works, external changes don't) | Outbound **port 8883** blocked by a firewall. |
+| Logs show different codes than expected | Use the codes from the startup log line shown above. |
+
+### Security note
+
+Your **Access Secret** and app password are sensitive. Keep them only in your Homebridge `config.json`. If you ever share a config for support, redact them — and you can always reset the Access Secret on the Tuya IoT platform.


### PR DESCRIPTION
## Why

Battery-powered **"sleepy"** Tuya devices — most notably the multi-zone **irrigation / faucet timers** — sleep almost all the time to save battery and only ever connect *outbound* to Tuya's cloud (over MQTT). They never keep the local TCP port open and never answer LAN discovery, so the local protocol can **never** reach them (Tuya's own docs confirm LAN control is unavailable in low-power mode). The existing cloud plugins don't help much either: the official one has no valve support, and the maintained fork only handles a single valve with no rain sensor.

This adds a **strictly opt-in, per-device** cloud transport so those devices work — while the plugin stays **LAN-first** (no behaviour change for existing local devices).

## What

A thin cloud transport that the existing accessories ride on **unchanged** (the `IrrigationSystem` accessory gets all its zones, durations and battery over the cloud):

- **`lib/TuyaCloudApi.js`** — dependency-free Tuya OpenAPI client: HMAC-SHA256 request signing, both **Custom** (`grant_type=1`) and **Smart Home** (app-account) login, token caching/refresh, status read, command write, and realtime MQTT broker config.
- **`lib/TuyaCloudMessaging.js`** — shared realtime stream over Tuya's **MQTT** message service (one connection per credential set, fanned out by `devId`). Uses the **optional, lazily-loaded `mqtt`** dependency and AES-128-GCM/ECB payload decryption. No polling.
- **`lib/TuyaCloudDevice.js`** — a drop-in replacement for `TuyaAccessory` implementing the identical device contract (`state` / `connected` / `update()` / `_connect()` + `change`/`connect` events), so accessories need no changes. Realtime-driven; the only REST calls are the ones inherent to the cloud (initial state read, commands, and a catch-up read when the stream reconnects).
- **`index.js`** — devices opt in with `cloud: true` (using a shared platform `cloud` block) **or** a per-device `cloud` credentials object. Clients are shared per credential set.
- **`IrrigationSystemAccessory`** — accepts data-points as Tuya **codes** (e.g. `switch_1`, `battery_percentage`) as well as numeric LAN ids, with cloud-aware defaults.
- **`config.schema.json`** — platform + per-device cloud config; datapoint fields accept codes; the local `key` is no longer hard-required (cloud devices don't need it).

## Tests & docs

- New unit tests for all three modules + an irrigation cloud-mode suite. **292 tests pass**, lint clean.
- README "Cloud devices" section, changelog entry, and a step-by-step **[Tuya Cloud Setup](https://github.com/adrianjagielak/homebridge-tuya-plus/blob/main/wiki/Tuya-Cloud-Setup.md)** wiki guide.

## Verified live against a real device

Tested against a real `sfkzq` 4-zone watering controller (Smart Home project): auth → token+uid, `GET /status` (reads `switch_1..4`, `countdown_1..4`, `battery_percentage`), `POST /commands` (a safe no-op `switch_1=false` — no water released), and `getMqttConfig`. The MQTT decrypt+dispatch pipeline passed a round-trip test. The MQTT **broker socket** couldn't be exercised in the build sandbox (outbound port 8883 is blocked there) — it connects on a normal home network.

## Example config

```json5
{
  "platform": "TuyaLan",
  "cloud": {
    "accessId": "…", "accessKey": "…",
    "region": "eu",
    "username": "…", "password": "…",
    "countryCode": "48", "schema": "tuyaSmart"
  },
  "devices": [
    { "name": "Garden Irrigation", "type": "IrrigationSystem",
      "id": "<cloud device id>", "cloud": true,
      "valveCount": 4, "noRainSensor": true }
  ]
}
```