### PR TITLE
Make Tuya Cloud realtime (MQTT) mandatory when cloud is configured

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -22,7 +22,7 @@
       "cloud": {
         "type": "object",
         "title": "Tuya Cloud fallback (optional)",
-        "description": "This plugin is LAN-first — every device is controlled locally. Add your Tuya Cloud project credentials here and the plugin keeps one Cloud session running in the background as a transparent fallback for every device: each accessory tries the LAN first, and only falls back to the cloud when it can't be reached locally — a flaky LAN moment, or a battery-powered 'sleepy' device that never appears on the LAN. It's opt-in and local is always preferred. Create a free Cloud project at iot.tuya.com. See the wiki for step-by-step setup.",
+        "description": "<a href='https://github.com/adrianjagielak/homebridge-tuya-plus/blob/main/wiki/Tuya-Cloud-Setup.md'>Tuya Cloud API Setup</a>.",
         "properties": {
           "accessId": {
             "type": "string",
@@ -69,12 +69,6 @@
               { "title": "Tuya Smart", "enum": ["tuyaSmart"] },
               { "title": "Smart Life", "enum": ["smartlife"] }
             ]
-          },
-          "realtime": {
-            "type": "boolean",
-            "title": "Realtime updates (MQTT)",
-            "default": true,
-            "description": "Receive instant updates over Tuya's MQTT message service (uses the 'mqtt' package, installed automatically). If disabled, devices stay controllable and show their state at startup, but external changes (physical buttons, the device's own timers) won't be reflected until restart."
           }
         }
       },
