### PR TITLE
Fix child-bridge crash on duplicate device ids

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,6 +123,7 @@ class TuyaLan {
         const lanDeviceIds = [];      // ids we still want to find on the LAN
         const connectedDevices = [];  // ids discovered on the LAN
         const fakeDevices = [];
+        const seenUUIDs = new Set();  // accessory UUIDs already configured this run
 
         this.config.devices.forEach(device => {
             try {
@@ -136,6 +137,15 @@ class TuyaLan {
 
             if (!device.type) return this.log.error('%s (%s) doesn\'t have a type defined.', device.name || 'Unnamed device', device.id);
             if (!CLASS_DEF[device.type.toLowerCase()]) return this.log.error('%s (%s) doesn\'t have a valid type defined.', device.name || 'Unnamed device', device.id);
+
+            // Two config entries that resolve to the same accessory UUID (the same
+            // Tuya id, real or fake) make addAccessory process that UUID twice. The
+            // second pass reads back the accessory wrapper the first pass cached
+            // instead of a PlatformAccessory and crashes the child bridge while
+            // trying to unregister it. Keep the first entry; skip the rest.
+            const uuid = UUID.generate(UUID_SEED + (device.fake ? ':fake:' : ':') + device.id);
+            if (seenUUIDs.has(uuid)) return this.log.warn('%s (%s) is configured more than once; ignoring the duplicate entry.', device.name || 'Unnamed device', device.id);
+            seenUUIDs.add(uuid);
 
             if (device.fake) {
                 fakeDevices.push({name: device.id.slice(8), ...device});
@@ -337,9 +347,17 @@ class TuyaLan {
     removeAccessory(homebridgeAccessory) {
         if (!homebridgeAccessory) return;
 
+        // Only real PlatformAccessory instances can be unregistered. cachedAccessories
+        // also holds accessory wrappers (set by addAccessory), and Homebridge throws a
+        // fatal TypeError when handed anything else, taking down the whole child bridge.
+        // Guard against it rather than trust every caller.
+        if (!(homebridgeAccessory instanceof PlatformAccessory)) {
+            return this.log.warn('Skipped unregistering %s: not a PlatformAccessory.', homebridgeAccessory.displayName);
+        }
+
         this.log.warn('Unregistering', homebridgeAccessory.displayName);
 
-        delete this.cachedAccessories[homebridgeAccessory.UUID];
+        this.cachedAccessories.delete(homebridgeAccessory.UUID);
         this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [homebridgeAccessory]);
     }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -24,6 +24,7 @@ jest.mock('../lib/TuyaDiscovery', () => ({
 }));
 
 const TuyaDevice = require('../lib/TuyaDevice');
+const TuyaAccessory = require('../lib/TuyaAccessory');
 const TuyaCloudApi = require('../lib/TuyaCloudApi');
 const TuyaCloudMessaging = require('../lib/TuyaCloudMessaging');
 const TuyaDiscovery = require('../lib/TuyaDiscovery');
@@ -56,7 +57,7 @@ function makeLog() {
 }
 
 function makeApi() {
-    return {hap: makeHap(), on: jest.fn(), registerPlatformAccessories: jest.fn()};
+    return {hap: makeHap(), on: jest.fn(), registerPlatformAccessories: jest.fn(), unregisterPlatformAccessories: jest.fn()};
 }
 
 function run(config) {
@@ -137,5 +138,52 @@ describe('TuyaLan — discovery routing', () => {
     test('a cloud-only configuration starts no LAN discovery', () => {
         run({cloud: CLOUD, devices: [SLEEPY()]});
         expect(TuyaDiscovery.start).not.toHaveBeenCalled();
+    });
+});
+
+describe('TuyaLan — duplicate device ids', () => {
+    // Two entries sharing an id resolve to one accessory UUID; configuring it twice
+    // used to crash the child bridge (addAccessory read back its own wrapper and
+    // tried to unregister it). The repeat must be dropped with a warning instead.
+    test('a repeated id is configured once and warns', () => {
+        const platform = run({devices: [SW(), SW()]});
+        expect(TuyaDevice).toHaveBeenCalledTimes(1);
+        expect(platform.addAccessory).toHaveBeenCalledTimes(1);
+        expect(platform.log.warn).toHaveBeenCalled();
+    });
+
+    test('distinct ids are all configured', () => {
+        run({devices: [SW(), SLEEPY()]});
+        expect(TuyaDevice).toHaveBeenCalledTimes(2);
+    });
+
+    test('a repeated fake id is configured once', () => {
+        run({devices: [SW({fake: true}), SW({fake: true})]});
+        expect(TuyaAccessory).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('TuyaLan — removeAccessory hardening', () => {
+    function platformWith(PlatformAccessory) {
+        let cls;
+        factory({platformAccessory: PlatformAccessory, hap: makeHap(), registerPlatform: (n, p, c) => { cls = c; }});
+        return new cls(makeLog(), {devices: [SW()]}, makeApi());
+    }
+    const PlatformAccessoryStub = function(name, uuid) { this.displayName = name; this.UUID = uuid; };
+
+    test('a non-PlatformAccessory (e.g. an accessory wrapper) is never unregistered', () => {
+        const platform = platformWith(PlatformAccessoryStub);
+        expect(() => platform.removeAccessory({accessory: {}})).not.toThrow();
+        expect(platform.api.unregisterPlatformAccessories).not.toHaveBeenCalled();
+        expect(platform.log.warn).toHaveBeenCalled();
+    });
+
+    test('a real PlatformAccessory is unregistered and dropped from the cache', () => {
+        const platform = platformWith(PlatformAccessoryStub);
+        const accessory = new PlatformAccessoryStub('Real', 'uuid:x');
+        platform.cachedAccessories.set('uuid:x', accessory);
+        platform.removeAccessory(accessory);
+        expect(platform.api.unregisterPlatformAccessories).toHaveBeenCalledTimes(1);
+        expect(platform.cachedAccessories.has('uuid:x')).toBe(false);
     });
 });


### PR DESCRIPTION
Two config entries that resolve to the same accessory UUID (the same Tuya
id, real or fake) made addAccessory process that UUID twice. The second
pass read back the accessory wrapper the first pass had cached in
cachedAccessories instead of a PlatformAccessory, then handed it to
removeAccessory -> unregisterPlatformAccessories, which throws a fatal
TypeError and takes down the whole child bridge.

Skip duplicate ids during discovery (first entry wins, the rest are
dropped with a warning) so the collision never happens, and harden
removeAccessory to refuse anything that isn't a real PlatformAccessory so
a stray wrapper can never crash the bridge again. Also fix the cache
cleanup there: cachedAccessories is a Map, so delete obj[key] was a no-op.