### PR TITLE
Fix simpledimmer mapping regression from PR #42 (+ WledDimmer refactor, log cleanup, docs)

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -318,7 +318,7 @@
               "title": "Sync brightness to WLED (IP[:port])",
               "placeholder": "192.168.1.100",
               "condition": {
-                "functionBody": "return model.devices && model.devices[arrayIndices] && ['WledDimmer', 'SimpleDimmer'].includes(model.devices[arrayIndices].type);"
+                "functionBody": "return model.devices && model.devices[arrayIndices] && ['WledDimmer'].includes(model.devices[arrayIndices].type);"
               }
             },            
             "dpColorTemperature": {

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ const ConvectorAccessory = require('./lib/ConvectorAccessory');
 const GarageDoorAccessory = require('./lib/GarageDoorAccessory');
 const SimpleGarageDoorAccessory = require('./lib/SimpleGarageDoorAccessory');
 const WledDimmerAccessory = require('./lib/WledDimmerAccessory');
+const SimpleDimmerAccessory = require('./lib/SimpleDimmerAccessory');
 const SimpleDimmer2Accessory = require('./lib/SimpleDimmer2Accessory');
 const SimpleBlindsAccessory = require('./lib/SimpleBlindsAccessory');
 const SimpleHeaterAccessory = require('./lib/SimpleHeaterAccessory');
@@ -60,7 +61,7 @@ const CLASS_DEF = {
     convector: ConvectorAccessory,
     garagedoor: GarageDoorAccessory,
     simplegaragedoor: SimpleGarageDoorAccessory,
-    simpledimmer: WledDimmerAccessory,
+    simpledimmer: SimpleDimmerAccessory,
     wleddimmer: WledDimmerAccessory,
     simpledimmer2: SimpleDimmer2Accessory,
     simpleblinds: SimpleBlindsAccessory,

--- a/lib/SimpleDimmerAccessory.js
+++ b/lib/SimpleDimmerAccessory.js
@@ -25,20 +25,24 @@ class SimpleDimmerAccessory extends BaseAccessory {
         this.dpPower = this._getCustomDP(this.device.context.dpPower) || '1';
         this.dpBrightness = this._getCustomDP(this.device.context.dpBrightness) || this._getCustomDP(this.device.context.dp) || '2';
 
-        const characteristicOn = service.getCharacteristic(Characteristic.On)
+        this._characteristicOn = service.getCharacteristic(Characteristic.On)
             .updateValue(dps[this.dpPower])
             .onGet(() => this.getStateAsync(this.dpPower))
             .onSet(value => this.setStateAsync(this.dpPower, value));
 
-        const characteristicBrightness = service.getCharacteristic(Characteristic.Brightness)
+        this._characteristicBrightness = service.getCharacteristic(Characteristic.Brightness)
             .updateValue(this.convertBrightnessFromTuyaToHomeKit(dps[this.dpBrightness]))
             .onGet(() => this.getBrightness())
             .onSet(value => this.setBrightness(value));
 
+        this._registerChangeListener();
+    }
+
+    _registerChangeListener() {
         this.device.on('change', changes => {
-            if (changes.hasOwnProperty(this.dpPower) && characteristicOn.value !== changes[this.dpPower]) characteristicOn.updateValue(changes[this.dpPower]);
-            if (changes.hasOwnProperty(this.dpBrightness) && this.convertBrightnessFromHomeKitToTuya(characteristicBrightness.value) !== changes[this.dpBrightness])
-                characteristicBrightness.updateValue(this.convertBrightnessFromTuyaToHomeKit(changes[this.dpBrightness]));
+            if (changes.hasOwnProperty(this.dpPower) && this._characteristicOn.value !== changes[this.dpPower]) this._characteristicOn.updateValue(changes[this.dpPower]);
+            if (changes.hasOwnProperty(this.dpBrightness) && this.convertBrightnessFromHomeKitToTuya(this._characteristicBrightness.value) !== changes[this.dpBrightness])
+                this._characteristicBrightness.updateValue(this.convertBrightnessFromTuyaToHomeKit(changes[this.dpBrightness]));
         });
     }
 

--- a/lib/SimpleGarageDoorAccessory.js
+++ b/lib/SimpleGarageDoorAccessory.js
@@ -197,7 +197,7 @@ class SimpleGarageDoorAccessory extends BaseAccessory {
         if (this.pendingCloseTimer) return;
         const isOpen = this._mapDpState(changes[this.dpState]);
         if (isOpen === null) {
-            this.log.info(`[SimpleGarageDoor] ${this.device.context.name}: ignoring unknown state DP value ${JSON.stringify(changes[this.dpState])}`);
+            this.log.debug(`[SimpleGarageDoor] ${this.device.context.name}: ignoring unknown state DP value ${JSON.stringify(changes[this.dpState])}`);
             return;
         }
         this._applyReportedState(isOpen);
@@ -266,7 +266,7 @@ class SimpleGarageDoorAccessory extends BaseAccessory {
     // own, even mid-close. Abandon any pending stop-before-close.
     _sendOpen() {
         this._cancelPendingClose();
-        this.log.info(`[SimpleGarageDoor] ${this.device.context.name}: open (dp${this.dpOpen})`);
+        this.log.debug(`[SimpleGarageDoor] ${this.device.context.name}: open (dp${this.dpOpen})`);
         this.setMultiStateLegacyInBackground({[this.dpOpen]: true});
     }
 
@@ -278,19 +278,19 @@ class SimpleGarageDoorAccessory extends BaseAccessory {
         if (this.pendingCloseTimer) {
             // A stop-before-close is already running — don't restart it (and
             // push the close out) on a duplicate or retransmitted request.
-            this.log.info(`[SimpleGarageDoor] ${name}: close ignored — a stop-before-close is already running`);
+            this.log.debug(`[SimpleGarageDoor] ${name}: close ignored — a stop-before-close is already running`);
             return;
         }
         if (this._isStopped()) {
-            this.log.info(`[SimpleGarageDoor] ${name}: close (dp${this.dpClose}) — gate already stopped`);
+            this.log.debug(`[SimpleGarageDoor] ${name}: close (dp${this.dpClose}) — gate already stopped`);
             this.setMultiStateLegacyInBackground({[this.dpClose]: true});
             return;
         }
-        this.log.info(`[SimpleGarageDoor] ${name}: stop-before-close — stop (dp${this.dpStop}) now, close (dp${this.dpClose}) in ${this.stopBeforeCloseMs}ms`);
+        this.log.debug(`[SimpleGarageDoor] ${name}: stop-before-close — stop (dp${this.dpStop}) now, close (dp${this.dpClose}) in ${this.stopBeforeCloseMs}ms`);
         this.setMultiStateLegacyInBackground({[this.dpStop]: true});
         this.pendingCloseTimer = setTimeout(() => {
             this.pendingCloseTimer = null;
-            this.log.info(`[SimpleGarageDoor] ${name}: stop-before-close — firing close (dp${this.dpClose})`);
+            this.log.debug(`[SimpleGarageDoor] ${name}: stop-before-close — firing close (dp${this.dpClose})`);
             this.setMultiStateLegacyInBackground({[this.dpClose]: true});
         }, this.stopBeforeCloseMs);
     }
@@ -323,15 +323,15 @@ class SimpleGarageDoorAccessory extends BaseAccessory {
             // Re-entrant press while a partial is already armed (e.g. a
             // HomeKit/iOS WRITE retransmit) — ignore so the stop isn't pushed
             // out, which would let the gate run further than intended.
-            this.log.info(`[SimpleGarageDoor] ${name}: partial press ignored — a partial open is already running`);
+            this.log.debug(`[SimpleGarageDoor] ${name}: partial press ignored — a partial open is already running`);
             return;
         }
 
-        this.log.info(`[SimpleGarageDoor] ${name}: partial open — opening, will stop in ${this.partialOpenMs}ms`);
+        this.log.debug(`[SimpleGarageDoor] ${name}: partial open — opening, will stop in ${this.partialOpenMs}ms`);
         this._applyTarget(Characteristic.TargetDoorState.OPEN);
         this.partialStopTimer = setTimeout(() => {
             this.partialStopTimer = null;
-            this.log.info(`[SimpleGarageDoor] ${name}: partial open — firing stop (dp${this.dpStop})`);
+            this.log.debug(`[SimpleGarageDoor] ${name}: partial open — firing stop (dp${this.dpStop})`);
             this.setMultiStateLegacyInBackground({[this.dpStop]: true});
         }, this.partialOpenMs);
     }

--- a/lib/ValveAccessory.js
+++ b/lib/ValveAccessory.js
@@ -55,7 +55,7 @@ class ValveAccessory extends BaseAccessory {
             service.getCharacteristic(Characteristic.SetDuration)
                 .onGet(() => { if (!this.device.connected) throw this._commError(); return this.setDuration; })
                 .on('change', (data) => {
-                    this.log.info('Water Valve Time Duration Set to: ' + data.newValue / 60 + ' Minutes');
+                    this.log.debug('Water Valve Time Duration Set to: ' + data.newValue / 60 + ' Minutes');
                     this.setDuration = data.newValue;
 
                     if (service.getCharacteristic(Characteristic.InUse).value) {
@@ -65,7 +65,7 @@ class ValveAccessory extends BaseAccessory {
 
                         clearTimeout(this.timer);
                         this.timer = setTimeout(() => {
-                            this.log.info('Water Valve Timer Expired. Shutting OFF Valve');
+                            this.log.debug('Water Valve Timer Expired. Shutting OFF Valve');
                             this.setStateInBackground(this.dpPower, 0);
                             service.getCharacteristic(Characteristic.Active).updateValue(0);
                             service.getCharacteristic(Characteristic.InUse).updateValue(0);
@@ -89,16 +89,16 @@ class ValveAccessory extends BaseAccessory {
                             service.getCharacteristic(Characteristic.RemainingDuration).updateValue(0);
                             service.getCharacteristic(Characteristic.Active).updateValue(0);
                             clearTimeout(this.timer);
-                            this.log.info('Water Valve is OFF!');
+                            this.log.debug('Water Valve is OFF!');
                             break;
                         case 1:
                             this.lastActivationTime = (new Date()).getTime();
                             service.getCharacteristic(Characteristic.RemainingDuration).updateValue(this.setDuration);
                             service.getCharacteristic(Characteristic.Active).updateValue(1);
-                            this.log.info('Water Valve Turning ON with Timer Set to: ' + this.setDuration / 60 + ' Minutes');
+                            this.log.debug('Water Valve Turning ON with Timer Set to: ' + this.setDuration / 60 + ' Minutes');
                             clearTimeout(this.timer);
                             this.timer = setTimeout(() => {
-                                this.log.info('Water Valve Timer Expired. Shutting OFF Valve');
+                                this.log.debug('Water Valve Timer Expired. Shutting OFF Valve');
                                 this.setStateInBackground(this.dpPower, 0);
                                 service.getCharacteristic(Characteristic.Active).updateValue(0);
                                 service.getCharacteristic(Characteristic.InUse).updateValue(0);
@@ -113,10 +113,10 @@ class ValveAccessory extends BaseAccessory {
                 service.getCharacteristic(Characteristic.RemainingDuration).updateValue(this.setDuration);
                 service.getCharacteristic(Characteristic.Active).updateValue(1);
                 service.getCharacteristic(Characteristic.InUse).updateValue(1);
-                this.log.info('Water Valve is ON After Restart. Setting Timer to: ' + this.setDuration / 60 + ' Minutes');
+                this.log.debug('Water Valve is ON After Restart. Setting Timer to: ' + this.setDuration / 60 + ' Minutes');
                 clearTimeout(this.timer);
                 this.timer = setTimeout(() => {
-                    this.log.info('Water Valve Timer Expired. Shutting OFF Valve');
+                    this.log.debug('Water Valve Timer Expired. Shutting OFF Valve');
                     this.setStateInBackground(this.dpPower, 0);
                     service.getCharacteristic(Characteristic.Active).updateValue(0);
                     this.lastActivationTime = null;

--- a/lib/WledDimmerAccessory.js
+++ b/lib/WledDimmerAccessory.js
@@ -1,4 +1,4 @@
-const BaseAccessory = require('./BaseAccessory');
+const SimpleDimmerAccessory = require('./SimpleDimmerAccessory');
 const http = require('http');
 const maxWledBrightness = 255;
 
@@ -6,30 +6,14 @@ const maxWledBrightness = 255;
 const wledDebounceMs = 50;
 const wledWarmupMs = 8000;
 
-class WledDimmerAccessory extends BaseAccessory {
-    static getCategory(Categories) {
-        return Categories.LIGHTBULB;
-    }
-
-    constructor(...props) {
-        super(...props);
-    }
-
-    _registerPlatformAccessory() {
-        const {Service} = this.hap;
-
-        this.accessory.addService(Service.Lightbulb, this.device.context.name);
-
-        super._registerPlatformAccessory();
-    }
-
+class WledDimmerAccessory extends SimpleDimmerAccessory {
     _registerCharacteristics(dps) {
-        const {Service, Characteristic} = this.hap;
-        const service = this.accessory.getService(Service.Lightbulb);
-        this._checkServiceName(service, this.device.context.name);
-
-        this.dpPower = this._getCustomDP(this.device.context.dpPower) || '1';
-        this.dpBrightness = this._getCustomDP(this.device.context.dpBrightness) || this._getCustomDP(this.device.context.dp) || '2';
+        // The Lightbulb service, On/Brightness characteristics, default DPs and
+        // the device 'change' listener are all set up by SimpleDimmerAccessory.
+        // WLED only layers optional brightness sync and preset-effect switches
+        // on top, so without syncBrightnessToWled configured this behaves
+        // exactly like a plain SimpleDimmer.
+        super._registerCharacteristics(dps);
 
         // State for debounced / delayed WLED updates
         this._wledPendingBri = null;
@@ -53,21 +37,9 @@ class WledDimmerAccessory extends BaseAccessory {
             this.syncBrightnessToWled || 'disabled'
         );
 
-        const characteristicOn = service.getCharacteristic(Characteristic.On)
-            .updateValue(dps[this.dpPower])
-            .onGet(() => this.getStateAsync(this.dpPower))
-            .onSet(value => this.setStateAsync(this.dpPower, value));
-
-        const characteristicBrightness = service.getCharacteristic(Characteristic.Brightness);
-        // Keep a reference so we can update brightness from background WLED calls
-        this._characteristicBrightness = characteristicBrightness;
-
         if (this.syncBrightnessToWled) {
             // Start with 100% locally while we fetch the actual WLED brightness
-            characteristicBrightness
-                .updateValue(100)
-                .onGet(() => this.getBrightness())
-                .onSet(value => this.setBrightness(value));
+            this._characteristicBrightness.updateValue(100);
 
             // Force Tuya dimmer brightness to 100% on startup
             const maxTuyaBrightness = this.convertBrightnessFromHomeKitToTuya(100);
@@ -80,19 +52,6 @@ class WledDimmerAccessory extends BaseAccessory {
                 );
                 this.setState(this.dpBrightness, maxTuyaBrightness, () => {});
             }
-        } else {
-            const initial = this.convertBrightnessFromTuyaToHomeKit(dps[this.dpBrightness]);
-            this.log.debug(
-                '%s: initial Tuya brightness DP%s=%s -> HomeKit %s%%',
-                this.device.context.name,
-                this.dpBrightness,
-                dps[this.dpBrightness],
-                initial
-            );
-            characteristicBrightness
-                .updateValue(initial)
-                .onGet(() => this.getBrightness())
-                .onSet(value => this.setBrightness(value));
         }
 
         // Optional: create one HomeKit Switch per configured WLED preset effect.
@@ -217,7 +176,9 @@ class WledDimmerAccessory extends BaseAccessory {
                     }
                 });
         }
+    }
 
+    _registerChangeListener() {
         this.device.on('change', changes => {
             // Log full DPS changes so we can see exactly what Tuya reported
             this.log.debug(
@@ -229,7 +190,7 @@ class WledDimmerAccessory extends BaseAccessory {
             );
 
             if (changes.hasOwnProperty(this.dpPower)) {
-                const oldPower = !!characteristicOn.value;
+                const oldPower = !!this._characteristicOn.value;
                 const newPower = !!changes[this.dpPower];
 
                 this.log.debug(
@@ -241,7 +202,7 @@ class WledDimmerAccessory extends BaseAccessory {
                 );
 
                 if (oldPower !== newPower) {
-                    characteristicOn.updateValue(newPower);
+                    this._characteristicOn.updateValue(newPower);
                 }
 
                 // Track warmup window for WLED after power ON
@@ -304,7 +265,7 @@ class WledDimmerAccessory extends BaseAccessory {
                     }
 
                     // Reflect that brightness back into HomeKit
-                    characteristicBrightness.updateValue(percent);
+                    this._characteristicBrightness.updateValue(percent);
 
                     // After a short delay, force Tuya brightness back to 100% so it stops dimming the strip
                     if (this._wledForceMaxTimeout) {
@@ -320,8 +281,8 @@ class WledDimmerAccessory extends BaseAccessory {
                         this.setState(this.dpBrightness, maxTuyaBrightness, () => {});
                     }, 5000);
                 });
-            } else if (!this.syncBrightnessToWled && changes.hasOwnProperty(this.dpBrightness) && this.convertBrightnessFromHomeKitToTuya(characteristicBrightness.value) !== changes[this.dpBrightness]) {
-                characteristicBrightness.updateValue(this.convertBrightnessFromTuyaToHomeKit(changes[this.dpBrightness]));
+            } else if (!this.syncBrightnessToWled && changes.hasOwnProperty(this.dpBrightness) && this.convertBrightnessFromHomeKitToTuya(this._characteristicBrightness.value) !== changes[this.dpBrightness]) {
+                this._characteristicBrightness.updateValue(this.convertBrightnessFromTuyaToHomeKit(changes[this.dpBrightness]));
             }
         });
     }
@@ -340,7 +301,8 @@ class WledDimmerAccessory extends BaseAccessory {
             }
             return 50;
         } else {
-            return this.convertBrightnessFromTuyaToHomeKit(this.device.state[this.dpBrightness]);
+            // No WLED sync: behave as a plain SimpleDimmer.
+            return super.getBrightness();
         }
     }
 
@@ -383,7 +345,8 @@ class WledDimmerAccessory extends BaseAccessory {
             // Return to HomeKit immediately; don't wait for network I/O.
             return null;
         } else {
-            return this.setStateAsync(this.dpBrightness, this.convertBrightnessFromHomeKitToTuya(value));
+            // No WLED sync: behave as a plain SimpleDimmer.
+            return super.setBrightness(value);
         }
     }
 

--- a/lib/WledDimmerAccessory.js
+++ b/lib/WledDimmerAccessory.js
@@ -47,7 +47,7 @@ class WledDimmerAccessory extends BaseAccessory {
             null;
         this.syncBrightnessToWled = (syncCfg && ('' + syncCfg).trim()) || null;
 
-        this.log.info(
+        this.log.debug(
             '[WLED Sync] %s: syncBrightnessToWled=%s',
             this.device.context.name,
             this.syncBrightnessToWled || 'disabled'
@@ -72,7 +72,7 @@ class WledDimmerAccessory extends BaseAccessory {
             // Force Tuya dimmer brightness to 100% on startup
             const maxTuyaBrightness = this.convertBrightnessFromHomeKitToTuya(100);
             if (dps[this.dpBrightness] !== maxTuyaBrightness) {
-                this.log.info(
+                this.log.debug(
                     '[WLED Sync] %s: setting Tuya brightness DP%s to max (%s)',
                     this.device.context.name,
                     this.dpBrightness,
@@ -148,7 +148,7 @@ class WledDimmerAccessory extends BaseAccessory {
                             return callback();
                         }
 
-                        this.log.info(
+                        this.log.debug(
                             '[WLED Sync] %s: setting preset effect "%s" (id=%s, index=%s)',
                             this.device.context.name,
                             effectName,
@@ -212,7 +212,7 @@ class WledDimmerAccessory extends BaseAccessory {
                 .filter(service => service.UUID === HapService.Switch.UUID && service.subtype && service.subtype.startsWith('wledEffect '))
                 .forEach(service => {
                     if (!validEffectServices.includes(service)) {
-                        this.log.info('Removing', service.displayName);
+                        this.log.debug('Removing', service.displayName);
                         this.accessory.removeService(service);
                     }
                 });
@@ -220,7 +220,7 @@ class WledDimmerAccessory extends BaseAccessory {
 
         this.device.on('change', changes => {
             // Log full DPS changes so we can see exactly what Tuya reported
-            this.log.info(
+            this.log.debug(
                 '%s DPS changes: %s %s was:',
                 this.device.context.name,
                 JSON.stringify(changes),
@@ -232,7 +232,7 @@ class WledDimmerAccessory extends BaseAccessory {
                 const oldPower = !!characteristicOn.value;
                 const newPower = !!changes[this.dpPower];
 
-                this.log.info(
+                this.log.debug(
                     '%s power change detected on DP%s: %s -> %s',
                     this.device.context.name,
                     this.dpPower,
@@ -247,7 +247,7 @@ class WledDimmerAccessory extends BaseAccessory {
                 // Track warmup window for WLED after power ON
                 if (this.syncBrightnessToWled && newPower) {
                     this._wledReadyAt = Date.now() + wledWarmupMs;
-                    this.log.info(
+                    this.log.debug(
                         '[WLED Sync] %s: power ON -> delaying WLED API calls for %sms',
                         this.device.context.name,
                         wledWarmupMs
@@ -271,7 +271,7 @@ class WledDimmerAccessory extends BaseAccessory {
 
                 // Ignore the "forced back to 100%" update to avoid feedback loops
                 if (tuyaValue === maxTuyaBrightness) {
-                    this.log.info(
+                    this.log.debug(
                         '[WLED Sync] %s: Tuya DP%s reported max brightness (%s), ignoring',
                         this.device.context.name,
                         this.dpBrightness,
@@ -283,7 +283,7 @@ class WledDimmerAccessory extends BaseAccessory {
                 const percent = this.convertBrightnessFromTuyaToHomeKit(tuyaValue);
                 const bri = Math.max(0, Math.min(maxWledBrightness, Math.round((percent / 100) * maxWledBrightness)));
 
-                this.log.info(
+                this.log.debug(
                     '[WLED Sync] %s: Tuya DP%s changed to %s -> %s%% -> WLED bri=%s (debounced)',
                     this.device.context.name,
                     this.dpBrightness,
@@ -311,7 +311,7 @@ class WledDimmerAccessory extends BaseAccessory {
                         clearTimeout(this._wledForceMaxTimeout);
                     }
                     this._wledForceMaxTimeout = setTimeout(() => {
-                        this.log.info(
+                        this.log.debug(
                             '[WLED Sync] %s: forcing Tuya DP%s back to max (%s) after Tuya app change',
                             this.device.context.name,
                             this.dpBrightness,
@@ -331,7 +331,7 @@ class WledDimmerAccessory extends BaseAccessory {
         if (this.syncBrightnessToWled) {
             // If we already have a cached WLED brightness, return it immediately.
             if (this._lastWledPercent != null) {
-                this.log.info(
+                this.log.debug(
                     '[WLED Sync] %s: getBrightness() -> using cached %s%%',
                     this.device.context.name,
                     this._lastWledPercent
@@ -346,7 +346,7 @@ class WledDimmerAccessory extends BaseAccessory {
 
     setBrightness(value) {
         if (this.syncBrightnessToWled) {
-            this.log.info(
+            this.log.debug(
                 '[WLED Sync] %s: setBrightness(%s%%)',
                 this.device.context.name,
                 value
@@ -358,7 +358,7 @@ class WledDimmerAccessory extends BaseAccessory {
             // Ensure Tuya stays at 100% so it doesn't interfere with WLED.
             const maxTuyaBrightness = this.convertBrightnessFromHomeKitToTuya(100);
             if (this.device.state[this.dpBrightness] !== maxTuyaBrightness) {
-                this.log.info(
+                this.log.debug(
                     '[WLED Sync] %s: ensuring Tuya DP%s=%s (max)',
                     this.device.context.name,
                     this.dpBrightness,
@@ -370,7 +370,7 @@ class WledDimmerAccessory extends BaseAccessory {
 
             // Compute desired WLED brightness once.
             const bri = Math.max(0, Math.min(maxWledBrightness, Math.round((value / 100) * maxWledBrightness)));
-            this.log.info(
+            this.log.debug(
                 '[WLED Sync] %s: mapped HomeKit %s%% -> WLED bri=%s (debounced background)',
                 this.device.context.name,
                 value,
@@ -392,7 +392,7 @@ class WledDimmerAccessory extends BaseAccessory {
         const parts = String(this.syncBrightnessToWled).split(':');
         const host = parts[0];
         const port = parts[1] ? parseInt(parts[1], 10) || 80 : 80;
-        this.log.info(
+        this.log.debug(
             '[WLED Sync] %s: target host=%s port=%s',
             this.device.context.name,
             host,
@@ -426,7 +426,7 @@ class WledDimmerAccessory extends BaseAccessory {
             timeout: 1000
         };
 
-        this.log.info(
+        this.log.debug(
             '[WLED Sync] %s: GET http://%s:%s/json/state',
             this.device.context.name,
             target.host,
@@ -449,7 +449,7 @@ class WledDimmerAccessory extends BaseAccessory {
                         );
                         return done(true);
                     }
-                    this.log.info(
+                    this.log.debug(
                         '[WLED Sync] %s: /json/state -> bri=%s',
                         this.device.context.name,
                         bri
@@ -508,7 +508,7 @@ class WledDimmerAccessory extends BaseAccessory {
             timeout: 1000
         };
 
-        this.log.info(
+        this.log.debug(
             '[WLED Sync] %s: POST http://%s:%s/json/state body=%s',
             this.device.context.name,
             target.host,
@@ -520,7 +520,7 @@ class WledDimmerAccessory extends BaseAccessory {
             // Consume response and ignore body
             res.on('data', () => {});
             res.on('end', () => {
-                this.log.info(
+                this.log.debug(
                     '[WLED Sync] %s: WLED brightness set, HTTP %s',
                     this.device.context.name,
                     res.statusCode
@@ -583,7 +583,7 @@ class WledDimmerAccessory extends BaseAccessory {
             timeout: 1000
         };
 
-        this.log.info(
+        this.log.debug(
             '[WLED Sync] %s: POST http://%s:%s/json/state body=%s (preset effect)',
             this.device.context.name,
             target.host,
@@ -595,7 +595,7 @@ class WledDimmerAccessory extends BaseAccessory {
             // Consume response and ignore body
             res.on('data', () => {});
             res.on('end', () => {
-                this.log.info(
+                this.log.debug(
                     '[WLED Sync] %s: WLED effect set to %s, HTTP %s',
                     this.device.context.name,
                     effectId,
@@ -659,7 +659,7 @@ class WledDimmerAccessory extends BaseAccessory {
         const warmupDelay = this._wledReadyAt && now < this._wledReadyAt ? (this._wledReadyAt - now) : 0;
         const delay = warmupDelay + wledDebounceMs;
 
-        this.log.info(
+        this.log.debug(
             '[WLED Sync] %s: scheduling WLED bri=%s in %sms (%s)',
             this.device.context.name,
             brightness,
@@ -672,7 +672,7 @@ class WledDimmerAccessory extends BaseAccessory {
 
             // If the light is now off, skip the call.
             if (!this.device.state[this.dpPower]) {
-                this.log.info(
+                this.log.debug(
                     '[WLED Sync] %s: skipping scheduled WLED bri=%s because power is OFF',
                     this.device.context.name,
                     this._wledPendingBri

--- a/test/getCategory.test.js
+++ b/test/getCategory.test.js
@@ -23,6 +23,7 @@ const CLASS_DEF = {
     garagedoor: require('../lib/GarageDoorAccessory'),
     simplegaragedoor: require('../lib/SimpleGarageDoorAccessory'),
     simpledimmer: require('../lib/SimpleDimmerAccessory'),
+    wleddimmer: require('../lib/WledDimmerAccessory'),
     simpledimmer2: require('../lib/SimpleDimmer2Accessory'),
     simpleblinds: require('../lib/SimpleBlindsAccessory'),
     simpleheater: require('../lib/SimpleHeaterAccessory'),

--- a/wiki/Supported-Device-Types.md
+++ b/wiki/Supported-Device-Types.md
@@ -15,7 +15,8 @@ If you are looking for verified configurations for your specific device, please 
 |Barely Smart Power Strip|`Outlet`|Smart power strips that don't allow individual control of the outlets|
 |Air Conditioner|`AirConditioner`<sup>[6](#air-conditioners)</sup>|Cooling and heating devices <small>([instructions](#air-conditioners))</small>|
 |Heat Convector|`Convector`<sup>[7](#heat-convectors)</sup>|Heating panels <small>([instructions](#heat-convectors))</small>|
-|WLED Dimmer|`WledDimmer` (or legacy `SimpleDimmer`)<sup>[8](#simple-dimmers)</sup>|Dimmer switches with power control, with optional WLED sync <small>([instructions](#simple-dimmers))</small>|
+|Simple Dimmer|`SimpleDimmer`<sup>[8](#simple-dimmers)</sup>|Dimmer switches with power control <small>([instructions](#simple-dimmers))</small>|
+|WLED Dimmer|`WledDimmer`<sup>[8](#simple-dimmers)</sup>|Dimmer switches with power control, plus optional WLED brightness sync and preset-effect switches <small>([instructions](#simple-dimmers))</small>|
 |Simple Heater|`SimpleHeater`<sup>[9](#simple-heaters)</sup>|Heating solutions with only temperature control <small>([instructions](#simple-heaters))</small>|
 |Garage Door|`GarageDoor`<sup>[10](#garage-doors)</sup>|Smart garage doors or garage door openers <small>([instructions](#garage-doors))</small>|
 |Simple Garage Door|`SimpleGarageDoor`<sup>[10](#simple-garage-doors)</sup>|Sliding gate openers and garage door controllers with open/stop/close action DPs and a simple three-value status DP <small>([instructions](#simple-garage-doors))</small>|
@@ -345,14 +346,15 @@ If your signature doesn't have a variation of _low_ or _high_, `SimpleHeater` wo
 ```
 
 ### Simple Dimmers / WLED Dimmers
-These are switches that allow turning on and off, and dimming. Use type `WledDimmer` (legacy `SimpleDimmer` alias is also supported for backward compatibility).
+These are switches that allow turning on and off, and dimming. Two distinct types are available:
 
-When using with a WLED controller (e.g. a Tuya-based relay/dimmer feeding power to a WLED strip), you can use advanced sync options:
+- `SimpleDimmer` — a plain dimmer with power and brightness control.
+- `WledDimmer` — a dimmer that can additionally drive a [WLED](https://kno.wled.ge/) controller (e.g. a Tuya-based relay/dimmer feeding power to a WLED strip). With none of the WLED options below configured, it behaves exactly like a `SimpleDimmer`.
 
-- `syncBrightnessToWled`: set to WLED device IP (e.g. "192.168.1.50" or "192.168.1.50:80") to sync HomeKit brightness changes directly to WLED over HTTP, keeping the Tuya dimmer at 100%.
+The following options apply to `WledDimmer` only (they are ignored by `SimpleDimmer`):
+
+- `syncBrightnessToWled`: set to the WLED device IP (e.g. "192.168.1.50" or "192.168.1.50:80") to sync HomeKit brightness changes directly to WLED over HTTP, keeping the Tuya dimmer at 100%.
 - `presetEffects`: array of effect configs to expose as switches in HomeKit (each turns on a WLED fx preset, optionally with staticColor).
-
-See the accessory source for full details on WLED integration.
 
 ```json5
 {


### PR DESCRIPTION
## The bug

PR #42 ("Add WLED Dimmer accessory type") coupled two changes in `index.js`: it **replaced** the `SimpleDimmerAccessory` import with `WledDimmerAccessory` and **remapped** the existing `simpledimmer` type to the new class:

```diff
-    simpledimmer: SimpleDimmerAccessory,
+    simpledimmer: WledDimmerAccessory,
+    wleddimmer: WledDimmerAccessory,
```

So every existing `simpledimmer` device silently started loading the new 700-line WLED accessory (HTTP sync, preset effects, debounce timers) instead of the lean 54-line `SimpleDimmerAccessory`. It didn't break devices (the WLED paths are gated behind `syncBrightnessToWled`), but `simpledimmer` is a pre-existing public type and shouldn't carry WLED behaviour.

## Changes

1. **Fix the mapping** — restore `simpledimmer` → `SimpleDimmerAccessory`, keep `wleddimmer` → `WledDimmerAccessory`. (`SimpleDimmerAccessory.js` was never deleted, just unreferenced.)
2. **Refactor `WledDimmerAccessory` to `extends SimpleDimmerAccessory`** — WledDimmer's non-sync path was a byte-for-byte copy of SimpleDimmer. It now inherits the shared dimmer logic and only layers the optional WLED sync + preset-effect switches on top. Net **−43 lines** in that file; the duplication is gone. Behaviour is unchanged for both plain and WLED-sync dimmers.
3. **Unify log levels** — downgrade routine per-operation `info` traces to `debug` in `WledDimmerAccessory`, `ValveAccessory`, and `SimpleGarageDoorAccessory`, matching the quiet-majority convention already used by the other lighting/blinds accessories (info reserved for sparse lifecycle, per-operation internals at debug). `warn`/`error` untouched. The Valve and SimpleGarageDoor changes preserve all of `main`'s functional logic — only the log levels changed.
4. **Docs** — present `SimpleDimmer` and `WledDimmer` as two distinct types (not a "legacy alias"), and stop offering `syncBrightnessToWled` for `SimpleDimmer` in the config schema since the lean class ignores it.
5. **Test** — add `wleddimmer` to the `getCategory` regression suite, which previously covered every configured type except this one. This guards the refactor (WledDimmer now inherits `getCategory`).

## Validation

- Full suite green: **315 tests / 14 suites pass** (was 314; +1 is the new `wleddimmer` category assertion).
- `node -c` on all changed JS, `config.schema.json` parses as valid JSON.
- Behavioural smoke test of `_registerCharacteristics` for both sync-off (behaves as SimpleDimmer) and sync-on (starts at 100%, forces Tuya to max) paths.

Net diff is **+80 / −109** across 8 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PbLkn39zg91dDtzfjR1JiG

---
_Generated by [Claude Code](https://claude.ai/code/session_01PbLkn39zg91dDtzfjR1JiG)_