### PR TITLE
Trim the `/publish` success comment

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -395,20 +395,12 @@ jobs:
             if (PUBLISH_RESULT === 'success') {
               const sha = (HEAD_SHA || '').slice(0, 7);
               const body = [
-                `🚀 Published this PR to npm for testing — built from \`${sha}\`.`,
+                `🚀 Published **\`${TAG}\`** for testing — commit \`${sha}\`.`,
                 ``,
-                `**Install this exact build:**`,
-                '```sh',
-                `npm install -g homebridge-tuya-plus@${VERSION}`,
-                '```',
-                `**…or follow this PR's tag** (always points at this PR's newest \`/publish\` build):`,
                 '```sh',
                 `npm install -g homebridge-tuya-plus@${TAG}`,
                 '```',
-                ``,
-                `In the Homebridge UI you can also paste \`${VERSION}\` into the plugin's “Install Alternate Version” field.`,
-                ``,
-                `> ℹ️ Prerelease for testing only — **not** tagged \`latest\` or \`dev\`, so it won't reach normal installs.`,
+                `Exact version: \`${VERSION}\``,
               ].join('\n');
               await github.rest.issues.createComment({ owner, repo, issue_number, body });
               await github.rest.reactions.createForIssueComment({ owner, repo, comment_id, content: 'rocket' });


### PR DESCRIPTION
Follow-up to #61.

Trims the comment the bot posts after a `/publish` test build goes out — it was doing too much (two install variants with headers, a Homebridge UI note, and a disclaimer). Now it's just the essentials.

**Before:**
> 🚀 Published this PR to npm for testing — built from `abc1234`.
>
> **Install this exact build:**
> ```sh
> npm install -g homebridge-tuya-plus@3.14.0-pr.57.3
> ```
> **…or follow this PR's tag** (always points at this PR's newest `/publish` build):
> ```sh
> npm install -g homebridge-tuya-plus@pr-57
> ```
>
> In the Homebridge UI you can also paste `3.14.0-pr.57.3` into the plugin's "Install Alternate Version" field.
>
> > ℹ️ Prerelease for testing only — **not** tagged `latest` or `dev`, so it won't reach normal installs.

**After:**
> 🚀 Published **`pr-57`** for testing — commit `abc1234`.
>
> ```sh
> npm install -g homebridge-tuya-plus@pr-57
> ```
> Exact version: `3.14.0-pr.57.3`

Leads with the friendly moving `pr-<N>` tag, keeps the exact immutable version for pinning, and drops the `latest`/`dev` disclaimer (it only drew attention to a non-issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DvJfCjKWjkq5WqmhWiJ8CW

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvJfCjKWjkq5WqmhWiJ8CW)_