### PR TITLE
Reject invalid local keys instead of crashing into a boot loop

### DIFF
--- a/lib/TuyaAccessory.js
+++ b/lib/TuyaAccessory.js
@@ -48,6 +48,21 @@ class TuyaAccessory extends EventEmitter {
             this.log.info(`${this.context.name} reports protocol ${this.context.version}, newer than the newest known Tuya LAN protocol (3.5); using the 3.5 (GCM) stack with ${this.context.version} headers.`);
         }
 
+        // A Tuya local key is the AES-128 key used for every LAN frame and must be
+        // exactly 16 bytes. A wrong-length key (mistyped, truncated, or pasted with
+        // stray characters) makes crypto.createCipheriv throw "Invalid key length"
+        // the moment we first talk to the device. That throw originates inside a
+        // socket callback, so it goes unhandled and crashes Homebridge - which then
+        // restarts and crashes again: a boot loop. Refuse to bring the LAN backend
+        // up for such a device and say why; with a Tuya Cloud session configured it
+        // still works as a cloud-only device, and other devices are unaffected.
+        this._invalidKey = !this.context.fake && !TuyaAccessory.isValidLocalKey(this.context.key);
+        if (this._invalidKey && this.log) {
+            const key = this.context.key;
+            const keyLength = typeof key === 'string' ? Buffer.byteLength(key, 'utf8') : (Buffer.isBuffer(key) ? key.length : 0);
+            this.log.error(`${this.context.name} (${this.context.id}) has an invalid local key: a Tuya local key must be exactly 16 characters (this one has ${keyLength}). LAN control is disabled for this device until the key is corrected.`);
+        }
+
         this.state = {};
         this._cachedBuffer = Buffer.allocUnsafe(0);
 
@@ -72,7 +87,19 @@ class TuyaAccessory extends EventEmitter {
         this.session_key = null;
     }
 
+    // A Tuya local key is the AES-128 key for the LAN protocol, so it must be
+    // exactly 16 bytes (createCipheriv rejects any other length). Measure a
+    // string the way createCipheriv does - by its UTF-8 byte length - so a key
+    // that merely looks 16 characters long but isn't (e.g. a stray multibyte
+    // character) is still caught.
+    static isValidLocalKey(key) {
+        if (Buffer.isBuffer(key)) return key.length === 16;
+        if (typeof key === 'string') return Buffer.byteLength(key, 'utf8') === 16;
+        return false;
+    }
+
     _connect() {
+        if (this._invalidKey) return;
         if (this.context.fake) {
             this.connected = true;
             return setTimeout(() => {
@@ -767,6 +794,7 @@ class TuyaAccessory extends EventEmitter {
 
     _send(o) {
         if (this.context.fake) return;
+        if (this._invalidKey) return false;
         if (!this.connected) return false;
 
         if (this._protocolVersion < 3.2) return this._send_3_1(o);

--- a/test/TuyaAccessory.protocol.test.js
+++ b/test/TuyaAccessory.protocol.test.js
@@ -155,6 +155,78 @@ describe('protocol version normalization', () => {
     });
 });
 
+// A wrong-length local key made crypto.createCipheriv throw "Invalid key length"
+// from inside a socket callback (see _send_3_3), which goes unhandled and crashes
+// Homebridge into a restart loop. An out-of-spec key must be refused clearly,
+// up front, without ever reaching the cipher or taking the process down.
+describe('invalid local key handling', () => {
+    describe('isValidLocalKey', () => {
+        test.each([
+            ['0123456789abcdef', true],    // 16 ASCII chars
+            ['short', false],
+            ['0123456789abcdefXX', false], // 18 chars
+            ['', false],
+            ['012345678901234é', false],   // 16 chars but 17 UTF-8 bytes
+            [Buffer.alloc(16), true],
+            [Buffer.alloc(8), false],
+            [null, false],
+            [undefined, false],
+            [12345678901234567, false],    // not a string/Buffer
+        ])('isValidLocalKey(%p) === %p', (key, expected) => {
+            expect(TuyaAccessory.isValidLocalKey(key)).toBe(expected);
+        });
+    });
+
+    test('a wrong-length key is flagged and logged without throwing', () => {
+        let device;
+        expect(() => { device = makeDevice('3.3', {key: 'too-short'}); }).not.toThrow();
+        expect(device._invalidKey).toBe(true);
+        expect(device.log.error).toHaveBeenCalledWith(expect.stringContaining('16 characters'));
+        const logged = device.log.error.mock.calls.flat().join(' ');
+        expect(logged).toContain('Protocol Test Device');
+    });
+
+    test('a valid 16-character key is accepted and logs no error', () => {
+        const device = makeDevice('3.3');
+        expect(device._invalidKey).toBe(false);
+        expect(device.log.error).not.toHaveBeenCalled();
+    });
+
+    test('_connect() opens no socket for an invalid-key device', () => {
+        const device = makeDevice('3.5', {key: 'bad'});
+        device._connect();
+        expect(device._socket).toBeUndefined();
+        expect(device.connected).toBe(false);
+    });
+
+    // The exact path that used to crash: a connected device whose update() flows
+    // into _send -> _send_3_x -> createCipheriv. It must short-circuit to false.
+    test.each(['3.1', '3.3', '3.4', '3.5'])(
+        'update() never reaches the cipher for an invalid-key %s device, even when connected',
+        version => {
+            const device = makeDevice(version, {key: 'nope'});
+            const written = attachSocketStub(device); // also forces connected = true
+
+            let result;
+            expect(() => { result = device.update({1: true}); }).not.toThrow();
+            expect(result).toBe(false);
+            expect(written).toHaveLength(0);
+        }
+    );
+
+    test('a fake device without a key is never treated as invalid', () => {
+        const device = new TuyaAccessory({
+            id: 'bf1234567890abcdef12',
+            name: 'Fake Device',
+            fake: true,
+            connect: false,
+            log: makeLog(),
+        });
+        expect(device._invalidKey).toBe(false);
+        expect(device.log.error).not.toHaveBeenCalled();
+    });
+});
+
 describe('message handler routing', () => {
     const HANDLERS = ['_msgHandler_3_1', '_msgHandler_3_3', '_msgHandler_3_4', '_msgHandler_3_5'];
 


### PR DESCRIPTION
A local key that isn't exactly 16 bytes made crypto.createCipheriv throw
"Invalid key length" the first time we talked to the device. That throw
originated inside a socket callback, so it went unhandled and took the
whole Homebridge process down - which restarted and crashed again on the
same device: a boot loop.

Validate the key up front in the TuyaAccessory constructor. A device with
a wrong-length key is refused (no socket is opened, _send short-circuits)
with a clear, actionable error naming the device, so other devices keep
working and a configured Tuya Cloud session still drives it as a
cloud-only device.
