### PR TITLE
Fix cloud irrigation: valves stuck open + missing realtime updates

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file. This projec
   * Works with both **Custom** and **Smart Home** Cloud projects (the latter via app-account login).
   * The existing **IrrigationSystem** accessory works unchanged over the cloud — its data-points are simply addressed by Tuya "code" (e.g. `switch_1`, `battery_percentage`) instead of a numeric id; the device logs its codes on startup. Battery-only controllers with no rain sensor: set `"noRainSensor": true`.
   * See the wiki: **[Tuya Cloud Setup](https://github.com/adrianjagielak/homebridge-tuya-plus/blob/main/wiki/Tuya-Cloud-Setup.md)**.
+* [*] **Fix realtime (MQTT) cloud updates being silently dropped** — external changes (physical buttons, the Tuya app, the device's own timers) now show up in HomeKit within a second or two. The decryptor was verifying the AES-GCM auth tag (`decipher.final()`), but Tuya's real status frames don't carry a tag that verifies against the documented AAD, so every realtime message was being thrown away. Now decrypts with `update()` only, matching the official `tuya/tuya-homebridge` and `0x5e/homebridge-tuya-platform` implementations.
+* [*] **Fix cloud irrigation valves that could be turned on but not off** — the per-zone write coalescer was dropping any command that matched the last-known `device.state`. Cloud devices never optimistically advance `state` (it only moves once the realtime stream confirms the device), so an "off" issued before the "on" was echoed matched the stale "off" and was discarded — HomeKit showed the zone closed while it kept running. Queued commands are now sent as-is (callers already queue only genuine changes).
 
 ## 2.0.1 (2021-03-25)
 This update includes the following changes:

--- a/lib/IrrigationSystemAccessory.js
+++ b/lib/IrrigationSystemAccessory.js
@@ -614,16 +614,19 @@ class IrrigationSystemAccessory extends BaseAccessory {
             return;
         }
 
-        const dps = {};
-        let count = 0;
-        Object.keys(pending.dps).forEach(dp => {
-            if (pending.dps[dp] !== this.device.state[dp]) {
-                dps[dp] = pending.dps[dp];
-                count++;
-            }
-        });
-
-        if (count) this.device.update(dps);
+        // Send exactly what was queued. We deliberately do NOT drop data-points
+        // that appear to already match `device.state`: cloud devices never
+        // optimistically advance `state` (it only moves when the realtime/refresh
+        // stream confirms the device), so comparing against it would silently
+        // swallow a genuine command. The most visible symptom was a valve that
+        // could be turned on but never off — the "off" matched the stale "off"
+        // still in `state` (the "on" hadn't been echoed back yet) and was
+        // discarded, so HomeKit showed the zone closed while it kept running.
+        // Callers (_setValveActive, _setSystemActive, the auto-shutoff timers)
+        // already queue only real changes, judged against the HomeKit state the
+        // user sees, so there is nothing left to de-dupe here.
+        const dps = pending.dps;
+        if (Object.keys(dps).length) this.device.update(dps);
     }
 
     _valveService(cfg) {

--- a/lib/TuyaCloudMessaging.js
+++ b/lib/TuyaCloudMessaging.js
@@ -145,12 +145,12 @@ class TuyaCloudMessaging extends EventEmitter {
             envelope = JSON.parse(payload.toString());
         } catch (_) { return; }
 
-        const {protocol, data, t} = envelope;
+        const {protocol, data} = envelope;
         if (!data) return;
 
         let plaintext;
         try {
-            plaintext = this._decrypt(data, this.config && this.config.password, t);
+            plaintext = this._decrypt(data, this.config && this.config.password);
         } catch (ex) {
             this.log.debug(`Tuya Cloud realtime decrypt failed: ${ex.message}`);
             return;
@@ -179,26 +179,31 @@ class TuyaCloudMessaging extends EventEmitter {
     // Decrypt the MQTT `data` field. msg_encrypted_version 2.0 → AES-128-GCM,
     // 1.0 → AES-128-ECB. The AES key is the middle 16 chars of the broker
     // password (NOT the project Access Secret).
-    _decrypt(data, password, t) {
+    //
+    // The GCM auth tag is intentionally NOT verified: Tuya's real status frames
+    // do not carry a tag that verifies against the documented AAD, so calling
+    // `decipher.final()` would throw on every genuine message and silently drop
+    // all realtime updates. AES-GCM is a stream cipher, so `update()` alone
+    // recovers the plaintext correctly regardless of the tag; a wrong key just
+    // yields garbage that the subsequent JSON.parse rejects. Both the official
+    // `tuya/tuya-homebridge` and `0x5e/homebridge-tuya-platform` decrypt with
+    // `update()` only, for exactly this reason — `final()` here was the bug that
+    // stopped external changes (physical buttons, the Tuya app) from showing up.
+    _decrypt(data, password) {
         const key = Buffer.from(('' + (password || '')).substring(8, 24), 'utf8');
         const buf = Buffer.from(data, 'base64');
 
         // GCM (v2.0) layout: [ivLen(4) BE][iv(ivLen)][ciphertext][tag(16)].
-        // Try it first; if the header doesn't look like a sane IV length, or
-        // auth fails, fall back to ECB (v1.0).
+        // Try it first; if the header doesn't look like a sane IV length, fall
+        // back to ECB (v1.0).
         if (buf.length > 4 + GCM_TAG_LENGTH) {
             const ivLen = buf.readUIntBE(0, 4);
             if (ivLen >= 12 && ivLen <= 16 && (4 + ivLen + GCM_TAG_LENGTH) <= buf.length) {
                 try {
                     const iv = buf.slice(4, 4 + ivLen);
                     const ciphertext = buf.slice(4 + ivLen, buf.length - GCM_TAG_LENGTH);
-                    const tag = buf.slice(buf.length - GCM_TAG_LENGTH);
                     const decipher = crypto.createDecipheriv('aes-128-gcm', key, iv);
-                    decipher.setAuthTag(tag);
-                    const aad = Buffer.allocUnsafe(6);
-                    aad.writeUIntBE(Number(t) || 0, 0, 6);
-                    decipher.setAAD(aad);
-                    return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
+                    return decipher.update(ciphertext).toString('utf8');
                 } catch (gcmEx) {
                     // fall through to ECB
                 }

--- a/test/IrrigationSystemAccessory.test.js
+++ b/test/IrrigationSystemAccessory.test.js
@@ -492,4 +492,36 @@ describe('IrrigationSystemAccessory — cloud mode (data-points keyed by code)',
         jest.advanceTimersByTime(500);
         expect(device.update).toHaveBeenCalledWith({ zone_b: true });
     });
+
+    test('turning a zone off still writes false when the cloud never echoed the "on"', () => {
+        // The real cloud device never optimistically advances `state`; it only
+        // moves when the realtime stream confirms the device. Emulate that by
+        // making update() a no-op on state. A follow-up "off" must STILL be sent
+        // — otherwise the valve stays open while HomeKit shows it closed (the
+        // exact "can turn on but not off" report).
+        const { accessory, device } = makeHarness(cloudState(), { ...cloudCtx, defaultDuration: 0 });
+        device.update.mockImplementation(() => true); // writes never touch state
+        const v = valve(accessory, 'switch_1');
+
+        v.getCharacteristic(Characteristic.Active).triggerSet(1);
+        jest.advanceTimersByTime(500);
+        expect(device.update).toHaveBeenLastCalledWith({ switch_1: true });
+
+        v.getCharacteristic(Characteristic.Active).triggerSet(0);
+        jest.advanceTimersByTime(500);
+        expect(device.update).toHaveBeenLastCalledWith({ switch_1: false });
+    });
+
+    test('master OFF closes zones the cloud has not echoed as open', () => {
+        const { accessory, device } = makeHarness(cloudState(), { ...cloudCtx, defaultDuration: 0 });
+        device.update.mockImplementation(() => true); // writes never touch state
+
+        valve(accessory, 'switch_1').getCharacteristic(Characteristic.Active).triggerSet(1);
+        valve(accessory, 'switch_2').getCharacteristic(Characteristic.Active).triggerSet(1);
+        jest.advanceTimersByTime(500);
+
+        irrigation(accessory).getCharacteristic(Characteristic.Active).triggerSet(0);
+        jest.advanceTimersByTime(500);
+        expect(device.update).toHaveBeenLastCalledWith({ switch_1: false, switch_2: false });
+    });
 });

--- a/test/TuyaCloudMessaging.test.js
+++ b/test/TuyaCloudMessaging.test.js
@@ -56,6 +56,30 @@ describe('TuyaCloudMessaging — decryption + dispatch', () => {
         expect(received[0]).toEqual([{code: 'switch_1', value: true, t}, {code: 'battery_percentage', value: 80, t}]);
     });
 
+    test('decrypts a GCM frame even when the auth tag does not verify (Tuya quirk)', () => {
+        // Real Tuya status frames carry a GCM tag that does NOT verify against
+        // the documented AAD. We must decrypt with update() only (no final(),
+        // no tag check) or every realtime update is silently dropped — which is
+        // exactly what stopped external changes from reaching HomeKit. Simulate
+        // it by clobbering the trailing 16-byte tag: the plaintext must still
+        // come through.
+        const mq = makeIdle();
+        const received = [];
+        mq.subscribeDevice('DEV1', status => received.push(status));
+
+        const t = Date.now();
+        const raw = Buffer.from(
+            encryptGCM(JSON.stringify({devId: 'DEV1', status: [{code: 'switch_1', value: true}]}), mq.config.password, t),
+            'base64'
+        );
+        crypto.randomBytes(16).copy(raw, raw.length - 16); // corrupt the auth tag
+
+        mq._onMessage('topic', Buffer.from(JSON.stringify({protocol: 4, data: raw.toString('base64'), t})));
+
+        expect(received).toHaveLength(1);
+        expect(received[0]).toEqual([{code: 'switch_1', value: true}]);
+    });
+
     test('decrypts a legacy ECB (v1.0) frame too', () => {
         const mq = makeIdle();
         const received = [];


### PR DESCRIPTION
Two related bugs on cloud-backed (sleepy) Tuya devices such as the multi-valve irrigation timers. Both share one root cause: a stale `device.state`.

For cloud devices, `TuyaCloudDevice.update()` deliberately never advances the local `state` cache — it relies entirely on the realtime MQTT stream to learn the device's true state. That stream was broken, so `state` was permanently stale, which broke two things downstream.

## 1. Realtime MQTT updates were silently dropped

`lib/TuyaCloudMessaging.js` verified the AES-GCM auth tag via `decipher.final()`. Tuya's real status frames don't carry a tag that verifies against the documented AAD, so **every** genuine message threw, fell through to the (also-failing) legacy path, and got discarded. External changes (physical buttons, the Tuya app, the device's own timers) therefore never reached HomeKit.

Fix: decrypt with `decipher.update()` only and skip tag verification. AES-GCM is a stream cipher, so `update()` recovers the plaintext correctly regardless of the tag; a wrong key just yields garbage that the following `JSON.parse` rejects. This matches both reference implementations the code claims to follow — the official [`tuya/tuya-homebridge`](https://github.com/tuya/tuya-homebridge) and [`0x5e/homebridge-tuya-platform`](https://github.com/homebridge-plugins/homebridge-tuya), which both decrypt with `update()` alone. The IV layout and AAD were already correct; the `final()` call was the lone deviation and the bug.

## 2. Valves could be turned on but not off

`lib/IrrigationSystemAccessory.js`'s per-zone write coalescer (`_flushWrites`) dropped any command whose value equaled the last-known `device.state`. With `state` stuck at `false` (the "on" was never echoed back), turning a valve off computed `false === false` → "no change" → the off command was swallowed. HomeKit showed the zone closed while it kept running. Turn-on worked because `true !== false` passed the check.

Fix: send queued commands as-is. The upstream callers (`_setValveActive`, `_setSystemActive`, the auto-shutoff timers) already queue only genuine changes, judged against the HomeKit state the user sees, so there was nothing left to safely de-dupe against the stale cache.

## Tests

Added 3 regression tests that fail without the fix and pass with it:
- a GCM frame whose auth tag does not verify is still decrypted and delivered;
- a cloud zone the device never echoed as "on" is still turned off;
- master-off closes zones the cloud has not echoed as open.

Full suite: 295 passing, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwXJykiwfUXTvjvs9GAWGh

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwXJykiwfUXTvjvs9GAWGh)_