### PR TITLE
Publish PR test builds to npm via `/publish` comment

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -1,56 +1,97 @@
-name: Publish dev to npm
+name: Publish to npm (dev + PR test builds)
 
-# Publishes commits on `main` to npm under the `dev` dist-tag.
+# This workflow publishes two kinds of UNSTABLE builds to npm. Stable releases
+# always live on the `latest` dist-tag and are cut manually; nothing here ever
+# touches `latest`.
 #
-# Versioning:
-#   * Dev builds target the NEXT minor release, since releases here are
-#     usually a minor bump. With package.json at e.g. 3.13.0, dev builds
-#     are published as 3.14.0-dev.<run-number> (minor +1, patch reset to 0,
-#     prerelease tag = the GitHub Actions run number). In semver these sort
-#     below the eventual 3.14.0 release, so `latest` always wins once cut.
-#   * Release commits are skipped: if a push changes package.json's version
-#     (i.e. you bumped it to cut a real release and publish to npm
-#     manually), no dev build is published for that push.
+# 1. Dev builds (automatic) — every push to `main`:
+#      * Published under the `dev` dist-tag.
+#      * Versioned as <next-minor>.0-dev.<run-number> (e.g. 3.14.0-dev.42).
+#        package.json at 3.13.0 -> dev builds target 3.14.0. In semver these
+#        sort below the eventual 3.14.0 release, so `latest` always wins.
+#      * Release commits are skipped: if a push changes package.json's version
+#        (you bumped it to cut a real release), no dev build is published.
 #
-# Security model (why a malicious PR cannot steal publishing rights):
-#   * No npm token is stored anywhere. Publishing uses npm Trusted
-#     Publishing (OIDC): GitHub mints a short-lived, cryptographically
-#     signed token that npm only accepts when its claims match THIS repo +
-#     THIS workflow file. There is no durable credential to exfiltrate.
-#   * This workflow never runs on `pull_request`, only on pushes to `main`
-#     (post-merge) and manual dispatch — so fork PRs get nothing.
-#   * The privileged `publish` job is minimal and isolated: it does not
-#     run `npm ci`, a build, or tests, and uses `--ignore-scripts`, so no
-#     repo/dependency code executes while the OIDC permission is present.
-#     Tests run in a separate, unprivileged job that gates publishing, and
-#     the version is computed in an unprivileged `prepare` job.
+# 2. PR test builds (manual) — a maintainer comments `/publish` on a PR:
+#      * Published under a PR-specific `pr-<N>` dist-tag (e.g. pr-57), with a
+#        unique version <next-minor>.0-pr.<N>.<run-number> (e.g. 3.14.0-pr.57.43).
+#      * Lets you install and try an unmerged PR on real hardware without
+#        disturbing `latest` OR `dev`:  npm i -g homebridge-tuya-plus@pr-57
+#      * Cleanup is a token-free local step: run `npm run cleanup:pr-tags` to
+#        delete the `pr-<N>` tags of merged/closed PRs (uses your npm login).
+#        OIDC can't manage dist-tags, so this is intentionally not a CI job.
+#      * Triggered ONLY by someone with push (write) access to the repo — the
+#        owner and any write/maintain/admin collaborator. A drive-by `/publish`
+#        from an outside PR author (no push access) does nothing.
 #
