### PR TITLE
SimpleGarageDoor: fix partial open running the gate all the way

### DIFF
--- a/lib/SimpleGarageDoorAccessory.js
+++ b/lib/SimpleGarageDoorAccessory.js
@@ -98,6 +98,12 @@ class SimpleGarageDoorAccessory extends BaseAccessory {
         // and the close that trails a stop in the stop-before-close path.
         this.partialStopTimer = null;
         this.pendingCloseTimer = null;
+        // A partial open that has fired its open but is still waiting for the
+        // controller to report it's moving before arming the auto-stop.
+        this.partialPending = false;
+        // Bumped whenever a partial open starts or is superseded/cancelled, so a
+        // stale auto-stop (and its re-sends) from an earlier flow bails out.
+        this.partialGeneration = 0;
 
         // Seed the initial state from whatever the device has already reported.
         // If it hasn't reported yet, fall back to the persisted target, then to
@@ -227,6 +233,11 @@ class SimpleGarageDoorAccessory extends BaseAccessory {
         if (this.characteristicPartialOpen) {
             this.characteristicPartialOpen.updateValue(isOpen);
         }
+
+        // A partial open fires its open and then waits for the controller to
+        // confirm the gate is actually moving before starting the auto-stop
+        // countdown — see _handlePartialOpen.
+        if (this.partialPending && isOpen) this._armPartialStop();
     }
 
     // onGet helper: a cached/optimistic door value is fine to report while the
@@ -310,33 +321,63 @@ class SimpleGarageDoorAccessory extends BaseAccessory {
         }
     }
 
