### PR TITLE
Quiet noisy logging: demote routine chatter to debug, align levels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,29 @@ When adding or changing a device type, follow the existing pattern:
   `no-prototype-builtins`) as tech debt; don't rely on or expand that. Keep new
   code clean.
 
+## Logging
+
+Users run this in Homebridge and read these logs; a chatty plugin is a real
+complaint. The bar for a non-debug line is high.
+
+- **`debug` is the default.** Anything routine, per-message, per-state-change,
+  per-connect, or protocol-level (odd/raw/malformed frames, reconnects, socket
+  recycling, DP dumps, "X changed: …") goes to `this.log.debug`. If it can fire
+  more than a handful of times in normal operation, it's `debug`.
+- **`info`/`warn`/`error` are for what the user must see or act on**, and the
+  level must match real severity — a harmless condition (e.g. a cloud-fallback
+  failure while the device is reachable over the LAN) is not a `warn`/`error`.
+  Prefer one actionable line over a vague one; name the device.
+- **Never spam.** A condition that recurs on a timer or hot path must be
+  deduplicated (surface once, then drop repeats to `debug` until it changes) and
+  its retry backed off — see `TuyaCloudDevice._onConnectFailure` and the
+  discovery port-in-use guard for the pattern.
+- **Use the Homebridge logger** (`this.log` / `this.log.debug|info|warn|error`),
+  never `console.*`, in plugin/runtime code. (The standalone `bin/` CLIs are the
+  exception: their `console.*` is intentional user-facing output.)
+- **Logging must never throw and must never leak secrets** — don't dump a whole
+  config/props object (it carries the device's local `key`); log the id/name.
+
 ## Backwards compatibility (read before changing behavior)
 
 This is the most important rule in this repo. Users have working setups and

--- a/index.js
+++ b/index.js
@@ -413,7 +413,10 @@ class TuyaLan {
           )
             return;
 
-          this.log.info(
+          // Each cached accessory starts faulted ("No Response") until its
+          // device connects — expected, and once per accessory at startup, so
+          // it belongs at debug rather than as a wall of cryptic info lines.
+          this.log.debug(
             'Marked %s unreachable by faulting Service.%s.%s',
             accessory.displayName,
             service.displayName,

--- a/lib/AirPurifierAccessory.js
+++ b/lib/AirPurifierAccessory.js
@@ -80,7 +80,7 @@ class AirPurifierAccessory extends BaseAccessory {
     _addAirQualityService() {
         const {Service} = this.hap;
         const nameAirQuality = this.device.context.nameAirQuality || 'Air Quality';
-        this.log.info('Adding air quality sensor: %s', nameAirQuality);
+        this.log.debug('Adding air quality sensor: %s', nameAirQuality);
         this.accessory.addService(Service.AirQualitySensor, nameAirQuality);
     }
 

--- a/lib/BaseAccessory.js
+++ b/lib/BaseAccessory.js
@@ -204,7 +204,7 @@ class BaseAccessory {
         this.colorFunction = this.device.context.colorFunction && {HSB: 'HSB', HEXHSB: 'HEXHSB'}[this.device.context.colorFunction.toUpperCase()];
         if (!this.colorFunction && value) {
             this.colorFunction = {12: 'HSB', 14: 'HEXHSB'}[value.length] || 'Unknown';
-            if (this.colorFunction) this.log.info(`Color format for ${this.device.context.name} (${this.device.context.version}) identified as ${this.colorFunction} (length: ${value.length}).`);
+            if (this.colorFunction) this.log.debug(`Color format for ${this.device.context.name} (${this.device.context.version}) identified as ${this.colorFunction} (length: ${value.length}).`);
         }
         if (!this.colorFunction) {
             this.colorFunction = 'Unknown';

--- a/lib/DoorbellAccessory.js
+++ b/lib/DoorbellAccessory.js
@@ -11,7 +11,8 @@ const LOCK_TIMEOUT = 5000;
 
 class DoorbellDelegate /*extends CameraStreamingDelegate*/ {
 
-    constructor() {
+    constructor(log) {
+        this.log = log || console;
         this.cameraImage = undefined;
     }
 
@@ -27,7 +28,7 @@ class DoorbellDelegate /*extends CameraStreamingDelegate*/ {
                 var body=Buffer.alloc(0);
 
                 if (res.statusCode!==200) {
-                    return console.error('HTTP '+res.statusCode);
+                    return me.log.error('Doorbell image fetch failed: HTTP %s', res.statusCode);
                 }
 
                 res.on('data', function(chunk) {
@@ -36,13 +37,12 @@ class DoorbellDelegate /*extends CameraStreamingDelegate*/ {
 
                 res.on('end', function() {
                     me.setCameraImage(body);
-                    console.log("Image stored");
+                    me.log.debug('Doorbell image stored.');
                     callback();
-                    console.log("Callback after image store complete");
                 });
 
                 res.on('error', function(err) {
-                    console.error(err);
+                    me.log.error('Doorbell image fetch error:', err);
                 });
             }
         );
@@ -96,12 +96,9 @@ class DoorbellAccessory extends BaseAccessory {
 
 
         this.device.on('change', (changes, state) => {
-            //console.log(`Changes: ${JSON.stringify(changes)}, State: ${JSON.stringify(state)}`);
-
             if (changes.hasOwnProperty(DP_DOORBELL)) {
                 const urlBase64 = changes[DP_DOORBELL];
                 const strUrl = Buffer.from(urlBase64, 'base64');
-                //console.log(`Image URL: ${strUrl}`);
 
                 this.streamingDelegate.storeImage(strUrl.toString(), () => {
                   service.updateCharacteristic(Characteristic.ProgrammableSwitchEvent, Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS);
@@ -109,18 +106,18 @@ class DoorbellAccessory extends BaseAccessory {
             }
 
             if (changes.hasOwnProperty(DP_DOOR)) {
-                console.log("Door button pressed");
+                this.log.debug('Door button pressed');
             }
 
             if (changes.hasOwnProperty(DP_GATE)) {
-                console.log("Gate button pressed");
+                this.log.debug('Gate button pressed');
             }
         });
     }
 
     configureCamera() {
-        this.streamingDelegate = new DoorbellDelegate();
-        console.log("created streaming delegate");
+        this.streamingDelegate = new DoorbellDelegate(this.log);
+        this.log.debug('Created camera streaming delegate.');
         const options = {
           cameraStreamCount: 1, 
           delegate: this.streamingDelegate,
@@ -157,12 +154,8 @@ class DoorbellAccessory extends BaseAccessory {
           },
         };
     
-        //console.log("created options");
         const cameraController = new this.hap.CameraController(options);
-        //console.log("created controller");
-    
         this.accessory.configureController(cameraController);
-        //console.log("configured controller with accessory");
     }
 
     pushDoor(callback) {

--- a/lib/GarageDoorAccessory.js
+++ b/lib/GarageDoorAccessory.js
@@ -105,7 +105,7 @@ class GarageDoorAccessory extends BaseAccessory {
             .onGet(() => this.getCurrentDoorState());
 
         this.device.on('change', changes => {
-            this._alwaysLog('changed:' + JSON.stringify(changes));
+            this._debugLog('changed:' + JSON.stringify(changes));
 
             if (changes.hasOwnProperty(this.dpStatus)) {
                 const newCurrentDoorState = this._getCurrentDoorState(changes[this.dpStatus]);

--- a/lib/IrrigationSystemAccessory.js
+++ b/lib/IrrigationSystemAccessory.js
@@ -161,7 +161,7 @@ class IrrigationSystemAccessory extends BaseAccessory {
         this.accessory.services
             .filter(service => service.UUID === Service.Valve.UUID && !validValveSubtypes.includes(service.subtype))
             .forEach(service => {
-                this.log.info('Removing stale valve service %s', service.displayName);
+                this.log.debug('Removing stale valve service %s', service.displayName);
                 this.accessory.removeService(service);
             });
 
@@ -178,7 +178,7 @@ class IrrigationSystemAccessory extends BaseAccessory {
         [Service.ContactSensor, Service.LeakSensor].forEach(S => {
             const svc = this.accessory.getService(S);
             if (svc) {
-                this.log.info('Removing rain sensor service %s (no longer supported)', svc.displayName);
+                this.log.debug('Removing rain sensor service %s (no longer supported)', svc.displayName);
                 this.accessory.removeService(svc);
             }
         });

--- a/lib/MultiOutletAccessory.js
+++ b/lib/MultiOutletAccessory.js
@@ -34,7 +34,7 @@ class MultiOutletAccessory extends BaseAccessory {
         this.accessory.services
             .filter(service => service.UUID === Service.Outlet.UUID && !_validServices.includes(service))
             .forEach(service => {
-                this.log.info('Removing', service.displayName);
+                this.log.debug('Removing', service.displayName);
                 this.accessory.removeService(service);
             });
     }

--- a/lib/SimpleHeaterAccessory.js
+++ b/lib/SimpleHeaterAccessory.js
@@ -90,7 +90,7 @@ class SimpleHeaterAccessory extends BaseAccessory {
                 characteristicCurrentTemperature.updateValue(this._getDividedState(changes[this.dpCurrentTemperature], this.temperatureDivisor, this.currentTemperatureOffset));
 
             characteristicCurrentHeaterCoolerState.updateValue(this._getCurrentHeaterCoolerState(state));
-            this.log.info('SimpleHeater changed: ' + JSON.stringify(state));
+            this.log.debug('SimpleHeater changed: ' + JSON.stringify(state));
         });
     }
 

--- a/lib/SimpleLightAccessory.js
+++ b/lib/SimpleLightAccessory.js
@@ -31,7 +31,7 @@ class SimpleLightAccessory extends BaseAccessory {
 
         this.device.on('change', (changes, state) => {
             if (changes.hasOwnProperty(this.dpPower) && characteristicOn.value !== changes[this.dpPower]) characteristicOn.updateValue(changes[this.dpPower]);
-            this.log.info('SimpleLight changed: ' + JSON.stringify(state));
+            this.log.debug('SimpleLight changed: ' + JSON.stringify(state));
         });
     }
 }

--- a/lib/SwitchAccessory.js
+++ b/lib/SwitchAccessory.js
@@ -34,7 +34,7 @@ class SwitchAccessory extends BaseAccessory {
         this.accessory.services
             .filter(service => service.UUID === Service.Switch.UUID && !_validServices.includes(service))
             .forEach(service => {
-                this.log.info('Removing', service.displayName);
+                this.log.debug('Removing', service.displayName);
                 this.accessory.removeService(service);
             });
     }

--- a/lib/TuyaAccessory.js
+++ b/lib/TuyaAccessory.js
@@ -13,7 +13,13 @@ class TuyaAccessory extends EventEmitter {
     constructor(props) {
         super();
 
-        if (!(props.id && props.key && props.ip) && !props.fake) return this.log.info('Insufficient details to initialize:', props);
+        if (!(props.id && props.key && props.ip) && !props.fake) {
+            // `this.log` isn't assigned yet, and `props` carries the device's
+            // local key — log via props.log and name only the id (never dump the
+            // whole config, which leaks the key into logs/bug reports).
+            if (props.log) props.log.warn('Insufficient details to initialize device %s (need id, key and ip).', props.id || '(unknown id)');
+            return;
+        }
 
         this.log = props.log;
 
@@ -53,7 +59,6 @@ class TuyaAccessory extends EventEmitter {
 
         if (this._protocolVersion >= 3.2) {
             this.context.pingGap = Math.min(this.context.pingGap || 9, 9);
-            //this.log.info(`Changing ping gap for ${this.context.name} to ${this.context.pingGap}s`);
         }
 
         this.connected = false;
@@ -80,7 +85,6 @@ class TuyaAccessory extends EventEmitter {
         this._incrementAttemptCounter();
 
         (this._socket.reconnect = () => {
-            //this.log.debug(`reconnect called for ${this.context.name}`);
             if (this._socket._pinger) {
                 clearTimeout(this._socket._pinger);
                 this._socket._pinger = null;
@@ -196,7 +200,11 @@ class TuyaAccessory extends EventEmitter {
 
         this._socket.on('error', err => {
             this.connected = false;
-            this.log.info(`Socket had a problem and will reconnect to ${this.context.name} (${err && err.code || err})`);
+            // Routine: many Tuya devices recycle their LAN socket every few
+            // minutes, and a transient ECONNRESET/EPIPE reconnects silently.
+            // Keep the churn at debug; a genuine outage surfaces as HomeKit
+            // "No Response" (and via the cloud-fallback warnings).
+            this.log.debug(`Socket had a problem and will reconnect to ${this.context.name} (${err && err.code || err})`);
 
             if (err && (err.code === 'ECONNRESET' || err.code === 'EPIPE') && this._connectionAttempts < 10) {
                 this.log.debug(`Reconnecting with connection attempts =  ${this._connectionAttempts}`);
@@ -209,10 +217,10 @@ class TuyaAccessory extends EventEmitter {
             if (err) {
                 if (err.code === 'ENOBUFS') {
                     this.log.warn('Operating system complained of resource exhaustion; did I open too many sockets?');
-                    this.log.info('Slowing down retry attempts; if you see this happening often, it could mean some sort of incompatibility.');
+                    this.log.debug('Slowing down retry attempts; if you see this happening often, it could mean some sort of incompatibility.');
                     delay = 60000;
                 } else if (this._connectionAttempts > 10) {
-                    this.log.info('Slowing down retry attempts; if you see this happening often, it could mean some sort of incompatibility.');
+                    this.log.debug('Slowing down retry attempts; if you see this happening often, it could mean some sort of incompatibility.');
                     delay = 60000;
                 }
             }
@@ -240,14 +248,15 @@ class TuyaAccessory extends EventEmitter {
                 clearTimeout(this._socket._pinger);
                 this._socket._pinger = null;
             }
-
-            //this.log.info('Closed connection with', this.context.name);
         });
 
         this._socket.on('end', () => {
             this.connected = false;
             this.session_key = null;
-            this.log.info('Disconnected from', this.context.name);
+            // Routine for devices that recycle their socket; we reconnect
+            // promptly below, so keep it at debug rather than announcing a
+            // disconnect every few minutes.
+            this.log.debug('Disconnected from', this.context.name);
 
             // The device closed the connection on its own. This is routine for
             // many Tuya devices (e.g. LED ceiling lights) that recycle their
@@ -300,7 +309,7 @@ class TuyaAccessory extends EventEmitter {
         let data = task.msg.slice(len - size, len - 8).toString('utf8').trim().replace(/\0/g, '');
 
         if (this.context.intro === false && cmd !== 9)
-            this.log.info('Message from', this.context.name + ':', data);
+            this.log.debug('Message from', this.context.name + ':', data);
 
         switch (cmd) {
             case 7:
@@ -334,7 +343,6 @@ class TuyaAccessory extends EventEmitter {
                 }
 
                 if (data && data.dps) {
-                    //this.log.info('Update from', this.context.name, 'with command', cmd + ':', data.dps);
                     this._change(data.dps);
                 }
                 break;
@@ -343,7 +351,7 @@ class TuyaAccessory extends EventEmitter {
             case 10:
                 if (data) {
                     if (data === 'json obj data unvalid') {
-                        this.log.info(`${this.context.name} (${this.context.version}) didn't respond with its current state.`);
+                        this.log.debug(`${this.context.name} (${this.context.version}) didn't respond with its current state.`);
                         this.emit('change', {}, this.state);
                         break;
                     }
@@ -407,7 +415,7 @@ class TuyaAccessory extends EventEmitter {
         }
 
         if (cmd === 10 && decryptedMsg === 'json obj data unvalid') {
-            this.log.info(`${this.context.name} (${this.context.version}) didn't respond with its current state.`);
+            this.log.debug(`${this.context.name} (${this.context.version}) didn't respond with its current state.`);
             this.emit('change', {}, this.state);
             return callback();
         }
@@ -426,7 +434,6 @@ class TuyaAccessory extends EventEmitter {
             case 10:
                 if (data) {
                     if (data.dps) {
-                        //this.log.info(`Heard back from ${this.context.name} with command ${cmd}`);
                         this._change(data.dps);
                     } else {
                         this.log.debug(`Malformed message from ${this.context.name} with command ${cmd}:`, decryptedMsg);
@@ -536,7 +543,7 @@ class TuyaAccessory extends EventEmitter {
         }
 
         if (cmd === 10 && parsedPayload === 'json obj data unvalid') {
-            this.log.info(`${this.context.name} (${this.context.version}) didn't respond with its current state.`);
+            this.log.debug(`${this.context.name} (${this.context.version}) didn't respond with its current state.`);
             this.emit('change', {}, this.state);
             return callback();
         }
@@ -547,7 +554,6 @@ class TuyaAccessory extends EventEmitter {
             case 16:
                 if (parsedPayload) {
                     if (parsedPayload.dps) {
-                        //this.log.info(`Heard back from ${this.context.name} with command ${cmd}`);
                         this._change(parsedPayload.dps);
                     } else {
                         this.log.debug(`Malformed message from ${this.context.name} with command ${cmd}:`, decryptedMsg);
@@ -602,7 +608,7 @@ class TuyaAccessory extends EventEmitter {
             decipher.setAuthTag(tag);
             decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
         } catch(ex) {
-            this.log.info(`Failed to decrypt message from ${this.context.name} (${this.context.version}) with command ${cmd}:`, ex);
+            this.log.debug(`Failed to decrypt message from ${this.context.name} (${this.context.version}) with command ${cmd}:`, ex);
             return callback();
         }
 
@@ -662,7 +668,7 @@ class TuyaAccessory extends EventEmitter {
         }
 
         if (cmd === 10 && parsedPayload === 'json obj data unvalid') {
-            this.log.info(`${this.context.name} (${this.context.version}) didn't respond with its current state.`);
+            this.log.debug(`${this.context.name} (${this.context.version}) didn't respond with its current state.`);
             this.emit('change', {}, this.state);
             return callback();
         }
@@ -701,7 +707,6 @@ class TuyaAccessory extends EventEmitter {
 
         let result = false;
         if (hasDataPoint) {
-            //this.log.info(" Sending", this.context.name, JSON.stringify(dps));
             const t = (Date.now() / 1000).toFixed(0);
             const payload = {
                 devId: this.context.id,
@@ -724,13 +729,14 @@ class TuyaAccessory extends EventEmitter {
                 data,
                 cmd: this._protocolVersion >= 3.4 ? 13 : 7
             });
-            if (result !== true) this.log.info(" Result", result);
+            // A non-true result here is the socket reporting backpressure (or a
+            // closed connection), not necessarily a dropped command; callers that
+            // care already check the boolean. Keep it as a debug breadcrumb.
+            if (result !== true) this.log.debug(`${this.context.name}: socket write returned ${JSON.stringify(result)}.`);
             if (this.context.sendEmptyUpdate) {
-                //this.log.info(" Sending", this.context.name, 'empty signature');
                 this._send({cmd: this._protocolVersion >= 3.4 ? 13 : 7});
             }
         } else {
-            //this.log.info(`Sending first query to ${this.context.name} (${this.context.version})`);
             result = this._send({
                 data: {
                     gwId: this.context.id,
@@ -962,7 +968,7 @@ class TuyaAccessory extends EventEmitter {
     }
 
     _fakeUpdate(dps) {
-        this.log.info('Fake update:', JSON.stringify(dps));
+        this.log.debug('Fake update:', JSON.stringify(dps));
         Object.keys(dps).forEach(dp => {
             this.state[dp] = dps[dp];
         });

--- a/lib/TuyaDiscovery.js
+++ b/lib/TuyaDiscovery.js
@@ -19,6 +19,7 @@ class TuyaDiscovery extends EventEmitter {
         this.limitedIds = [];
         this._servers = {};
         this._running = false;
+        this._portInUseWarned = {}; // ports already warned as in-use, so repeats stay at debug
     }
 
     start(props) {
@@ -85,7 +86,8 @@ class TuyaDiscovery extends EventEmitter {
         server.on('message', this._onDgramMessage.bind(this, port));
 
         server.bind(port, () => {
-            this.log.info(`Discovery - Discovery started on port ${port}.`);
+            this._portInUseWarned[port] = false; // a successful bind re-arms the in-use warning
+            this.log.debug(`Discovery started on port ${port}.`);
         });
     }
 
@@ -101,20 +103,30 @@ class TuyaDiscovery extends EventEmitter {
         this._stop(port);
 
         if (err && err.code === 'EADDRINUSE') {
-            this.log.warn(`Discovery - Port ${port} is in use. Will retry in 15 seconds.`);
+            // The retry runs every 15s for as long as the port stays taken (usually
+            // another Tuya plugin or a second instance). Warn once so it's
+            // actionable, then drop to debug so a persistent conflict doesn't flood
+            // the log; a later successful bind re-arms the warning.
+            const message = `Port ${port} is in use (is another Tuya plugin or instance running?). Will retry in 15 seconds.`;
+            if (this._portInUseWarned[port]) {
+                this.log.debug(`Discovery - ${message}`);
+            } else {
+                this.log.warn(`Discovery - ${message}`);
+                this._portInUseWarned[port] = true;
+            }
 
             setTimeout(() => {
                 this._start(port);
             }, 15000);
         } else {
-            this.log.error(`Discovery - Port ${port} failed:\n${err.stack}`);
+            this.log.error(`Discovery - Port ${port} failed:\n${err && err.stack || err}`);
         }
     }
 
     _onDgramClose(port) {
         this._stop(port);
 
-        this.log.info(`Discovery - Port ${port} closed.${this._running ? ' Restarting...' : ''}`);
+        this.log.debug(`Discovery - Port ${port} closed.${this._running ? ' Restarting...' : ''}`);
         if (this._running)
             setTimeout(() => {
                 this._start(port);
@@ -152,7 +164,7 @@ class TuyaDiscovery extends EventEmitter {
         const size = pkt.readUInt32BE(12);
 
         if (len - size < 8) {
-            this.log.error(`Discovery - UDP from ${info.address}:${port} size ${len - size}`);
+            this.log.debug(`Discovery - undersized UDP packet from ${info.address}:${port} (ignored).`);
             return;
         }
 
@@ -174,11 +186,14 @@ class TuyaDiscovery extends EventEmitter {
             if (result && result.gwId && result.ip) {
                 this._onDiscover(result);
             } else {
-                this.log.error(`Discovery - UDP from ${info.address}:${port} decrypted`, cleanMsg.toString('hex'));
+                this.log.debug(`Discovery - unrecognised UDP payload from ${info.address}:${port} (ignored):`, cleanMsg.toString('hex'));
             }
         } catch (ex) {
-            this.log.error(`Discovery - Failed to parse discovery response on port ${port}: ${decryptedMsg}`);
-            this.log.error(`Discovery - Failed to parse discovery raw message on port ${port}: ${pkt.toString('hex')}`);
+            // Not every Tuya-framed packet on these ports is a discovery reply we
+            // can parse (other broadcast types, foreign accounts, partial packets);
+            // none of it is an error worth surfacing.
+            this.log.debug(`Discovery - could not parse discovery response on port ${port}: ${decryptedMsg}`);
+            this.log.debug(`Discovery - raw unparsed message on port ${port}: ${pkt.toString('hex')}`);
         }
     }
 
@@ -230,7 +245,8 @@ class TuyaDiscovery extends EventEmitter {
                 this._onDiscover(payload);
             }
         } catch (ex) {
-            this.log.error(
+            // Foreign or partial packets on the v3.5 reply port are expected noise.
+            this.log.debug(
                 `Discovery v3.5 – failed to decrypt packet from ${info.address}:${srcPort}:`,
                 ex.message
             );

--- a/lib/VerticalBlindsWithTilt.js
+++ b/lib/VerticalBlindsWithTilt.js
@@ -67,10 +67,10 @@ class VerticalBlindsWithTilt extends BaseAccessory {
 
     _getInitialPosition(dps) {
         if (this.accessory.context.cachedPosition !== undefined) {
-            this.log('[TuyaAccessory] Restored position from cache:', this.accessory.context.cachedPosition + '%');
+            this.log.debug('[TuyaAccessory] Restored position from cache:', this.accessory.context.cachedPosition + '%');
             return this.accessory.context.cachedPosition;
         }
-        this.log('[TuyaAccessory] Initial position unknown (first time setup), defaulting to open (100%)');
+        this.log.debug('[TuyaAccessory] Initial position unknown (first time setup), defaulting to open (100%)');
         return 100;
     }
 
@@ -80,21 +80,21 @@ class VerticalBlindsWithTilt extends BaseAccessory {
 
         if (value === 0) {
             if (this.currentPosition === 0) {
-                this.log('[TuyaAccessory] Blinds already closed, skipping close command');
+                this.log.debug('[TuyaAccessory] Blinds already closed, skipping close command');
                 return;
             }
 
-            this.log('[TuyaAccessory] Closing blinds');
+            this.log.debug('[TuyaAccessory] Closing blinds');
             this.lastCloseTime = Date.now();
             this.isMoving = true;
 
             if (this.lastTiltCommand && (Date.now() - this.lastTiltCommand.time < this.timeToClose * 1000)) {
-                this.log('[TuyaAccessory] Close command received while tilt was pending - rescheduling tilt delay');
+                this.log.debug('[TuyaAccessory] Close command received while tilt was pending - rescheduling tilt delay');
                 if (this.tiltBufferTimeout) { clearTimeout(this.tiltBufferTimeout); this.tiltBufferTimeout = null; }
                 if (this.tiltDelayTimeout) clearTimeout(this.tiltDelayTimeout);
                 const delayMs = this.timeToClose * 1000;
                 this.tiltDelayTimeout = setTimeout(() => {
-                    this.log('[TuyaAccessory] Executing delayed tilt angle:', this.lastTiltCommand.angle, '-> Tuya percent_control:', this.lastTiltCommand.value);
+                    this.log.debug('[TuyaAccessory] Executing delayed tilt angle:', this.lastTiltCommand.angle, '-> Tuya percent_control:', this.lastTiltCommand.value);
                     this._executeTilt(this.lastTiltCommand.value);
                     this.tiltDelayTimeout = null;
                     this.lastTiltCommand = null;
@@ -106,7 +106,7 @@ class VerticalBlindsWithTilt extends BaseAccessory {
 
             if (this.positionStateTimeout) clearTimeout(this.positionStateTimeout);
             this.positionStateTimeout = setTimeout(() => {
-                this.log('[TuyaAccessory] Blinds finished closing');
+                this.log.debug('[TuyaAccessory] Blinds finished closing');
                 this.currentPosition = 0;
                 this.accessory.context.cachedPosition = 0;
                 this.characteristicCurrentPosition.updateValue(0);
@@ -120,19 +120,19 @@ class VerticalBlindsWithTilt extends BaseAccessory {
 
         } else if (value === 100) {
             if (this.currentPosition === 100) {
-                this.log('[TuyaAccessory] Blinds already open, skipping open command');
+                this.log.debug('[TuyaAccessory] Blinds already open, skipping open command');
                 return;
             }
 
-            this.log('[TuyaAccessory] Opening blinds');
+            this.log.debug('[TuyaAccessory] Opening blinds');
 
             if (this.lastTiltCommand && (Date.now() - this.lastTiltCommand.time < this.timeToClose * 1000)) {
-                this.log('[TuyaAccessory] Open command received while tilt was pending - rescheduling tilt delay');
+                this.log.debug('[TuyaAccessory] Open command received while tilt was pending - rescheduling tilt delay');
                 if (this.tiltBufferTimeout) { clearTimeout(this.tiltBufferTimeout); this.tiltBufferTimeout = null; }
                 if (this.tiltDelayTimeout) clearTimeout(this.tiltDelayTimeout);
                 const delayMs = this.timeToClose * 1000;
                 this.tiltDelayTimeout = setTimeout(() => {
-                    this.log('[TuyaAccessory] Executing delayed tilt angle:', this.lastTiltCommand.angle, '-> Tuya percent_control:', this.lastTiltCommand.value);
+                    this.log.debug('[TuyaAccessory] Executing delayed tilt angle:', this.lastTiltCommand.angle, '-> Tuya percent_control:', this.lastTiltCommand.value);
                     this._executeTilt(this.lastTiltCommand.value);
                     this.tiltDelayTimeout = null;
                     this.lastTiltCommand = null;
@@ -149,7 +149,7 @@ class VerticalBlindsWithTilt extends BaseAccessory {
 
             if (this.positionStateTimeout) clearTimeout(this.positionStateTimeout);
             this.positionStateTimeout = setTimeout(() => {
-                this.log('[TuyaAccessory] Blinds finished opening');
+                this.log.debug('[TuyaAccessory] Blinds finished opening');
                 this.currentPosition = 100;
                 this.accessory.context.cachedPosition = 100;
                 this.characteristicCurrentPosition.updateValue(100);
@@ -161,15 +161,15 @@ class VerticalBlindsWithTilt extends BaseAccessory {
             return this.setStateAsync(this.dpAction, 'open');
 
         } else {
-            this.log('[TuyaAccessory] Partial position requested, opening fully');
+            this.log.debug('[TuyaAccessory] Partial position requested, opening fully');
 
             if (this.lastTiltCommand && (Date.now() - this.lastTiltCommand.time < this.timeToClose * 1000)) {
-                this.log('[TuyaAccessory] Partial open command received while tilt was pending - rescheduling tilt delay');
+                this.log.debug('[TuyaAccessory] Partial open command received while tilt was pending - rescheduling tilt delay');
                 if (this.tiltBufferTimeout) { clearTimeout(this.tiltBufferTimeout); this.tiltBufferTimeout = null; }
                 if (this.tiltDelayTimeout) clearTimeout(this.tiltDelayTimeout);
                 const delayMs = this.timeToClose * 1000;
                 this.tiltDelayTimeout = setTimeout(() => {
-                    this.log('[TuyaAccessory] Executing delayed tilt angle:', this.lastTiltCommand.angle, '-> Tuya percent_control:', this.lastTiltCommand.value);
+                    this.log.debug('[TuyaAccessory] Executing delayed tilt angle:', this.lastTiltCommand.angle, '-> Tuya percent_control:', this.lastTiltCommand.value);
                     this._executeTilt(this.lastTiltCommand.value);
                     this.tiltDelayTimeout = null;
                     this.lastTiltCommand = null;
@@ -186,7 +186,7 @@ class VerticalBlindsWithTilt extends BaseAccessory {
 
             if (this.positionStateTimeout) clearTimeout(this.positionStateTimeout);
             this.positionStateTimeout = setTimeout(() => {
-                this.log('[TuyaAccessory] Blinds finished opening');
+                this.log.debug('[TuyaAccessory] Blinds finished opening');
                 this.currentPosition = 100;
                 this.accessory.context.cachedPosition = 100;
                 this.characteristicCurrentPosition.updateValue(100);
@@ -223,12 +223,12 @@ class VerticalBlindsWithTilt extends BaseAccessory {
                 ? (this.timeToClose * 1000) - timeSinceClose
                 : (this.timeToClose * 1000) - timeSinceOpen;
             const action = shouldDelayForClose ? 'close' : 'open';
-            this.log('[TuyaAccessory] Tilt command received during', action, '- delaying by', Math.round(delayMs / 1000), 'seconds');
+            this.log.debug('[TuyaAccessory] Tilt command received during', action, '- delaying by', Math.round(delayMs / 1000), 'seconds');
 
             this._cancelPendingTilts();
 
             this.tiltDelayTimeout = setTimeout(() => {
-                this.log('[TuyaAccessory] Executing delayed tilt angle:', value, '-> Tuya percent_control:', clampedValue);
+                this.log.debug('[TuyaAccessory] Executing delayed tilt angle:', value, '-> Tuya percent_control:', clampedValue);
                 this._executeTilt(clampedValue);
                 this.tiltDelayTimeout = null;
                 this.lastCloseTime = 0;
@@ -237,7 +237,7 @@ class VerticalBlindsWithTilt extends BaseAccessory {
             }, delayMs);
 
         } else {
-            this.log('[TuyaAccessory] Setting tilt angle:', value, '-> Tuya percent_control:', clampedValue);
+            this.log.debug('[TuyaAccessory] Setting tilt angle:', value, '-> Tuya percent_control:', clampedValue);
 
             if (this.tiltBufferTimeout) clearTimeout(this.tiltBufferTimeout);
 
@@ -258,7 +258,7 @@ class VerticalBlindsWithTilt extends BaseAccessory {
 
     _executeTilt(value) {
         if (!this.device.connected) {
-            this.log('[TuyaAccessory] Cannot execute tilt - device not connected');
+            this.log.debug('[TuyaAccessory] Cannot execute tilt - device not connected');
             return;
         }
         this.device.update({[this.dpTilt]: value});
@@ -268,12 +268,12 @@ class VerticalBlindsWithTilt extends BaseAccessory {
         if (this.tiltBufferTimeout) {
             clearTimeout(this.tiltBufferTimeout);
             this.tiltBufferTimeout = null;
-            this.log('[TuyaAccessory] Cleared pending tilt buffer');
+            this.log.debug('[TuyaAccessory] Cleared pending tilt buffer');
         }
         if (this.tiltDelayTimeout) {
             clearTimeout(this.tiltDelayTimeout);
             this.tiltDelayTimeout = null;
-            this.log('[TuyaAccessory] Cleared pending tilt delay');
+            this.log.debug('[TuyaAccessory] Cleared pending tilt delay');
         }
     }
 

--- a/test/TuyaAccessory.protocol.test.js
+++ b/test/TuyaAccessory.protocol.test.js
@@ -607,9 +607,10 @@ describe('graceful disconnect handling', () => {
         jest.advanceTimersByTime(1000);
         expect(pingErrors).toHaveLength(0);
 
-        // The log reflects a clean disconnect, never a ping failure.
-        expect(device.log.info).toHaveBeenCalledWith('Disconnected from', device.context.name);
-        const logged = device.log.info.mock.calls.flat().join(' ');
+        // The log reflects a clean disconnect, never a ping failure. (A device
+        // recycling its socket is routine, so the disconnect is logged at debug.)
+        expect(device.log.debug).toHaveBeenCalledWith('Disconnected from', device.context.name);
+        const logged = device.log.debug.mock.calls.flat().join(' ');
         expect(logged).not.toMatch(/ERR_PING_TIMED_OUT/);
     });
 


### PR DESCRIPTION
## Why

The plugin logged far too much at `info`/`warn`/`error` during normal operation — every device update, reconnect, socket recycle, and blind/door action ended up in the user's Homebridge log. This continues the cleanup started in #74/#77 and applies one consistent rule throughout: **`debug` is the default; `info`/`warn`/`error` are reserved for what the user must see or act on, at a level matching real severity.**

The conventions are now written down in `AGENTS.md` so future changes hold the line.

## What changed

**LAN stack (`TuyaAccessory.js`)** — the worst offender. Many Tuya devices recycle their LAN socket every few minutes, so these fired at `info` constantly:
- `Disconnected from` / `Socket had a problem and will reconnect` → `debug`
- `…didn't respond with its current state` (×4 handlers), `Failed to decrypt message`, intro-mode `Message from`, `Slowing down retry attempts` → `debug`
- The cryptic `" Result"` log (actually TCP backpressure, not a failure) and `Fake update` → `debug`
- **Bug fix:** the "insufficient details to initialize" guard referenced `this.log` *before it was assigned* (a latent crash) **and dumped the whole config — including the device's local `key` — into the log**. It now logs via `props.log` at `warn`, naming only the id.

**Discovery (`TuyaDiscovery.js`):**
- Per-port start/close → `debug` (fixed the `Discovery - Discovery` double-word too)
- Foreign/partial UDP packets (other Tuya broadcasts, other accounts, partial frames) were logged at **`error`** — now `debug`, since they're routine LAN noise, not errors
- Port-in-use now **warns once, then drops to `debug`** instead of repeating every 15s forever

**Accessories:**
- Per-state-change dumps (`SimpleLight`/`SimpleHeater` "changed: {state}", GarageDoor "changed:") → `debug`
- **`VerticalBlindsWithTilt`** — all 22 per-operation traces (every open/close/tilt) were at `info` → `debug`
- `DoorbellAccessory` now logs through the Homebridge logger instead of `console.*` (which bypassed the plugin prefix and debug gating)
- Service-cleanup `Removing …` (`MultiOutlet`, `Switch`, `Irrigation`), `AirPurifier` "Adding air quality sensor", `BaseAccessory` "Color format identified", and `index.js` "Marked … unreachable" → `debug`

**Cleanup:** deleted all dead commented-out log statements (`//this.log…` / `//console.log…`) scattered through `TuyaAccessory` and `DoorbellAccessory`.

## Deliberately kept

One-time startup milestones (`Connected to X`, `Discovered X identified as`, `Starting discovery`, cloud session enabled) and genuine `warn`/`error` (duplicate-device config, missing key/cloud, unrecognized protocol, ENOBUFS, `UNKNOWN STATE`/`Unhandled value`) stay as-is. The `bin/` CLIs keep `console.*` — that's correct user-facing output for standalone tools, not plugin logging.

## Verification

`npm test` (365 passing) and `npm run lint` both green. One test assertion was updated (`'Disconnected from'` now asserted at `debug`; its intent — clean disconnect, not a ping failure — is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSc4hQcdYaqMUMv9y9jpHt)_