-# One-time setup required for this to succeed (see PR/commit notes):
+# Why a separate `pr-<N>` tag instead of reusing `dev`: `dev` is a moving
+# channel users follow to get "latest main". Publishing unmerged PR code there
+# would feed untested code to everyone on `@dev`. A per-PR tag keeps three clear
+# lanes — `latest` (everyone), `dev` (main followers), `pr-<N>` (that one PR).
+#
+# ---------------------------------------------------------------------------
+# Security model (why a malicious PR cannot steal publishing rights)
+# ---------------------------------------------------------------------------
+#   * No npm token is stored anywhere. Publishing uses npm Trusted Publishing
+#     (OIDC): GitHub mints a short-lived token that npm only accepts when its
+#     claims match THIS repo + THIS workflow file (publish-dev.yml) + the
+#     `npm-dev` environment. There is no durable credential to exfiltrate.
+#   * npm allows only ONE trusted publisher per package, so BOTH paths must run
+#     from this file and use `environment: npm-dev` to authenticate. (The PR
+#     path needs no extra npm/GitHub setup beyond the existing dev config.)
+#   * The `dev` path never runs on `pull_request`; the PR path runs on
+#     `issue_comment`, which always uses the workflow file from `main` — a PR
+#     cannot alter this file to change what runs.
+#   * Untrusted PR code is fenced off from the publishing credential:
+#       - `pr-test` checks out and runs the PR's code (npm ci / lint / test)
+#         but is UNPRIVILEGED: `contents: read`, no secrets, no id-token, and
+#         `persist-credentials: false`. Same blast radius as ordinary fork CI.
+#       - `pr-publish` HOLDS the OIDC permission but runs NO PR code: no
+#         `npm ci`, no build, no tests, and `--ignore-scripts` on both
+#         `npm version` and `npm publish`, so no lifecycle script executes
+#         while the credential is present. It only packs + uploads the tarball.
+#       - The OIDC token is scoped to THIS package, so a PR that renames the
+#         package in package.json cannot hijack a different one (publish fails).
+#       - The head SHA is resolved once, up front, and pinned for every later
+#         job, so a push landed after `/publish` cannot swap in different code.
+#   * Comment/reaction jobs use a write-scoped token but check out NO PR code.
+#
+# ---------------------------------------------------------------------------
+# One-time setup (already in place for the dev path; PR path reuses it):
 #   1. npmjs.com -> package Settings -> Trusted Publisher:
 #        Publisher: GitHub Actions
 #        Organization/user: adrianjagielak
 #        Repository:        homebridge-tuya-plus
 #        Workflow filename: publish-dev.yml
 #        Environment:       npm-dev
-#   2. GitHub repo Settings -> Environments -> create `npm-dev`,
-#      restrict deployment branches to `main` (optional: required reviewer).
+#   2. GitHub repo Settings -> Environments -> `npm-dev`, deployment branches
+#      restricted to `main` (optional: required reviewer). The PR path runs on
+#      `main`'s ref too, so this restriction is satisfied for both paths.
 
 on:
   push:
     branches: [main]
   workflow_dispatch:
+  # Maintainer types `/publish` on a PR to cut a test build of that PR.
+  issue_comment:
+    types: [created]
 
-# Least privilege by default; only the publish job opts into id-token.
+# Least privilege by default; jobs opt into more only where needed.
 permissions:
   contents: read
 
-# Don't cancel an in-flight publish; let each commit publish its version.
+# Serialize per lane, never cancel an in-flight publish: `publish-dev` for the
+# dev path, `publish-pr-<N>` per PR for the PR path (so they don't block).
 concurrency:
-  group: publish-dev
+  group: ${{ github.event_name == 'issue_comment' && format('publish-pr-{0}', github.event.issue.number) || 'publish-dev' }}
   cancel-in-progress: false
 
 jobs:
+  # ===========================================================================
+  # DEV PATH — push to main / manual dispatch. (Behavior unchanged.)
+  # ===========================================================================
   test:
+    if: github.event_name != 'issue_comment'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -65,6 +106,7 @@ jobs:
   # computes the dev version. Kept out of the `publish` job so no extra work
   # runs while the OIDC publishing permission is present.
   prepare:
+    if: github.event_name != 'issue_comment'
     runs-on: ubuntu-latest
     outputs:
       should_publish: ${{ steps.check.outputs.should_publish }}
@@ -113,8 +155,8 @@ jobs:
 
   publish:
     needs: [test, prepare]
-    # Skip release commits (version bumped in this push).
-    if: needs.prepare.outputs.should_publish == 'true'
+    # Dev path only, and skip release commits (version bumped in this push).
+    if: github.event_name != 'issue_comment' && needs.prepare.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
     # Bind this environment in repo Settings to the `main` branch so that
     # only main can ever reach the publish step.
@@ -144,3 +186,236 @@ jobs:
       # --provenance attaches a signed build attestation (needs a public repo).
       - name: Publish (dev tag)
         run: npm publish --tag dev --provenance --ignore-scripts