-    // Partial open: fire the open action, then after partialOpenMs fire a stop
-    // so the gate ends up parked part-way. Anchored to the button press (the
-    // controller starts moving and reports state within ~1s), which is all the
-    // user asked for.
+    // Partial open: fire the open action, wait partialOpenMs, then fire a stop
+    // so the gate ends up parked part-way.
+    //
+    // The auto-stop is anchored to the controller *reporting the gate is moving*
+    // (the status DP flipping to OPEN), not to the button press: the open
+    // command takes time to reach the gate, and a stop fired before the gate is
+    // actually moving lands as a no-op the controller drops — letting the gate
+    // run all the way open. If the gate already reads open/opening, no fresh
+    // report is coming, so we arm straight away.
     _handlePartialOpen() {
         const {Characteristic} = this.hap;
         const name = this.device.context.name;
         if (!this.device.connected) throw this._commError();
         if (!this.partialOpenMs) return;
-        if (this.partialStopTimer) {
-            // Re-entrant press while a partial is already armed (e.g. a
+        if (this.partialPending || this.partialStopTimer) {
+            // Re-entrant press while a partial is already in progress (e.g. a
             // HomeKit/iOS WRITE retransmit) — ignore so the stop isn't pushed
             // out, which would let the gate run further than intended.
             this.log.debug(`[SimpleGarageDoor] ${name}: partial press ignored — a partial open is already running`);
             return;
         }
 
-        this.log.debug(`[SimpleGarageDoor] ${name}: partial open — opening, will stop in ${this.partialOpenMs}ms`);
+        this.log.debug(`[SimpleGarageDoor] ${name}: partial open — opening, will stop ${this.partialOpenMs}ms after the gate starts moving`);
+        this.partialGeneration++;
+        this.partialPending = true;
         this._applyTarget(Characteristic.TargetDoorState.OPEN);
+
+        const reported = this.device.state ? this.device.state[this.dpState] : undefined;
+        if (this._mapDpState(reported) === true) this._armPartialStop();
+    }
+
+    _armPartialStop() {
+        if (!this.partialPending || this.partialStopTimer) return;
+        this.partialPending = false;
+        const name = this.device.context.name;
+        const generation = this.partialGeneration;
         this.partialStopTimer = setTimeout(() => {
             this.partialStopTimer = null;
             this.log.debug(`[SimpleGarageDoor] ${name}: partial open — firing stop (dp${this.dpStop})`);
-            this.setMultiStateLegacyInBackground({[this.dpStop]: true});
+            this._sendPartialStop(generation, 1);
         }, this.partialOpenMs);
     }
 
+    // The controller occasionally drops a lone write (its command queue can
+    // coalesce back-to-back writes, and brief Wi-Fi blips lose individual
+    // packets), and a dropped stop here is exactly what lets a partial open run
+    // all the way. Re-send it a few times; a stop on an already-parked gate is a
+    // harmless no-op. Bails out if the flow was superseded mid-way.
+    _sendPartialStop(generation, attempt) {
+        if (generation !== this.partialGeneration) return;
+        this.setMultiStateLegacyInBackground({[this.dpStop]: true});
+        if (attempt < 3) setTimeout(() => this._sendPartialStop(generation, attempt + 1), 300);
+    }
+
     _cancelPartialStop() {
+        this.partialPending = false;
+        this.partialGeneration++;
         if (this.partialStopTimer) {
             clearTimeout(this.partialStopTimer);
             this.partialStopTimer = null;

--- a/test/SimpleGarageDoorAccessory.test.js
+++ b/test/SimpleGarageDoorAccessory.test.js
@@ -52,6 +52,8 @@ function makeSimpleGarage(initialContext = {}) {
     instance.stopBeforeCloseMs = 1500;
     instance.partialStopTimer = null;
     instance.pendingCloseTimer = null;
+    instance.partialPending = false;
+    instance.partialGeneration = 0;
     instance.currentDoorState = CDS.CLOSED;
     instance.characteristicCurrentDoorState = {
         value: CDS.CLOSED,
@@ -409,35 +411,71 @@ describe('SimpleGarageDoorAccessory._handlePartialOpen', () => {
     beforeEach(() => jest.useFakeTimers());
     afterEach(() => jest.useRealTimers());
 
-    test('Fires open, then fires stop after partialOpenMs', () => {
+    test('Stop is anchored to the gate reporting it is moving, not the button press', () => {
         const { instance, device } = makeSimpleGarage();
         instance.partialOpenMs = 2000;
+        // Gate starts closed, so the open command needs time to reach it and
+        // get the gate moving before a stop can do anything.
+        device.state['105'] = STATE_CLOSING_OR_CLOSED;
 
         instance._handlePartialOpen();
 
-        // Open goes out immediately.
+        // Open goes out immediately, but the auto-stop is NOT armed yet.
         expect(device.update).toHaveBeenCalledTimes(1);
         expect(device.update).toHaveBeenNthCalledWith(1, { '101': true });
         expect(instance.characteristicTargetDoorState.value).toBe(TDS.OPEN);
+        expect(instance.partialStopTimer).toBeNull();
+        expect(instance.partialPending).toBe(true);
 
-        // Nothing happens until the timer elapses.
+        // No amount of waiting fires a stop until the gate reports it's moving —
+        // this is what stops a too-early stop from being a dropped no-op.
+        jest.advanceTimersByTime(10_000);
+        expect(device.update).toHaveBeenCalledTimes(1);
+
+        // Controller reports it has started opening: now the countdown arms.
+        emitState(device, STATE_OPENING_OR_OPEN);
+        expect(instance.partialStopTimer).not.toBeNull();
+        expect(instance.partialPending).toBe(false);
+
         jest.advanceTimersByTime(2000 - 1);
         expect(device.update).toHaveBeenCalledTimes(1);
 
-        // Then a single stop is fired.
+        // The stop fires, and is re-sent a couple of times to survive a dropped
+        // write (the controller occasionally drops a lone command).
         jest.advanceTimersByTime(1);
         expect(device.update).toHaveBeenCalledTimes(2);
         expect(device.update).toHaveBeenNthCalledWith(2, { '103': true });
+        jest.advanceTimersByTime(300);
+        expect(device.update).toHaveBeenNthCalledWith(3, { '103': true });
+        jest.advanceTimersByTime(300);
+        expect(device.update).toHaveBeenNthCalledWith(4, { '103': true });
 
-        // And nothing more after that.
+        // And nothing more after the re-sends.
         jest.advanceTimersByTime(10_000);
-        expect(device.update).toHaveBeenCalledTimes(2);
+        expect(device.update).toHaveBeenCalledTimes(4);
         expect(instance.partialStopTimer).toBeNull();
     });
 
-    test('Re-entrant press while armed is ignored (idempotent)', () => {
+    test('Arms straight away when the gate already reports open/opening', () => {
         const { instance, device } = makeSimpleGarage();
         instance.partialOpenMs = 2000;
+        device.state['105'] = STATE_OPENING_OR_OPEN;
+
+        instance._handlePartialOpen();
+
+        // Open fired and the countdown armed without waiting for a fresh report.
+        expect(device.update).toHaveBeenNthCalledWith(1, { '101': true });
+        expect(instance.partialStopTimer).not.toBeNull();
+        expect(instance.partialPending).toBe(false);
+
+        jest.advanceTimersByTime(2000);
+        expect(device.update).toHaveBeenNthCalledWith(2, { '103': true });
+    });
+
+    test('Re-entrant press while in progress is ignored (idempotent)', () => {
+        const { instance, device } = makeSimpleGarage();
+        instance.partialOpenMs = 2000;
+        device.state['105'] = STATE_OPENING_OR_OPEN; // arms immediately
 
         instance._handlePartialOpen();
         expect(device.update).toHaveBeenCalledTimes(1);
@@ -452,6 +490,20 @@ describe('SimpleGarageDoorAccessory._handlePartialOpen', () => {
         expect(device.update).toHaveBeenCalledTimes(1);
         jest.advanceTimersByTime(1);
         expect(device.update).toHaveBeenNthCalledWith(2, { '103': true });
+    });
+
+    test('Re-entrant press while waiting for movement is ignored', () => {
+        const { instance, device } = makeSimpleGarage();
+        instance.partialOpenMs = 2000;
+        device.state['105'] = STATE_CLOSING_OR_CLOSED;
+
+        instance._handlePartialOpen();
+        expect(device.update).toHaveBeenCalledTimes(1); // open
+        expect(instance.partialPending).toBe(true);
+
+        // A second press before the gate reports moving must not fire another open.
+        instance._handlePartialOpen();
+        expect(device.update).toHaveBeenCalledTimes(1);
     });
 
     test('A direct close cancels the partial auto-stop and runs stop-before-close', () => {

--- a/wiki/Supported-Device-Types.md
+++ b/wiki/Supported-Device-Types.md
@@ -500,9 +500,10 @@ external stop, where close is accepted immediately), a close is sent as
     /* Optional. If set, exposes an extra stateful switch that mirrors
        whether the gate is currently open in HomeKit's view. Tapping it
        ON triggers a partial-open: the gate opens and then stops itself
-       this many milliseconds later, leaving the gate partially open.
-       Tapping it OFF triggers a standard full close. Useful for letting
-       someone pass through briefly. Leave unset to skip the switch. */
+       this many milliseconds after it actually starts moving, leaving the
+       gate partially open. Tapping it OFF triggers a standard full close.
+       Useful for letting someone pass through briefly. Leave unset to skip
+       the switch. */
     "partialOpenMs": 2000,
 
     /* Optional. Exposes extra Force Open and Force Close momentary


### PR DESCRIPTION
## Problem

Partial open (`partialOpenMs`) never parked the gate part-way — it always ran all the way open.

`_handlePartialOpen()` fired the open action and then sent **a single stop** on a `setTimeout` anchored to the **button press**. That stop fails to park the gate in two ways:

1. **It can land before the gate is moving.** The open command takes time to reach the controller; a stop fired too early is a no-op the controller drops, and the gate then runs to fully open.
2. **A lone stop write gets dropped.** The controller's command queue coalesces back-to-back writes and brief Wi-Fi blips lose individual packets.

This is a regression from #51 ("Rewrite SimpleGarageDoor"), which simplified partial open to "fire open + a single stop after the delay." The original implementation (`bf5ddb1`) deliberately guarded against both cases — its own comments describe this exact failure mode — and the rewrite dropped those safeguards.

## Fix

- **Anchor the auto-stop to the controller reporting the gate is moving** (the status DP flipping to OPEN) instead of to the button press. If the gate already reports open/opening, it arms immediately. This uses the status DP the rewrite itself introduced.
- **Re-send the stop a few times** (3×, ~300 ms apart) so a dropped write can't let the gate run on. A stop on an already-parked gate is a harmless no-op.
- A `partialGeneration` counter lets a direct open/close cleanly supersede an in-flight partial (and abort its re-sends); the re-entrancy guard now also covers the new "waiting for movement" phase.

## Testing

- Updated and expanded the partial-open unit tests.
- `npm test` — 347 passed.
- `npm run lint` — clean.
- Refreshed the `partialOpenMs` note in the wiki docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P43Qf3b5zqP9cBTb1xBNHb)_