### PR TITLE
Stop connection-attempt counter from spamming the debug log

### DIFF
--- a/lib/TuyaAccessory.js
+++ b/lib/TuyaAccessory.js
@@ -280,7 +280,6 @@ class TuyaAccessory extends EventEmitter {
     _incrementAttemptCounter() {
         this._connectionAttempts++;
         setTimeout(() => {
-            this.log.debug(`decrementing this._connectionAttempts, currently ${this._connectionAttempts}`);
             this._connectionAttempts--;
         }, 10000);
     }


### PR DESCRIPTION
The decrement scheduled by _incrementAttemptCounter logged an internal
counter trace on a 10s timer for every connection attempt. On a flaky
device this floods the log with "decrementing this._connectionAttempts"
lines that carry no diagnostic value (line 202 already logs the
meaningful reconnect). Drop the trace; keep the decrement.