+
+  # ===========================================================================
+  # PR PATH — maintainer comments `/publish` on a PR. (New.)
+  # ===========================================================================
+
+  # Gate + ack. Runs NO PR code. Verifies the commenter is a maintainer,
+  # resolves & pins the PR head, and reads the version base from trusted `main`.
+  authorize:
+    if: >
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/publish') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout main to read the version base
+      issues: write # react to / comment on the triggering comment
+      pull-requests: write
+    outputs:
+      authorized: ${{ steps.auth.outputs.authorized }}
+      head_sha: ${{ steps.auth.outputs.head_sha }}
+      head_repo: ${{ steps.auth.outputs.head_repo }}
+      pr_number: ${{ steps.auth.outputs.pr_number }}
+      base_version: ${{ steps.basever.outputs.base_version }}
+    steps:
+      - name: Verify maintainer & resolve PR head
+        id: auth
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Require the command to be exactly `/publish` (optional trailing text).
+            const body = (context.payload.comment.body || '').trim();
+            if (!/^\/publish(?:\s|$)/.test(body)) {
+              core.setOutput('authorized', 'false');
+              return;
+            }
+            // Authorization: the commenter must have PUSH (write) access. The
+            // REST `permission` field uses legacy roles, so `admin`/`write`
+            // covers admin/maintain/write (can push) and excludes triage/read.
+            // This is stricter and truer to intent than author_association (a
+            // COLLABORATOR could be read-only). The job `if` is only a coarse
+            // pre-filter; this API check is the authoritative gate.
+            const username = context.payload.comment.user.login;
+            let canPush = false;
+            try {
+              const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username,
+              });
+              canPush = ['admin', 'write'].includes(perm.permission);
+              core.info(`${username} permission: ${perm.permission} (role: ${perm.role_name || 'n/a'})`);
+            } catch (err) {
+              // If the permission API can't be read, fall back to the trusted
+              // author_association set so a maintainer is never locked out. This
+              // still keeps out drive-by PR authors (CONTRIBUTOR / NONE).
+              const assoc = context.payload.comment.author_association;
+              canPush = ['OWNER', 'MEMBER', 'COLLABORATOR'].includes(assoc);
+              core.warning(`Permission API unavailable (${err.status || err.message}); fell back to association ${assoc}.`);
+            }
+            if (!canPush) {
+              core.notice(`Ignoring /publish from ${username}: no push access.`);
+              core.setOutput('authorized', 'false');
+              return;
+            }
+            // Resolve the PR's CURRENT head and pin this exact SHA for every
+            // later job, so a push landed after `/publish` can't swap in code.
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.issue.number,
+            });
+            if (!pr.head.repo) {
+              core.setFailed('PR head repository is unavailable (fork deleted?).');
+              core.setOutput('authorized', 'false');
+              return;
+            }
+            core.setOutput('head_sha', pr.head.sha);
+            core.setOutput('head_repo', pr.head.repo.full_name);
+            core.setOutput('pr_number', String(pr.number));
+            core.setOutput('authorized', 'true');
+            // Acknowledge so the maintainer sees the command was accepted.
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes',
+            });
+
+      # Version base comes from TRUSTED main, never the PR's package.json, so an
+      # untrusted PR cannot influence the published version.
+      - name: Checkout main (trusted)
+        if: steps.auth.outputs.authorized == 'true'
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Compute version base from main
+        id: basever
+        if: steps.auth.outputs.authorized == 'true'
+        run: |
+          NEXT="$(node -e "const v=require('./package.json').version.split('.'); v[1]=Number(v[1])+1; v[2]=0; console.log(v.join('.'))")"
+          echo "base_version=$NEXT" >> "$GITHUB_OUTPUT"
+          echo "Version base (from main): $NEXT"
+
+  # Unprivileged gate: runs the PR's code. No secrets, read-only token, no
+  # id-token, no persisted git credentials — same trust level as fork CI.
+  pr-test:
+    needs: authorize
+    if: needs.authorize.outputs.authorized == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ needs.authorize.outputs.head_repo }}
+          ref: ${{ needs.authorize.outputs.head_sha }}
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run test
+
+  # Privileged publish. Holds the OIDC permission but runs NO PR code: no
+  # npm ci, no build, no tests; --ignore-scripts on version + publish.
+  pr-publish:
+    needs: [authorize, pr-test]
+    if: needs.authorize.outputs.authorized == 'true'
+    runs-on: ubuntu-latest
+    # Must match the trusted publisher's environment (npm allows one publisher
+    # per package). issue_comment runs on main's ref, so a main-only branch
+    # restriction on this environment is satisfied.
+    environment: npm-dev
+    permissions:
+      contents: read
+      id-token: write # OIDC -> npm Trusted Publishing (no stored token)
+    outputs:
+      version: ${{ steps.ver.outputs.version }}
+      tag: ${{ steps.ver.outputs.tag }}
+    steps:
+      # The PR's code — but we never execute it (see --ignore-scripts below).
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ needs.authorize.outputs.head_repo }}
+          ref: ${{ needs.authorize.outputs.head_sha }}
+          persist-credentials: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      # Trusted Publishing (OIDC) requires npm >= 11.5.1.
+      - name: Ensure OIDC-capable npm
+        run: npm install -g npm@latest
+
+      # Unique, immutable version + a PR-specific dist-tag. Base comes from main
+      # (via authorize), so the PR's package.json cannot influence versioning.
+      - name: Compute PR build version + tag
+        id: ver
+        env:
+          BASE: ${{ needs.authorize.outputs.base_version }}
+          PR: ${{ needs.authorize.outputs.pr_number }}
+        run: |
+          VERSION="${BASE}-pr.${PR}.${GITHUB_RUN_NUMBER}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=pr-${PR}" >> "$GITHUB_OUTPUT"
+          echo "Will publish $VERSION under dist-tag pr-${PR}"
+
+      # Writes package.json on the runner only; --ignore-scripts so no PR
+      # version/preversion/postversion hook runs with the credential present.
+      - name: Set version
+        run: npm version "${{ steps.ver.outputs.version }}" --no-git-tag-version --allow-same-version --ignore-scripts
+
+      # Published under pr-<N>, NEVER latest/dev. No NODE_AUTH_TOKEN: npm
+      # exchanges the OIDC id-token for a short-lived, package-scoped credential.
+      # --ignore-scripts ensures no PR lifecycle script runs with that credential.
+      - name: Publish (pr-<N> tag)
+        run: npm publish --tag "${{ steps.ver.outputs.tag }}" --provenance --ignore-scripts
+
+  # Report the outcome back on the PR. Runs NO PR code.
+  notify:
+    needs: [authorize, pr-publish]
+    if: always() && needs.authorize.outputs.authorized == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@v7
+        env:
+          PUBLISH_RESULT: ${{ needs.pr-publish.result }}
+          PR_NUMBER: ${{ needs.authorize.outputs.pr_number }}
+          HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+          VERSION: ${{ needs.pr-publish.outputs.version }}
+          TAG: ${{ needs.pr-publish.outputs.tag }}
+        with:
+          script: |
+            const { PUBLISH_RESULT, PR_NUMBER, HEAD_SHA, VERSION, TAG } = process.env;
+            const issue_number = Number(PR_NUMBER);
+            const comment_id = context.payload.comment.id;
+            const { owner, repo } = context.repo;
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            if (PUBLISH_RESULT === 'success') {
+              const sha = (HEAD_SHA || '').slice(0, 7);
+              const body = [
+                `🚀 Published this PR to npm for testing — built from \`${sha}\`.`,
+                ``,
+                `**Install this exact build:**`,
+                '```sh',
+                `npm install -g homebridge-tuya-plus@${VERSION}`,
+                '```',
+                `**…or follow this PR's tag** (always points at this PR's newest \`/publish\` build):`,
+                '```sh',
+                `npm install -g homebridge-tuya-plus@${TAG}`,
+                '```',
+                ``,
+                `In the Homebridge UI you can also paste \`${VERSION}\` into the plugin's “Install Alternate Version” field.`,
+                ``,
+                `> ℹ️ Prerelease for testing only — **not** tagged \`latest\` or \`dev\`, so it won't reach normal installs.`,
+              ].join('\n');
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+              await github.rest.reactions.createForIssueComment({ owner, repo, comment_id, content: 'rocket' });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number,
+                body: `❌ \`/publish\` did not complete — the build, tests, or publish step failed. See the [run logs](${runUrl}).`,
+              });
+              await github.rest.reactions.createForIssueComment({ owner, repo, comment_id, content: 'confused' });
+            }