@@ -96,7 +90,7 @@
                 {
                   "title": "Switch Gang / Basic Switch",
                   "enum": ["Switch"]
-                },                
+                },
                 {
                   "title": "Smart Plug / Barely Smart Power Strip",
                   "enum": ["Outlet"]
@@ -311,7 +305,7 @@
               "condition": {
                 "functionBody": "return model.devices && model.devices[arrayIndices] && ['WledDimmer'].includes(model.devices[arrayIndices].type);"
               }
-            },            
+            },
             "dpColorTemperature": {
               "type": "integer",
               "placeholder": "3",
@@ -754,9 +748,21 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "name": { "type": "string", "title": "Zone name", "placeholder": "Lawn" },
-                  "dp": { "type": ["integer", "string"], "title": "Data-point (numeric id, or cloud code)", "placeholder": "1 or switch_1" },
-                  "defaultDuration": { "type": "integer", "title": "Default run time (seconds, 0 = run indefinitely)", "placeholder": 600 }
+                  "name": {
+                    "type": "string",
+                    "title": "Zone name",
+                    "placeholder": "Lawn"
+                  },
+                  "dp": {
+                    "type": ["integer", "string"],
+                    "title": "Data-point (numeric id, or cloud code)",
+                    "placeholder": "1 or switch_1"
+                  },
+                  "defaultDuration": {
+                    "type": "integer",
+                    "title": "Default run time (seconds, 0 = run indefinitely)",
+                    "placeholder": 600
+                  }
                 }
               },
               "condition": {

--- a/index.js
+++ b/index.js
@@ -40,328 +40,459 @@ const PLATFORM_NAME = 'TuyaLan';
 const UUID_SEED = 'homebridge-tuya';
 const DEFAULT_DISCOVER_TIMEOUT = 60000;
 
-// Lenient boolean coercion (matches BaseAccessory._coerceBoolean) so config
-// values like true / "true" / 1 all read as true.
-const coerceBoolean = (b, df = false) =>
-    typeof b === 'boolean' ? b :
-    typeof b === 'string' ? b.toLowerCase().trim() === 'true' :
-    typeof b === 'number' ? b !== 0 : df;
-
 const CLASS_DEF = {
-    outlet: OutletAccessory,
-    simplelight: SimpleLightAccessory,
-    rgbtwlight: RGBTWLightAccessory,
-    rgbtwoutlet: RGBTWOutletAccessory,
-    twlight: TWLightAccessory,
-    multioutlet: MultiOutletAccessory,
-    custommultioutlet: CustomMultiOutletAccessory,
-    airconditioner: AirConditionerAccessory,
-    airpurifier: AirPurifierAccessory,
-    dehumidifier: DehumidifierAccessory,
-    convector: ConvectorAccessory,
-    garagedoor: GarageDoorAccessory,
-    simplegaragedoor: SimpleGarageDoorAccessory,
-    simpledimmer: SimpleDimmerAccessory,
-    wleddimmer: WledDimmerAccessory,
-    simpledimmer2: SimpleDimmer2Accessory,
-    simpleblinds: SimpleBlindsAccessory,
-    simpleheater: SimpleHeaterAccessory,
-    switch: SwitchAccessory,
-    fan: SimpleFanAccessory,
-    fanlight: SimpleFanLightAccessory,
-    watervalve: ValveAccessory,
-    irrigationsystem: IrrigationSystemAccessory,
-    oildiffuser: OilDiffuserAccessory,
-    doorbell: DoorbellAccessory,
-    verticalblindswithtilt: VerticalBlindsWithTilt,
-    percentblinds: PercentBlindsAccessory
+  outlet: OutletAccessory,
+  simplelight: SimpleLightAccessory,
+  rgbtwlight: RGBTWLightAccessory,
+  rgbtwoutlet: RGBTWOutletAccessory,
+  twlight: TWLightAccessory,
+  multioutlet: MultiOutletAccessory,
+  custommultioutlet: CustomMultiOutletAccessory,
+  airconditioner: AirConditionerAccessory,
+  airpurifier: AirPurifierAccessory,
+  dehumidifier: DehumidifierAccessory,
+  convector: ConvectorAccessory,
+  garagedoor: GarageDoorAccessory,
+  simplegaragedoor: SimpleGarageDoorAccessory,
+  simpledimmer: SimpleDimmerAccessory,
+  wleddimmer: WledDimmerAccessory,
+  simpledimmer2: SimpleDimmer2Accessory,
+  simpleblinds: SimpleBlindsAccessory,
+  simpleheater: SimpleHeaterAccessory,
+  switch: SwitchAccessory,
+  fan: SimpleFanAccessory,
+  fanlight: SimpleFanLightAccessory,
+  watervalve: ValveAccessory,
+  irrigationsystem: IrrigationSystemAccessory,
+  oildiffuser: OilDiffuserAccessory,
+  doorbell: DoorbellAccessory,
+  verticalblindswithtilt: VerticalBlindsWithTilt,
+  percentblinds: PercentBlindsAccessory,
 };
 
-let Characteristic, Formats, Perms, Categories, PlatformAccessory, Service, AdaptiveLightingController, UUID;
+let Characteristic,
+  Formats,
+  Perms,
+  Categories,
+  PlatformAccessory,
+  Service,
+  AdaptiveLightingController,
+  UUID;
 
-module.exports = function(homebridge) {
-    ({
-        platformAccessory: PlatformAccessory,
-        hap: {Characteristic, Formats, Perms, Categories, Service, AdaptiveLightingController, uuid: UUID}
-    } = homebridge);
+module.exports = function (homebridge) {
+  ({
+    platformAccessory: PlatformAccessory,
+    hap: {
+      Characteristic,
+      Formats,
+      Perms,
+      Categories,
+      Service,
+      AdaptiveLightingController,
+      uuid: UUID,
+    },
+  } = homebridge);
 
-    homebridge.registerPlatform(PLUGIN_NAME, PLATFORM_NAME, TuyaLan, true);
+  homebridge.registerPlatform(PLUGIN_NAME, PLATFORM_NAME, TuyaLan, true);
 };
 
 class TuyaLan {
-    constructor(...props) {
-        [this.log, this.config, this.api] = [...props];
+  constructor(...props) {
+    [this.log, this.config, this.api] = [...props];
 
-        this.cachedAccessories = new Map();
-        // One TuyaDevice per configured device, keyed by Tuya id, so discovery can
-        // hand each its LAN target once it's found on the network.
-        this.tuyaDevices = new Map();
-        // A SINGLE shared Tuya Cloud session (OpenAPI token + realtime MQTT) for the
-        // whole platform — the global fallback every device can lean on. Stays null
-        // unless cloud credentials are configured.
-        this.cloudApi = null;
-        this.cloudMessaging = null;
-        this.api.hap.EnergyCharacteristics = require('./lib/EnergyCharacteristics')(this.api.hap);
+    this.cachedAccessories = new Map();
+    // One TuyaDevice per configured device, keyed by Tuya id, so discovery can
+    // hand each its LAN target once it's found on the network.
+    this.tuyaDevices = new Map();
+    // A SINGLE shared Tuya Cloud session (OpenAPI token + realtime MQTT) for the
+    // whole platform — the global fallback every device can lean on. Stays null
+    // unless cloud credentials are configured.
+    this.cloudApi = null;
+    this.cloudMessaging = null;
+    this.api.hap.EnergyCharacteristics = require('./lib/EnergyCharacteristics')(
+      this.api.hap,
+    );
 
-        if(!this.config || !this.config.devices) {
-            this.log("No devices found. Check that you have specified them in your config.json file.");
-            return false;
-        }
-
-        this._expectedUUIDs = this.config.devices.map(device => UUID.generate(UUID_SEED +(device.fake ? ':fake:' : ':') + device.id));
-
-        this.api.on('didFinishLaunching', () => {
-            this.discoverDevices();
-        });
+    if (!this.config || !this.config.devices) {
+      this.log(
+        'No devices found. Check that you have specified them in your config.json file.',
+      );
+      return false;
     }
 
-    discoverDevices() {
-        // Bring up the single shared cloud session first, so every device that opts
-        // into (or falls back to) the cloud shares one token and one MQTT stream.
-        this._setupCloudSession();
+    this._expectedUUIDs = this.config.devices.map((device) =>
+      UUID.generate(UUID_SEED + (device.fake ? ':fake:' : ':') + device.id),
+    );
 
-        const lanDeviceIds = [];      // ids we still want to find on the LAN
-        const connectedDevices = [];  // ids discovered on the LAN
-        const fakeDevices = [];
-        const seenUUIDs = new Set();  // accessory UUIDs already configured this run
+    this.api.on('didFinishLaunching', () => {
+      this.discoverDevices();
+    });
+  }
 
-        this.config.devices.forEach(device => {
-            try {
-                device.id = ('' + device.id).trim();
-                // Cloud-only devices don't need a local key; only trim when present.
-                if (device.key != null) device.key = ('' + device.key).trim();
-                device.type = ('' + device.type).trim();
+  discoverDevices() {
+    // Bring up the single shared cloud session first, so every device that opts
+    // into (or falls back to) the cloud shares one token and one MQTT stream.
+    this._setupCloudSession();
 
-                device.ip = ('' + (device.ip || '')).trim();
-            } catch(ex) {}
+    const lanDeviceIds = []; // ids we still want to find on the LAN
+    const connectedDevices = []; // ids discovered on the LAN
+    const fakeDevices = [];
+    const seenUUIDs = new Set(); // accessory UUIDs already configured this run
 
-            if (!device.type) return this.log.error('%s (%s) doesn\'t have a type defined.', device.name || 'Unnamed device', device.id);
-            if (!CLASS_DEF[device.type.toLowerCase()]) return this.log.error('%s (%s) doesn\'t have a valid type defined.', device.name || 'Unnamed device', device.id);
+    this.config.devices.forEach((device) => {
+      try {
+        device.id = ('' + device.id).trim();
+        // Cloud-only devices don't need a local key; only trim when present.
+        if (device.key != null) device.key = ('' + device.key).trim();
+        device.type = ('' + device.type).trim();
 
-            // Two config entries that resolve to the same accessory UUID (the same
-            // Tuya id, real or fake) make addAccessory process that UUID twice. The
-            // second pass reads back the accessory wrapper the first pass cached
-            // instead of a PlatformAccessory and crashes the child bridge while
-            // trying to unregister it. Keep the first entry; skip the rest.
-            const uuid = UUID.generate(UUID_SEED + (device.fake ? ':fake:' : ':') + device.id);
-            if (seenUUIDs.has(uuid)) return this.log.warn('%s (%s) is configured more than once; ignoring the duplicate entry.', device.name || 'Unnamed device', device.id);
-            seenUUIDs.add(uuid);
+        device.ip = ('' + (device.ip || '')).trim();
+      } catch (ex) {}
 
-            if (device.fake) {
-                fakeDevices.push({name: device.id.slice(8), ...device});
-                return;
-            }
+      if (!device.type)
+        return this.log.error(
+          "%s (%s) doesn't have a type defined.",
+          device.name || 'Unnamed device',
+          device.id,
+        );
+      if (!CLASS_DEF[device.type.toLowerCase()])
+        return this.log.error(
+          "%s (%s) doesn't have a valid type defined.",
+          device.name || 'Unnamed device',
+          device.id,
+        );
 
-            const tuyaDevice = this._createDevice({name: device.id.slice(8), ...device});
-            this.tuyaDevices.set(device.id, tuyaDevice);
-            this.addAccessory(tuyaDevice);
+      // Two config entries that resolve to the same accessory UUID (the same
+      // Tuya id, real or fake) make addAccessory process that UUID twice. The
+      // second pass reads back the accessory wrapper the first pass cached
+      // instead of a PlatformAccessory and crashes the child bridge while
+      // trying to unregister it. Keep the first entry; skip the rest.
+      const uuid = UUID.generate(
+        UUID_SEED + (device.fake ? ':fake:' : ':') + device.id,
+      );
+      if (seenUUIDs.has(uuid))
+        return this.log.warn(
+          '%s (%s) is configured more than once; ignoring the duplicate entry.',
+          device.name || 'Unnamed device',
+          device.id,
+        );
+      seenUUIDs.add(uuid);
 
-            // A device with a local key can be reached on the LAN, so it wants
-            // discovery; the cloud, when configured, is its fallback. A device with
-            // no key is cloud-only (e.g. a battery-powered "sleepy" unit) and relies
-            // on the cloud session to be reachable at all.
-            if (device.key) lanDeviceIds.push(device.id);
-            else if (!this.cloudApi) this.log.error('%s (%s) has no local key and no Tuya Cloud session is configured, so it can\'t be reached. Add a key for LAN control, or a top-level "cloud" block.', tuyaDevice.context.name, device.id);
-        });
+      if (device.fake) {
+        fakeDevices.push({ name: device.id.slice(8), ...device });
+        return;
+      }
 
-        fakeDevices.forEach(config => {
-            this.log.info('Adding fake device: %s', config.name);
-            this.addAccessory(new TuyaAccessory({
-                ...config,
-                log: this.log,
-                UUID: UUID.generate(UUID_SEED + ':fake:' + config.id),
-                connect: false
-            }));
-        });
+      const tuyaDevice = this._createDevice({
+        name: device.id.slice(8),
+        ...device,
+      });
+      this.tuyaDevices.set(device.id, tuyaDevice);
+      this.addAccessory(tuyaDevice);
 
-        if (lanDeviceIds.length === 0) {
-            if (this.tuyaDevices.size === 0 && fakeDevices.length === 0) this.log.error('No valid configured devices found.');
-            return; // cloud-only (or empty) configuration: nothing to discover over the LAN
-        }
+      // A device with a local key can be reached on the LAN, so it wants
+      // discovery; the cloud, when configured, is its fallback. A device with
+      // no key is cloud-only (e.g. a battery-powered "sleepy" unit) and relies
+      // on the cloud session to be reachable at all.
+      if (device.key) lanDeviceIds.push(device.id);
+      else if (!this.cloudApi)
+        this.log.error(
+          '%s (%s) has no local key and no Tuya Cloud session is configured, so it can\'t be reached. Add a key for LAN control, or a top-level "cloud" block.',
+          tuyaDevice.context.name,
+          device.id,
+        );
+    });
 
-        this.log.info('Starting discovery...');
+    fakeDevices.forEach((config) => {
+      this.log.info('Adding fake device: %s', config.name);
+      this.addAccessory(
+        new TuyaAccessory({
+          ...config,
+          log: this.log,
+          UUID: UUID.generate(UUID_SEED + ':fake:' + config.id),
+          connect: false,
+        }),
+      );
+    });
 
-        TuyaDiscovery.start({ids: lanDeviceIds, log: this.log})
-            .on('discover', config => {
-                if (!config || !config.id) return;
-                const tuyaDevice = this.tuyaDevices.get(config.id);
-                if (!tuyaDevice) return this.log.warn('Discovered a device that has not been configured yet (%s@%s).', config.id, config.ip);
-                if (connectedDevices.includes(config.id)) return;
-
-                connectedDevices.push(config.id);
-
-                this.log.info('Discovered %s (%s) identified as %s (%s)', tuyaDevice.context.name, config.id, tuyaDevice.context.type, config.version);
-
-                // The version broadcast by the device wins over a configured `version`,
-                // but `forceVersion` overrides everything; attachLan applies that order.
-                tuyaDevice.attachLan({ip: config.ip, version: config.version});
-            });
-
-        setTimeout(() => {
-            lanDeviceIds.forEach(deviceId => {
-                if (connectedDevices.includes(deviceId)) return;
-
-                const tuyaDevice = this.tuyaDevices.get(deviceId);
-                if (!tuyaDevice) return;
-
-                if (tuyaDevice.context.ip) {
-                    this.log.info('Failed to discover %s (%s) in time but will connect via %s.', tuyaDevice.context.name, deviceId, tuyaDevice.context.ip);
-                    tuyaDevice.attachLan({ip: tuyaDevice.context.ip});
-                } else if (tuyaDevice.cloud) {
-                    this.log.info('Failed to discover %s (%s) on the LAN; it will run over the Tuya Cloud fallback.', tuyaDevice.context.name, deviceId);
-                } else {
-                    this.log.warn('Failed to discover %s (%s) in time but will keep looking.', tuyaDevice.context.name, deviceId);
-                }
-            });
-        }, this.config.discoverTimeout ?? DEFAULT_DISCOVER_TIMEOUT);
+    if (lanDeviceIds.length === 0) {
+      if (this.tuyaDevices.size === 0 && fakeDevices.length === 0)
+        this.log.error('No valid configured devices found.');
+      return; // cloud-only (or empty) configuration: nothing to discover over the LAN
     }
 
-    /* ------------------------------------------------------------------ *
-     *  Tuya Cloud — a single, global fallback session.
-     *
-     *  This plugin stays LAN-first: every device is controlled locally when it
-     *  can be. When a top-level `cloud` block is configured, the plugin keeps one
-     *  shared Tuya Cloud session alive in the background, and every device gains a
-     *  transparent cloud fallback for the moments the LAN can't be reached (a
-     *  flaky connection, or a battery-powered "sleepy" device that never appears
-     *  on the LAN at all). It's all opt-in — without `cloud`, nothing here runs.
-     * ------------------------------------------------------------------ */
+    this.log.info('Starting discovery...');
 
-    _setupCloudSession() {
-        const cloudCfg = (this.config.cloud && typeof this.config.cloud === 'object') ? this.config.cloud : null;
-        if (!cloudCfg) return; // no cloud block: the plugin runs purely on the LAN
+    TuyaDiscovery.start({ ids: lanDeviceIds, log: this.log }).on(
+      'discover',
+      (config) => {
+        if (!config || !config.id) return;
+        const tuyaDevice = this.tuyaDevices.get(config.id);
+        if (!tuyaDevice)
+          return this.log.warn(
+            'Discovered a device that has not been configured yet (%s@%s).',
+            config.id,
+            config.ip,
+          );
+        if (connectedDevices.includes(config.id)) return;
 
-        if (!cloudCfg.accessId || !cloudCfg.accessKey) {
-            return this.log.error('A "cloud" block is present but is missing accessId/accessKey, so the Tuya Cloud fallback is disabled. See the wiki: Tuya Cloud Setup.');
-        }
+        connectedDevices.push(config.id);
 
-        this.cloudApi = new TuyaCloudApi({...cloudCfg, log: this.log});
+        this.log.info(
+          'Discovered %s (%s) identified as %s (%s)',
+          tuyaDevice.context.name,
+          config.id,
+          tuyaDevice.context.type,
+          config.version,
+        );
 
-        const realtime = cloudCfg.realtime === undefined ? true : coerceBoolean(cloudCfg.realtime, true);
-        this.cloudMessaging = realtime ? new TuyaCloudMessaging({api: this.cloudApi, log: this.log}) : null;
+        // The version broadcast by the device wins over a configured `version`,
+        // but `forceVersion` overrides everything; attachLan applies that order.
+        tuyaDevice.attachLan({ ip: config.ip, version: config.version });
+      },
+    );
 
-        this.log.info('Tuya Cloud fallback enabled via %s%s.', this.cloudApi.endpoint, this.cloudMessaging ? ' (with realtime updates)' : ' (realtime updates disabled)');
-    }
+    setTimeout(() => {
+      lanDeviceIds.forEach((deviceId) => {
+        if (connectedDevices.includes(deviceId)) return;
 
-    _createDevice(device) {
-        // The one shared cloud session, when configured, backs every device as its
-        // fallback. There is no per-device cloud configuration.
-        const usesCloud = !!this.cloudApi;
-        return new TuyaDevice({
-            ...device,
-            cloudApi: usesCloud ? this.cloudApi : undefined,
-            messaging: usesCloud ? this.cloudMessaging : undefined,
-            cloudStartDelay: usesCloud ? this._nextCloudStartDelay() : 0,
-            log: this.log,
-            UUID: UUID.generate(UUID_SEED + ':' + device.id),
-            connect: false
-        });
-    }
+        const tuyaDevice = this.tuyaDevices.get(deviceId);
+        if (!tuyaDevice) return;
 
-    // Spread the cloud devices' first reads over a few seconds so a large install
-    // doesn't fire dozens of OpenAPI calls at once and trip Tuya's per-second rate
-    // limit at startup.
-    _nextCloudStartDelay() {
-        this._cloudStartCount = (this._cloudStartCount || 0) + 1;
-        return Math.min(15000, (this._cloudStartCount - 1) * 300);
-    }
-
-    registerPlatformAccessories(platformAccessories) {
-        this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, Array.isArray(platformAccessories) ? platformAccessories : [platformAccessories]);
-    }
-
-    configureAccessory(accessory) {
-        // also checks null objects or empty config - this._expectedUUIDs
-        if (accessory instanceof PlatformAccessory && this._expectedUUIDs && this._expectedUUIDs.includes(accessory.UUID)) {
-            this.cachedAccessories.set(accessory.UUID, accessory);
-            accessory.services.forEach(service => {
-                if (service.UUID === Service.AccessoryInformation.UUID) return;
-                service.characteristics.some(characteristic => {
-                    if (!characteristic.props ||
-                        !Array.isArray(characteristic.props.perms) ||
-                        characteristic.props.perms.length !== 3 ||
-                        !(characteristic.props.perms.includes(Perms.WRITE) && characteristic.props.perms.includes(Perms.NOTIFY))
-                    ) return;
-
-                    this.log.info('Marked %s unreachable by faulting Service.%s.%s', accessory.displayName, service.displayName, characteristic.displayName);
-
-                    characteristic.updateValue(new Error('Unreachable'));
-                    return true;
-                });
-            });
+        if (tuyaDevice.context.ip) {
+          this.log.info(
+            'Failed to discover %s (%s) in time but will connect via %s.',
+            tuyaDevice.context.name,
+            deviceId,
+            tuyaDevice.context.ip,
+          );
+          tuyaDevice.attachLan({ ip: tuyaDevice.context.ip });
+        } else if (tuyaDevice.cloud) {
+          this.log.info(
+            'Failed to discover %s (%s) on the LAN; it will run over the Tuya Cloud fallback.',
+            tuyaDevice.context.name,
+            deviceId,
+          );
         } else {
-            /*
-             * Irrespective of this unregistering, Homebridge continues
-             * to "_prepareAssociatedHAPAccessory" and "addBridgedAccessory".
-             * This timeout will hopefully remove the accessory after that has happened.
-             */
-            setTimeout(() => {
-                this.removeAccessory(accessory);
-            }, 1000);
+          this.log.warn(
+            'Failed to discover %s (%s) in time but will keep looking.',
+            tuyaDevice.context.name,
+            deviceId,
+          );
         }
+      });
+    }, this.config.discoverTimeout ?? DEFAULT_DISCOVER_TIMEOUT);
+  }
+
+  /* ------------------------------------------------------------------ *
+   *  Tuya Cloud — a single, global fallback session.
+   *
+   *  This plugin stays LAN-first: every device is controlled locally when it
+   *  can be. When a top-level `cloud` block is configured, the plugin keeps one
+   *  shared Tuya Cloud session alive in the background, and every device gains a
+   *  transparent cloud fallback for the moments the LAN can't be reached (a
+   *  flaky connection, or a battery-powered "sleepy" device that never appears
+   *  on the LAN at all). It's all opt-in — without `cloud`, nothing here runs.
+   * ------------------------------------------------------------------ */
+
+  _setupCloudSession() {
+    const cloudCfg =
+      this.config.cloud && typeof this.config.cloud === 'object'
+        ? this.config.cloud
+        : null;
+    if (!cloudCfg) return; // no cloud block: the plugin runs purely on the LAN
+
+    if (!cloudCfg.accessId || !cloudCfg.accessKey) {
+      return this.log.error(
+        'A "cloud" block is present but is missing accessId/accessKey, so the Tuya Cloud fallback is disabled. See the wiki: Tuya Cloud Setup.',
+      );
     }
 
-    addAccessory(device) {
-        const deviceConfig = device.context;
-        const type = (deviceConfig.type || '').toLowerCase();
+    this.cloudApi = new TuyaCloudApi({ ...cloudCfg, log: this.log });
+    this.cloudMessaging = new TuyaCloudMessaging({
+      api: this.cloudApi,
+      log: this.log,
+    });
 
-        const Accessory = CLASS_DEF[type];
+    this.log.info(
+      'Tuya Cloud fallback enabled via %s.',
+      this.cloudApi.endpoint,
+    );
+  }
 
-        let accessory = this.cachedAccessories.get(deviceConfig.UUID),
-            isCached = true;
+  _createDevice(device) {
+    // The one shared cloud session, when configured, backs every device as its
+    // fallback. There is no per-device cloud configuration.
+    const usesCloud = !!this.cloudApi;
+    return new TuyaDevice({
+      ...device,
+      cloudApi: usesCloud ? this.cloudApi : undefined,
+      messaging: usesCloud ? this.cloudMessaging : undefined,
+      cloudStartDelay: usesCloud ? this._nextCloudStartDelay() : 0,
+      log: this.log,
+      UUID: UUID.generate(UUID_SEED + ':' + device.id),
+      connect: false,
+    });
+  }
 
-        const expectedCategory = Accessory.getCategory(Categories);
+  // Spread the cloud devices' first reads over a few seconds so a large install
+  // doesn't fire dozens of OpenAPI calls at once and trip Tuya's per-second rate
+  // limit at startup.
+  _nextCloudStartDelay() {
+    this._cloudStartCount = (this._cloudStartCount || 0) + 1;
+    return Math.min(15000, (this._cloudStartCount - 1) * 300);
+  }
 
-        // Only treat a cached accessory as a "different type" when we actually
-        // have a category to compare against. If getCategory() resolves to
-        // undefined (e.g. an unknown HAP category constant), HomeKit stores the
-        // accessory as Categories.OTHER, so an undefined expectation would never
-        // match and we would needlessly unregister & recreate the accessory on
-        // every restart — wiping its HomeKit identity (name, room, automations).
-        if (accessory && expectedCategory !== undefined && accessory.category !== expectedCategory) {
-            this.log.info("%s has a different type (%s vs %s)", accessory.displayName, accessory.category, expectedCategory);
-            this.removeAccessory(accessory);
-            accessory = null;
-        }
+  registerPlatformAccessories(platformAccessories) {
+    this.api.registerPlatformAccessories(
+      PLUGIN_NAME,
+      PLATFORM_NAME,
+      Array.isArray(platformAccessories)
+        ? platformAccessories
+        : [platformAccessories],
+    );
+  }
 
-        if (!accessory) {
-            accessory = new PlatformAccessory(deviceConfig.name, deviceConfig.UUID, expectedCategory);
-            accessory.getService(Service.AccessoryInformation)
-                .setCharacteristic(Characteristic.Manufacturer, deviceConfig.manufacturer || "Unknown")
-                .setCharacteristic(Characteristic.Model, deviceConfig.model || "Unknown")
-                .setCharacteristic(Characteristic.SerialNumber, deviceConfig.id.slice(8));
+  configureAccessory(accessory) {
+    // also checks null objects or empty config - this._expectedUUIDs
+    if (
+      accessory instanceof PlatformAccessory &&
+      this._expectedUUIDs &&
+      this._expectedUUIDs.includes(accessory.UUID)
+    ) {
+      this.cachedAccessories.set(accessory.UUID, accessory);
+      accessory.services.forEach((service) => {
+        if (service.UUID === Service.AccessoryInformation.UUID) return;
+        service.characteristics.some((characteristic) => {
+          if (
+            !characteristic.props ||
+            !Array.isArray(characteristic.props.perms) ||
+            characteristic.props.perms.length !== 3 ||
+            !(
+              characteristic.props.perms.includes(Perms.WRITE) &&
+              characteristic.props.perms.includes(Perms.NOTIFY)
+            )
+          )
+            return;
 
-            isCached = false;
-        }
+          this.log.info(
+            'Marked %s unreachable by faulting Service.%s.%s',
+            accessory.displayName,
+            service.displayName,
+            characteristic.displayName,
+          );
 
-        if (accessory && accessory.displayName !== deviceConfig.name) {
-            this.log.info(
-                "Configuration name %s differs from cached displayName %s. Updating cached displayName to %s ",
-                deviceConfig.name, accessory.displayName, deviceConfig.name);
-            accessory.displayName = deviceConfig.name;
-        }
+          characteristic.updateValue(new Error('Unreachable'));
+          return true;
+        });
+      });
+    } else {
+      /*
+       * Irrespective of this unregistering, Homebridge continues
+       * to "_prepareAssociatedHAPAccessory" and "addBridgedAccessory".
+       * This timeout will hopefully remove the accessory after that has happened.
+       */
+      setTimeout(() => {
+        this.removeAccessory(accessory);
+      }, 1000);
+    }
+  }
 
-        this.cachedAccessories.set(deviceConfig.UUID, new Accessory(this, accessory, device, !isCached));
+  addAccessory(device) {
+    const deviceConfig = device.context;
+    const type = (deviceConfig.type || '').toLowerCase();
+
+    const Accessory = CLASS_DEF[type];
+
+    let accessory = this.cachedAccessories.get(deviceConfig.UUID),
+      isCached = true;
+
+    const expectedCategory = Accessory.getCategory(Categories);
+
+    // Only treat a cached accessory as a "different type" when we actually
+    // have a category to compare against. If getCategory() resolves to
+    // undefined (e.g. an unknown HAP category constant), HomeKit stores the
+    // accessory as Categories.OTHER, so an undefined expectation would never
+    // match and we would needlessly unregister & recreate the accessory on
+    // every restart — wiping its HomeKit identity (name, room, automations).
+    if (
+      accessory &&
+      expectedCategory !== undefined &&
+      accessory.category !== expectedCategory
+    ) {
+      this.log.info(
+        '%s has a different type (%s vs %s)',
+        accessory.displayName,
+        accessory.category,
+        expectedCategory,
+      );
+      this.removeAccessory(accessory);
+      accessory = null;
     }
 
-    removeAccessory(homebridgeAccessory) {
-        if (!homebridgeAccessory) return;
+    if (!accessory) {
+      accessory = new PlatformAccessory(
+        deviceConfig.name,
+        deviceConfig.UUID,
+        expectedCategory,
+      );
+      accessory
+        .getService(Service.AccessoryInformation)
+        .setCharacteristic(
+          Characteristic.Manufacturer,
+          deviceConfig.manufacturer || 'Unknown',
+        )
+        .setCharacteristic(
+          Characteristic.Model,
+          deviceConfig.model || 'Unknown',
+        )
+        .setCharacteristic(
+          Characteristic.SerialNumber,
+          deviceConfig.id.slice(8),
+        );
 
-        // Only real PlatformAccessory instances can be unregistered. cachedAccessories
-        // also holds accessory wrappers (set by addAccessory), and Homebridge throws a
-        // fatal TypeError when handed anything else, taking down the whole child bridge.
-        // Guard against it rather than trust every caller.
-        if (!(homebridgeAccessory instanceof PlatformAccessory)) {
-            return this.log.warn('Skipped unregistering %s: not a PlatformAccessory.', homebridgeAccessory.displayName);
-        }
-
-        this.log.warn('Unregistering', homebridgeAccessory.displayName);
-
-        this.cachedAccessories.delete(homebridgeAccessory.UUID);
-        this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [homebridgeAccessory]);
+      isCached = false;
     }
 
-    removeAccessoryByUUID(uuid) {
-        if (uuid) this.removeAccessory(this.cachedAccessories.get(uuid));
+    if (accessory && accessory.displayName !== deviceConfig.name) {
+      this.log.info(
+        'Configuration name %s differs from cached displayName %s. Updating cached displayName to %s ',
+        deviceConfig.name,
+        accessory.displayName,
+        deviceConfig.name,
+      );
+      accessory.displayName = deviceConfig.name;
     }
+
+    this.cachedAccessories.set(
+      deviceConfig.UUID,
+      new Accessory(this, accessory, device, !isCached),
+    );
+  }
+
+  removeAccessory(homebridgeAccessory) {
+    if (!homebridgeAccessory) return;
+
+    // Only real PlatformAccessory instances can be unregistered. cachedAccessories
+    // also holds accessory wrappers (set by addAccessory), and Homebridge throws a
+    // fatal TypeError when handed anything else, taking down the whole child bridge.
+    // Guard against it rather than trust every caller.
+    if (!(homebridgeAccessory instanceof PlatformAccessory)) {
+      return this.log.warn(
+        'Skipped unregistering %s: not a PlatformAccessory.',
+        homebridgeAccessory.displayName,
+      );
+    }
+
+    this.log.warn('Unregistering', homebridgeAccessory.displayName);
+
+    this.cachedAccessories.delete(homebridgeAccessory.UUID);
+    this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [
+      homebridgeAccessory,
+    ]);
+  }
+
+  removeAccessoryByUUID(uuid) {
+    if (uuid) this.removeAccessory(this.cachedAccessories.get(uuid));
+  }
 }

--- a/lib/TuyaCloudMessaging.js
+++ b/lib/TuyaCloudMessaging.js
@@ -6,35 +6,26 @@ const crypto = require('crypto');
 /*
  * TuyaCloudMessaging
  * ------------------
- * Optional realtime updates for cloud-backed devices, over Tuya's MQTT message
- * service. ONE instance is shared by every cloud device on the same Tuya
- * project (one broker connection delivers status for all of them); messages are
- * fanned out to the right device by its `devId`.
+ * Realtime updates for cloud-backed devices, over Tuya's MQTT message service.
+ * ONE instance is shared by every cloud device on the same Tuya project (one
+ * broker connection delivers status for all of them); messages are fanned out
+ * to the right device by its `devId`.
  *
- * This is intentionally a best-effort accelerator layered on top of polling:
- * if the optional `mqtt` package is missing, or the broker can't be reached, or
- * a message can't be decrypted, nothing breaks — the devices simply keep
- * polling. When it IS working, changes (including physical button presses and
- * the rain sensor) show up in HomeKit within a second or two.
+ * Cloud updates (including physical button presses and the rain sensor) arrive
+ * over this stream rather than by polling, so they show up in HomeKit within a
+ * second or two. `mqtt` is a required dependency; if the broker can't be
+ * reached or a message can't be decrypted nothing crashes — the stream simply
+ * reconnects and the cloud REST reads still cover initial state.
  *
  * The connection + AES-GCM message decryption are faithful to the
  * actively-maintained `0x5e/homebridge-tuya-platform` (`src/core/TuyaOpenMQ.ts`),
  * re-implemented here with Node's built-in `crypto`.
  */
 
+const mqtt = require('mqtt');
+
 const GCM_TAG_LENGTH = 16;
 const PROTOCOL_DEVICE_STATUS = 4;
-
-// `mqtt` is an OPTIONAL dependency: realtime is a bonus, polling is the
-// guarantee. Loading it lazily keeps the plugin LAN-first and lets it run in
-// environments where mqtt isn't (or can't be) installed.
-let mqtt = null;
-let mqttLoadError = null;
-try {
-    mqtt = require('mqtt');
-} catch (ex) {
-    mqttLoadError = ex;
-}
 
 class TuyaCloudMessaging extends EventEmitter {
     constructor({api, log} = {}) {
@@ -56,10 +47,6 @@ class TuyaCloudMessaging extends EventEmitter {
         this.setMaxListeners(0);
     }
 
-    static isAvailable() {
-        return !!mqtt;
-    }
-
     // Register a device's status handler and lazily start the shared connection.
     subscribeDevice(devId, handler) {
         const id = '' + devId;
@@ -72,13 +59,8 @@ class TuyaCloudMessaging extends EventEmitter {
         if (this._stopped || this._started) return;
         this._started = true;
 
-        if (!mqtt) {
-            this.log.warn(`Tuya Cloud realtime disabled: the optional "mqtt" package is not installed${mqttLoadError ? ` (${mqttLoadError.message})` : ''}. Devices will poll instead. Install it with "npm install mqtt" in the plugin folder to enable instant updates.`);
-            return;
-        }
-
         this._connect().catch(ex => {
-            this.log.warn(`Tuya Cloud realtime could not start (${ex.message}); devices will poll instead.`);
+            this.log.warn(`Tuya Cloud realtime could not start (${ex.message}); it will keep retrying.`);
             this._scheduleRenew(60);
         });
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "fs-extra": "^8.1.0",
         "http-mitm-proxy": "^1.1.0",
         "json5": "^2.2.0",
-        "mqtt": "^5.10.1",
+        "mqtt": "^5.15.1",
         "qrcode": "^1.4.1",
         "yaml": "^1.6.0"
       },
@@ -32,9 +32,6 @@
       "engines": {
         "homebridge": "^1.8.0 || ^2.0.0-beta.0",
         "node": "^20.18.0 || ^22.10.0 || ^24.0.0"
-      },
-      "optionalDependencies": {
-        "mqtt": "^5.15.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -483,7 +480,6 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1490,7 +1486,6 @@
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
@@ -1501,7 +1496,6 @@
       "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.23.tgz",
       "integrity": "sha512-wwXrtQvbMHxCbBgjHaMGEmImFTQxxpfMOR/ZoQnXxB1woqkUbdLGFDgauo00Py9IudiaqSeiBiulSV9i6XIPig==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -1518,7 +1512,6 @@
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -1821,7 +1814,6 @@
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -2077,8 +2069,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.25",
@@ -2098,7 +2089,6 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-6.1.6.tgz",
       "integrity": "sha512-jLsPgN/YSvPUg9UX0Kd73CXpm2Psg9FxMeCSXnk3WBO3CMT10JMwijubhGfHCnFu6TPn1ei3b975dxv7K2pWVg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@types/readable-stream": "^4.0.0",
         "buffer": "^6.0.3",
@@ -2122,7 +2112,6 @@
       "resolved": "https://registry.npmjs.org/broker-factory/-/broker-factory-3.1.15.tgz",
       "integrity": "sha512-ko+aWvgNuP49meGrdjUu7rC+Y+Wai3cCPxP3xWwHsHfehFjOh5ZQM2yC4gEB2UddeZ/YXhm0K1eG/L6fxym2Og==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.29.7",
         "fast-unique-numbers": "^9.0.27",
@@ -2193,7 +2182,6 @@
         }
       ],
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -2203,7 +2191,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/callsites": {
@@ -2414,8 +2401,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/commist/-/commist-3.2.0.tgz",
       "integrity": "sha512-4PIMoPniho+LqXmpS5d3NuGYncG6XWlkBSVGiWycL22dd42OYdUGil2CWuzklaJoNxyxUSpO4MKIBU94viWNAw==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2432,7 +2418,6 @@
         "node >= 6.0"
       ],
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -2445,7 +2430,6 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -2790,7 +2774,6 @@
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -2800,7 +2783,6 @@
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -2890,7 +2872,6 @@
       "resolved": "https://registry.npmjs.org/fast-unique-numbers/-/fast-unique-numbers-9.0.27.tgz",
       "integrity": "sha512-nDA9ADeINN8SA2u2wCtU+siWFTTDqQR37XvgPIDDmboWQeExz7X0mImxuaN+kJddliIqy2FpVRmnvRZ+j8i1/A==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.29.2",
         "tslib": "^2.8.1"
@@ -3149,8 +3130,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
       "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -3209,8 +3189,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "BSD-3-Clause",
-      "optional": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -3285,7 +3264,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/ip-address": {
@@ -3293,7 +3271,6 @@
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 12"
       }
@@ -4064,7 +4041,6 @@
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
       "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
       "license": "MIT",
-      "optional": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
@@ -4300,7 +4276,6 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "license": "MIT",
-      "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4332,7 +4307,6 @@
       "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-5.15.1.tgz",
       "integrity": "sha512-V1WnkGuJh3ec9QXzy5Iylw8OOBK+Xu1WhxcQ9mMpLThG+/JZIMV1PgLNRgIiqXhZnvnVLsuyxHl5A/3bHHbcAA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@types/readable-stream": "^4.0.21",
         "@types/ws": "^8.18.1",
@@ -4365,7 +4339,6 @@
       "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-9.0.2.tgz",
       "integrity": "sha512-MvIY0B8/qjq7bKxdN1eD+nrljoeaai+qjLJgfRn3TiMuz0pamsIWY2bFODPZMSNmabsLANXsLl4EMoWvlaTZWA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "bl": "^6.0.8",
         "debug": "^4.3.4",
@@ -4376,8 +4349,7 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -4459,7 +4431,6 @@
       "resolved": "https://registry.npmjs.org/number-allocator/-/number-allocator-1.0.14.tgz",
       "integrity": "sha512-OrL44UTVAvkKdOdRQZIJpLkAdjXGTRda052sN4sO77bKEzYYqWKMBjQvrJFzqygI99gL6Z4u2xctPW1tB8ErvA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "debug": "^4.3.1",
         "js-sdsl": "4.3.0"
@@ -4793,7 +4764,6 @@
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -4802,8 +4772,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -5020,7 +4989,6 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
       "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",
@@ -5084,8 +5052,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -5105,8 +5072,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/semaphore": {
       "version": "1.1.0",
@@ -5183,7 +5149,6 @@
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -5194,7 +5159,6 @@
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
       "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
@@ -5230,7 +5194,6 @@
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": ">= 10.x"
       }
@@ -5270,7 +5233,6 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -5526,8 +5488,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -5569,14 +5530,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/universalify": {
@@ -5668,8 +5627,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "9.0.1",
@@ -5747,7 +5705,6 @@
       "resolved": "https://registry.npmjs.org/worker-factory/-/worker-factory-7.0.50.tgz",
       "integrity": "sha512-hhwc0G+sFwM4qBuhJIUBn2p1Jf8v/FwmLUANBf/Q+Lt2uI8mfIZQhXaZQACodQD4R7Zp6cn/6702bIvNn2puJQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.29.7",
         "fast-unique-numbers": "^9.0.27",
@@ -5759,7 +5716,6 @@
       "resolved": "https://registry.npmjs.org/worker-timers/-/worker-timers-8.0.32.tgz",
       "integrity": "sha512-huEv5mB6xIqcadsZ8SuuFQH9Lg9Hq0h0xD9vAZZsLPNw0aLxoDWyjTALAUD3hAA4cuKbKaqrjbBcbEYClwSh3w==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.29.7",
         "tslib": "^2.8.1",
@@ -5772,7 +5728,6 @@
       "resolved": "https://registry.npmjs.org/worker-timers-broker/-/worker-timers-broker-8.0.17.tgz",
       "integrity": "sha512-avGDVB9AP5k5eCAP2AiT/nwCHGCNla7Z+nMZWXpmhbiSTry6A7VwEzlffTO34/5Eo55O+XLbWQu0bBW3uEO0UA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.29.7",
         "broker-factory": "^3.1.15",
@@ -5786,7 +5741,6 @@
       "resolved": "https://registry.npmjs.org/worker-timers-worker/-/worker-timers-worker-9.0.15.tgz",
       "integrity": "sha512-KKUe7lZ/Aignr51H6hOUik8LwTnIgojH/1lwhli8A8qIEIyewogZTpNpMW5B6BF7nmwBOkUoTYgf1H3QShcjSA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.29.7",
         "tslib": "^2.8.1",

--- a/package.json
+++ b/package.json
@@ -29,11 +29,9 @@
     "fs-extra": "^8.1.0",
     "http-mitm-proxy": "^1.1.0",
     "json5": "^2.2.0",
+    "mqtt": "^5.15.1",
     "qrcode": "^1.4.1",
     "yaml": "^1.6.0"
-  },
-  "optionalDependencies": {
-    "mqtt": "^5.15.1"
   },
   "keywords": [
     "homebridge-plugin",

--- a/test/TuyaCloudMessaging.test.js
+++ b/test/TuyaCloudMessaging.test.js
@@ -110,9 +110,4 @@ describe('TuyaCloudMessaging — decryption + dispatch', () => {
         mq.subscribeDevice('DEV1', () => { throw new Error('should not be called'); });
         expect(() => mq._onMessage('topic', Buffer.from('not json'))).not.toThrow();
     });
-
-    test('reports whether realtime is available (mqtt installed)', () => {
-        // mqtt is an (optional) dependency of this project, so it should load.
-        expect(typeof TuyaCloudMessaging.isAvailable()).toBe('boolean');
-    });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -97,12 +97,6 @@ describe('TuyaLan — cloud session setup', () => {
         expect(TuyaCloudApi.mock.calls[0][0]).toMatchObject({accessId: 'aid', accessKey: 'akey', region: 'eu'});
         expect(TuyaCloudMessaging).toHaveBeenCalledTimes(1);
     });
-
-    test('realtime:false skips the MQTT session', () => {
-        run({cloud: {...CLOUD, realtime: false}, devices: [SW()]});
-        expect(TuyaCloudApi).toHaveBeenCalledTimes(1);
-        expect(TuyaCloudMessaging).not.toHaveBeenCalled();
-    });
 });
 
 describe('TuyaLan — cloud participation', () => {

--- a/wiki/Tuya-Cloud-Setup.md
+++ b/wiki/Tuya-Cloud-Setup.md
@@ -20,12 +20,23 @@ It helps in two situations:
 
 ## 2. Authorize the required API services
 
+There are two types of projects: `Custom` and `Smart Home`. The difference between them is:
+
+* The `Custom` project pulls devices from the project's assets.
+* The `Smart Home` project pulls devices from the user's home in the Tuya app.
+
+If you are a personal user and are unsure which one to choose, please use the Smart Home project.
+
 In the project, go to **Service API → Go to Authorize** and make sure these are subscribed (all free):
 
-* **IoT Core**
-* **Authorization**
-* **Smart Home Basic Service**
-* **Device Status Notification** ← needed for realtime MQTT updates
+* Authorization Token Management
+* Device Status Notification
+* IoT Core
+* IoT Video Live Stream (for cameras)
+* Industry Project Client Service (for the `Custom` project)
+* IR Control Hub Open Service (for IR devices)
+* Smart Home Scene Linkage (for scenes)
+* Smart Lock Open Service (for Lock devices)
 
 > **⚠️Remember to extend the API trial period every 6 months here: [Tuya IoT Platform > Cloud > Cloud Services > IoT Core](https://iot.tuya.com/cloud/products/detail?abilityId=1442730014117204014&id=p1668587814138nv4h3n&abilityAuth=0&tab=1) (the first-time subscription only gives you 1 month).**
 


### PR DESCRIPTION
Remove the per-cloud "realtime" switch and always run the shared MQTT
session whenever a cloud block is configured. Promote `mqtt` from an
optional to a required dependency and load it directly.
