### PR TITLE
Stop failed Tuya Cloud connections from flooding the log

### DIFF
--- a/lib/TuyaCloudDevice.js
+++ b/lib/TuyaCloudDevice.js
@@ -50,6 +50,8 @@ class TuyaCloudDevice extends EventEmitter {
         this.connected = false;
         this._stopped = false;
         this._retryTimer = null;
+        this._retryDelay = 0;          // current connect-retry backoff (ms); grows on repeated failure
+        this._lastConnectError = null; // last surfaced connect error, so identical repeats stay quiet
 
         // Bidirectional data-point maps, learned from the device's thing-shadow on
         // connect. They let this cloud transport (and the LAN+cloud TuyaDevice that
@@ -92,18 +94,55 @@ class TuyaCloudDevice extends EventEmitter {
 
             this._logDiscoveredCodes(props);
 
+            // Connected: announce recovery from any earlier failure once, and
+            // reset the retry backoff.
+            if (this._lastConnectError) {
+                this.log.info(`${this.context.name}: Tuya Cloud connection restored.`);
+                this._lastConnectError = null;
+            }
+            this._retryDelay = 0;
+
             this.emit('connect');
             // Accessories register their characteristics off the first 'change'.
             this.emit('change', {...this.state}, this.state);
 
             this._subscribeRealtime();
         } catch (ex) {
-            this.log.error(`${this.context.name}: failed to connect to Tuya Cloud: ${ex.message}`);
-            // Retry later — credentials/permissions/network may recover.
-            if (!this._stopped) {
-                this._retryTimer = setTimeout(() => this._connect(), 30000);
-            }
+            this._onConnectFailure(ex);
         }
+    }
+
+    // A failed connect is retried, but the cause is frequently permanent — the
+    // cloud project can't see this device (permission denied / "no space"), the
+    // datacenter region is wrong, or the device isn't linked to the account — and
+    // won't clear without the user changing their Tuya project. Since PR #71 the
+    // cloud backs *every* device as a fallback, so a LAN-only device whose cloud
+    // project lacks permission would otherwise log an error every 30s forever.
+    // Two things keep that out of the log: a given error is surfaced once and then
+    // suppressed to debug until it changes (or the device connects), and the retry
+    // interval backs off (30s → 30m cap) instead of hammering the OpenAPI.
+    _onConnectFailure(ex) {
+        const message = ex && ex.message ? ex.message : String(ex);
+
+        if (message !== this._lastConnectError) {
+            // The cloud is only a fallback for a LAN-capable device (one with a
+            // local key); for a cloud-only device it is the sole path, so the same
+            // failure is more serious. Reflect that in the level and the hint.
+            const lanFallback = !!this.context.key;
+            const hint = lanFallback
+                ? ' The cloud is only a fallback here, so this is harmless if the device is reachable over the LAN; otherwise check that it is linked to the cloud project (matching account/home and datacenter region).'
+                : ' This device is cloud-only, so it stays unreachable until this clears — check that it is linked to the cloud project (matching account/home and datacenter region).';
+            this.log[lanFallback ? 'warn' : 'error'](`${this.context.name}: Tuya Cloud connection failed: ${message}.${hint}`);
+            this._lastConnectError = message;
+        } else {
+            this.log.debug(`${this.context.name}: Tuya Cloud connection still failing: ${message}`);
+        }
+
+        if (this._stopped) return;
+        // Exponential backoff: 30s after the first failure, doubling to a 30m cap.
+        this._retryDelay = Math.min(this._retryDelay ? this._retryDelay * 2 : 30000, 1800000);
+        this._retryTimer = setTimeout(() => this._connect(), this._retryDelay);
+        if (this._retryTimer && this._retryTimer.unref) this._retryTimer.unref();
     }
 
     /* ------------------------------------------------------------------ *

--- a/test/TuyaCloudDevice.test.js
+++ b/test/TuyaCloudDevice.test.js
@@ -201,4 +201,104 @@ describe('TuyaCloudDevice', () => {
         await new Promise(r => setImmediate(r));
         expect(api.getStatus).toHaveBeenCalledWith('dev1');
     });
+
+    describe('connect-failure handling (no log spam)', () => {
+        afterEach(() => jest.restoreAllMocks());
+
+        test('a repeated failure is surfaced once, suppressed after, and backs off', () => {
+            jest.useFakeTimers();
+            try {
+                const dev = makeDevice(makeApi(), null, {key: 'abc'}); // LAN-capable → fallback
+                const warn = jest.spyOn(log, 'warn');
+                const debug = jest.spyOn(log, 'debug');
+                const err = new Error('GET /v1.0/devices/dev1/status failed: permission deny (code 1106)');
+
+                dev._onConnectFailure(err);
+                expect(warn).toHaveBeenCalledTimes(1);
+                expect(warn.mock.calls[0][0]).toContain('permission deny (code 1106)');
+                expect(dev._retryDelay).toBe(30000);
+
+                dev._onConnectFailure(err); // identical → not surfaced again, just debug + backoff
+                expect(warn).toHaveBeenCalledTimes(1);
+                expect(debug).toHaveBeenCalledWith(expect.stringContaining('still failing'));
+                expect(dev._retryDelay).toBe(60000);
+
+                dev._onConnectFailure(err);
+                expect(dev._retryDelay).toBe(120000);
+            } finally {
+                jest.useRealTimers();
+            }
+        });
+
+        test('a cloud-only device (no key) surfaces the failure at error level', () => {
+            jest.useFakeTimers();
+            try {
+                const dev = makeDevice(makeApi()); // no key → cloud is the only path
+                const error = jest.spyOn(log, 'error');
+                const warn = jest.spyOn(log, 'warn');
+
+                dev._onConnectFailure(new Error('permission deny (code 1106)'));
+                expect(warn).not.toHaveBeenCalled();
+                expect(error).toHaveBeenCalledTimes(1);
+                expect(error.mock.calls[0][0]).toContain('cloud-only');
+            } finally {
+                jest.useRealTimers();
+            }
+        });
+
+        test('a different error message is surfaced again, not suppressed', () => {
+            jest.useFakeTimers();
+            try {
+                const dev = makeDevice(makeApi(), null, {key: 'abc'});
+                const warn = jest.spyOn(log, 'warn');
+
+                dev._onConnectFailure(new Error('permission deny (code 1106)'));
+                dev._onConnectFailure(new Error('request timed out'));
+                expect(warn).toHaveBeenCalledTimes(2);
+            } finally {
+                jest.useRealTimers();
+            }
+        });
+
+        test('backoff is capped at 30 minutes', () => {
+            jest.useFakeTimers();
+            try {
+                const dev = makeDevice(makeApi(), null, {key: 'abc'});
+                jest.spyOn(log, 'warn');
+                jest.spyOn(log, 'debug');
+                const err = new Error('permission deny (code 1106)');
+
+                for (let i = 0; i < 20; i++) dev._onConnectFailure(err);
+                expect(dev._retryDelay).toBe(1800000);
+            } finally {
+                jest.useRealTimers();
+            }
+        });
+
+        test('reconnecting after a failure logs recovery once and resets backoff', async () => {
+            const dev = makeDevice(makeApi(), null, {key: 'abc'});
+            dev._lastConnectError = 'permission deny (code 1106)';
+            dev._retryDelay = 240000;
+            const info = jest.spyOn(log, 'info');
+
+            await dev._connect(); // mocked api resolves → success path runs
+
+            expect(dev._lastConnectError).toBeNull();
+            expect(dev._retryDelay).toBe(0);
+            expect(info).toHaveBeenCalledWith(expect.stringContaining('connection restored'));
+        });
+
+        test('a stopped device does not schedule another retry', () => {
+            jest.useFakeTimers();
+            try {
+                const dev = makeDevice(makeApi(), null, {key: 'abc'});
+                jest.spyOn(log, 'warn');
+                dev.stop();
+                dev._onConnectFailure(new Error('permission deny (code 1106)'));
+                expect(dev._retryTimer).toBeNull();
+            } finally {
+                jest.useRealTimers();
+            }
+        });
+    });
 });

--- a/wiki/Tuya-Cloud-Setup.md
+++ b/wiki/Tuya-Cloud-Setup.md
@@ -132,8 +132,8 @@ The realtime stream connects out to Tuya's broker on **port 8883** — make sure
 
 | Symptom | Cause / fix |
 |---|---|
-| `failed to connect to Tuya Cloud: token request failed … (code 1004)` | Wrong **Access ID/Secret**, or host clock skew — the signature includes a timestamp, so keep the machine **NTP-synced**. |
-| `… (code 1106) permission deny` / `No permissions` | API service not authorized or **trial expired** (step 2), or **wrong region**, or you logged in with the developer account instead of the **app** account. |
+| `Tuya Cloud connection failed: token request failed … (code 1004)` | Wrong **Access ID/Secret**, or host clock skew — the signature includes a timestamp, so keep the machine **NTP-synced**. |
+| `… (code 1106) permission deny` / `(code 40001900) No space permission` | API service not authorized or **trial expired** (step 2), or **wrong region**, or you logged in with the developer account instead of the **app** account, or this specific device isn't linked to the project (step 3). The cloud backs every device as a fallback, so a single LAN-only device that isn't in the project logs this once — harmless if that device already works over the LAN. |
 | Device connects but shows nothing / `0` devices | **Region mismatch**, or the device isn't linked to the project (step 3), or the linked account isn't the device's **owner** (shared/guest access hides devices). |
 | `realtime disabled: the optional "mqtt" package is not installed` | Install `mqtt` (above), or ignore if you don't need live external updates. |
 | Realtime never connects (control works, external changes don't) | Outbound **port 8883** blocked by a firewall. |


### PR DESCRIPTION
Since the global cloud fallback (#71) backs every device, a LAN-only
device whose cloud project lacks permission for it (e.g. codes 1106
"permission deny" / 40001900 "No space permission") could never connect
its cloud backend and logged an error every 30s forever — even while the
device worked fine over the LAN.

TuyaCloudDevice now surfaces a given connect error once (with an
actionable hint, at warn for LAN-capable devices where the cloud is only
a fallback, error for cloud-only ones), suppresses identical repeats to
debug, and backs the retry off (30s → 30m cap) instead of hammering the
OpenAPI. A later success announces recovery once and resets the backoff.