--- a/Readme.MD
+++ b/Readme.MD
@@ -99,8 +99,22 @@ won't affect normal installs. To try the latest in-development build:
 sudo npm install -g homebridge-tuya-plus@dev
 ```
 
-These are versioned like `3.13.1-dev.<n>` and may be unstable; use the default
+These are versioned like `3.14.0-dev.<n>` and may be unstable; use the default
 install above for production.
+
+#### Testing a specific pull request:
+
+Maintainers can publish an unmerged PR as a throwaway test build by commenting
+`/publish` on it. The build goes to its own `pr-<number>` tag — never `latest`
+or `dev` — so it never reaches normal installs. The bot replies on the PR with
+the exact install command, e.g.:
+
+```
+sudo npm install -g homebridge-tuya-plus@pr-57
+```
+
+Each build also gets a unique, immutable version like `3.14.0-pr.57.<n>` that you
+can pin or paste into the Homebridge UI's "Install Alternate Version" field.
 
 ## Configuration
 > UI

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
-    "lint": "eslint index.js lib/**.js bin/**.js"
+    "lint": "eslint index.js lib/**.js bin/**.js",
+    "cleanup:pr-tags": "node scripts/cleanup-pr-tags.js"
   },
   "bin": {
     "tuya-lan": "./bin/cli.js",

--- a/scripts/cleanup-pr-tags.js
+++ b/scripts/cleanup-pr-tags.js
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Prune stale `pr-<N>` npm dist-tags created by the `/publish` PR-test-build
+ * workflow (.github/workflows/publish-dev.yml).
+ *
+ * Token-free by design: it shells out to `npm dist-tag`, which uses your
+ * existing local npm login — the same one you use to publish releases. No CI
+ * secret is involved. (npm's OIDC trusted publishing only covers `npm publish`,
+ * not dist-tag management, which is why this is a local maintainer script
+ * rather than a CI job.)
+ *
+ * Default: removes the `pr-<N>` tag for every PR that is MERGED or CLOSED, and
+ * keeps tags for PRs that are still open. PR state is read from the public
+ * GitHub API (unauthenticated).
+ *
+ * Usage:
+ *   npm run cleanup:pr-tags                # remove tags for merged/closed PRs
+ *   npm run cleanup:pr-tags -- --dry-run   # preview only, change nothing
+ *   npm run cleanup:pr-tags -- --all       # remove ALL pr-* tags (incl. open)
+ *
+ * Note: this removes the dist-tag pointer only. The underlying prerelease
+ * versions stay published (npm disallows unpublishing after 72h), but they sort
+ * below `latest`/`dev` and are never installed by default.
+ */
+
+const { execFileSync } = require('child_process');
+const path = require('path');
+
+const pkgJson = require(path.join(__dirname, '..', 'package.json'));
+const PKG = pkgJson.name;
+const NPM = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes('--dry-run') || args.includes('-n');
+const ALL = args.includes('--all');
+
+// Derive "owner/repo" from package.json's repository URL.
+function repoSlug() {
+  const url = (pkgJson.repository && pkgJson.repository.url) || '';
+  const m = url.match(/github\.com[/:]([^/]+)\/(.+?)(?:\.git)?$/i);
+  if (!m) throw new Error(`Cannot parse a GitHub repo from repository.url: "${url}"`);
+  return `${m[1]}/${m[2]}`;
+}
+
+// Parse `npm dist-tag ls <pkg>` output ("pr-57: 3.14.0-pr.57.3") into pr-* tags.
+function listPrTags() {
+  let out;
+  try {
+    out = execFileSync(NPM, ['dist-tag', 'ls', PKG], { encoding: 'utf8' });
+  } catch (err) {
+    throw new Error(`Failed to list dist-tags for ${PKG}: ${err.message}`);
+  }
+  const tags = [];
+  for (const line of out.split('\n')) {
+    const m = line.match(/^(pr-(\d+)):\s*(.+)$/);
+    if (m) tags.push({ tag: m[1], pr: Number(m[2]), version: m[3].trim() });
+  }
+  return tags;
+}
+
+async function prState(slug, num) {
+  const res = await fetch(`https://api.github.com/repos/${slug}/pulls/${num}`, {
+    headers: { Accept: 'application/vnd.github+json', 'User-Agent': `${PKG}-cleanup` },
+  });
+  if (res.status === 404) return 'unknown';
+  if (!res.ok) throw new Error(`GitHub API responded ${res.status}`);
+  const data = await res.json();
+  return data.merged ? 'merged' : data.state; // 'merged' | 'open' | 'closed'
+}
+
+async function main() {
+  const slug = repoSlug();
+  const tags = listPrTags();
+  if (tags.length === 0) {
+    console.log(`No pr-* dist-tags on ${PKG}. Nothing to do.`);
+    return;
+  }
+  console.log(`Found ${tags.length} pr-* tag(s) on ${PKG}${DRY_RUN ? ' (dry run)' : ''}:`);
+
+  let removed = 0;
+  for (const { tag, pr, version } of tags) {
+    let remove = ALL;
+    let reason = 'forced by --all';
+    if (!ALL) {
+      let state;
+      try {
+        state = await prState(slug, pr);
+      } catch (err) {
+        console.log(`  • ${tag} -> ${version}: skip (could not check PR #${pr}: ${err.message})`);
+        continue;
+      }
+      remove = state === 'merged' || state === 'closed';
+      reason = `PR #${pr} is ${state}`;
+    }
+
+    if (!remove) {
+      console.log(`  • ${tag} -> ${version}: keep (${reason})`);
+      continue;
+    }
+    if (DRY_RUN) {
+      console.log(`  • ${tag} -> ${version}: would remove (${reason})`);
+      removed++;
+      continue;
+    }
+    try {
+      execFileSync(NPM, ['dist-tag', 'rm', PKG, tag], { encoding: 'utf8' });
+      console.log(`  • ${tag} -> ${version}: removed (${reason})`);
+      removed++;
+    } catch (err) {
+      console.log(`  • ${tag}: FAILED to remove (${err.message}). Are you \`npm login\`'d?`);
+    }
+  }
+
+  console.log(DRY_RUN ? `Would remove ${removed} tag(s).` : `Removed ${removed} tag(s).`);
+}
+
+main().catch((err) => {
+  console.error(err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## What

Adds a maintainer-triggered way to publish an **unmerged PR** to npm so it can be installed and tested on real hardware before merging — alongside the existing `main` → `dev` publishing.

Comment **`/publish`** on a PR and a test build of that PR is published. The bot reacts 👀 when it starts and replies with the exact install command (and 🚀) when it's live.

## How it works

| | Audience | Install |
|---|---|---|
| `latest` | normal users | `homebridge-tuya-plus` |
| `dev` | main followers | `homebridge-tuya-plus@dev` |
| **`pr-<N>`** | **testing one PR** | **`homebridge-tuya-plus@pr-57`** |

Each PR build also gets a unique immutable version like `3.14.0-pr.57.<run>` (pin it, or paste it into the Homebridge UI's "Install Alternate Version" field). PR builds are **never** tagged `latest` or `dev`, so they never reach normal installs.

## Why it lives in `publish-dev.yml` (not a new file)

npm allows **only one trusted publisher per package** ([npm docs](https://docs.npmjs.com/trusted-publishers/)), bound to `publish-dev.yml` + the `npm-dev` environment. A separate workflow file would fail OIDC. So the PR path is added to the existing workflow and reuses `npm-dev` — **no extra npm/GitHub setup required.** (The dev path is unchanged; its jobs are simply gated to not run on `issue_comment`.)

## Security model

- **Authorization:** only someone with **push (write) access** can trigger it — checked via the repo permission API (`admin`/`write`, which covers admin/maintain/write), with a safe fallback to `author_association` if that API can't be read. A drive-by `/publish` from an outside PR author is inert (no reaction, no publish, no comment).
- **Untrusted PR code never touches the publish credential.** An unprivileged `pr-test` job runs the PR's code (read-only token, no secrets, no id-token, `persist-credentials: false` — same blast radius as ordinary fork CI). The privileged `pr-publish` job runs **no** PR code: no `npm ci`/build/test, `--ignore-scripts` on both `npm version` and `npm publish`. OIDC is package-scoped, so a PR that renames the package can't hijack another one.
- **No TOCTOU:** the PR head SHA is resolved once at `/publish` time and pinned for every job, so a push landed *after* the command can't swap in different code.
- `issue_comment` always uses the workflow file from `main`, so a PR can't alter what runs.

## Tag cleanup (token-free)

npm's OIDC covers only `npm publish`, **not** `dist-tag rm` — so automating cleanup in CI would require storing a publish-capable npm token, defeating the no-stored-credential design. Instead, cleanup is a local maintainer step:

```sh
npm run cleanup:pr-tags            # remove pr-<N> tags of merged/closed PRs
npm run cleanup:pr-tags -- --dry-run
npm run cleanup:pr-tags -- --all   # remove all pr-* tags
```

It uses your existing `npm login` (the one you already publish releases with) and reads PR state from the public GitHub API — no secret in CI. (Removes the dist-tag pointer; the underlying prerelease versions linger but sort below `latest`/`dev` and are never installed by default.)

## Tunable defaults

- **Tests gate the publish** (lint + test must pass), matching the dev pipeline. Easy to relax if you'd rather sideload a red-CI WIP onto hardware.
- If the `npm-dev` environment has a **required reviewer**, that approval now applies to PR publishes too.

Readme documents the new flow; the dev-build version example is also corrected to the actual next-minor scheme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DvJfCjKWjkq5WqmhWiJ8CW