### PR TITLE
Refresh cloud device state after writes and via the shadow

### DIFF
--- a/lib/TuyaCloudDevice.js
+++ b/lib/TuyaCloudDevice.js
@@ -75,6 +75,7 @@ class TuyaCloudDevice extends EventEmitter {
         this._codeMethod = {};
         this._propertiesTried = new Set();
         this._announcedProperties = false;
+        this._catchupTimers = null; // post-write state re-reads (see _scheduleStateCatchup)
 
         // Bidirectional data-point maps, learned from the device's thing-shadow on
         // connect. They let this cloud transport (and the LAN+cloud TuyaDevice that
@@ -224,8 +225,11 @@ class TuyaCloudDevice extends EventEmitter {
                 this.connected = online;
                 this.log.info(`${this.context.name}: Tuya now reports the device ${online ? 'online' : 'offline'}.`);
             }
-            const status = await this.api.getStatus(this.context.id);
-            this._applyStatus(status);
+            // Read via the same shadow-preferred path as the initial connect, not
+            // the plain /status endpoint: a thing-model-only device (e.g. a custom
+            // gate controller) returns an EMPTY /status result, so /status would
+            // silently wipe nothing in and never reflect a state change.
+            this._applyStatus(await this._readInitialProperties());
         } catch (ex) {
             this.log.debug(`${this.context.name}: cloud state refresh failed: ${ex.message}`);
         }
@@ -382,6 +386,7 @@ class TuyaCloudDevice extends EventEmitter {
 
         if (byCommands.ok && byProperties.ok) {
             this._lastWriteError = null;
+            this._scheduleStateCatchup();
             return true;
         }
         this._reportWriteFailure(byCommands.error || byProperties.error);
@@ -416,6 +421,31 @@ class TuyaCloudDevice extends EventEmitter {
             this.log.info(`${this.context.name}: controlling some of this device's data-points over the Tuya thing-model property endpoint (they aren't in its standard instruction set).`);
         }
         return this._learn(fresh, 'properties');
+    }
+
+    // After a cloud write the resulting state (e.g. a gate's return_state flipping
+    // to "opening") shows up in the cloud within ~a second, but the realtime stream
+    // doesn't always carry it — and an accessory that mirrors a status DP (the
+    // garage door) would otherwise sit on the old value forever. So re-read the
+    // device a couple of times after a command to catch the transition. Each new
+    // command re-arms it, so a burst of writes only triggers one catch-up; it only
+    // runs on the cloud path, so a LAN-reachable device pays nothing.
+    _scheduleStateCatchup() {
+        if (this._catchupTimers) this._catchupTimers.forEach(t => clearTimeout(t));
+        this._catchupTimers = [2000, 8000].map(delay => {
+            const t = setTimeout(() => this._catchupOnce(), delay);
+            if (t && t.unref) t.unref();
+            return t;
+        });
+    }
+
+    async _catchupOnce() {
+        if (this._stopped) return;
+        try {
+            this._applyStatus(await this._readInitialProperties());
+        } catch (ex) {
+            this.log.debug(`${this.context.name}: post-write state catch-up failed: ${ex.message}`);
+        }
     }
 
     // Invoke one control endpoint; resolves to {ok, error} and never rejects, so a
@@ -505,6 +535,7 @@ class TuyaCloudDevice extends EventEmitter {
     stop() {
         this._stopped = true;
         if (this._retryTimer) { clearTimeout(this._retryTimer); this._retryTimer = null; }
+        if (this._catchupTimers) { this._catchupTimers.forEach(t => clearTimeout(t)); this._catchupTimers = null; }
     }
 }
 

--- a/lib/TuyaCloudMessaging.js
+++ b/lib/TuyaCloudMessaging.js
@@ -152,6 +152,12 @@ class TuyaCloudMessaging extends EventEmitter {
         if (!devId || !Array.isArray(status)) return;
 
         const handlers = this._handlers.get('' + devId);
+        // Trace what the realtime stream actually delivers (debug only). A device
+        // whose status never arrives here — while it clearly changed in the cloud —
+        // is the signature of the message service not pushing that device's reports.
+        try {
+            this.log.debug(`Tuya Cloud realtime update for ${devId}${handlers && handlers.length ? '' : ' (no subscriber)'}: ${JSON.stringify(status)}`);
+        } catch (_) { /* logging must never throw */ }
         if (!handlers || !handlers.length) return;
         handlers.forEach(fn => {
             try { fn(status); } catch (ex) { this.log.debug(`Tuya Cloud realtime handler error: ${ex.message}`); }

--- a/test/TuyaCloudDevice.test.js
+++ b/test/TuyaCloudDevice.test.js
@@ -293,6 +293,51 @@ describe('TuyaCloudDevice', () => {
         expect(api.getStatus).toHaveBeenCalledWith('dev1');
     });
 
+    describe('cloud state sync', () => {
+        test('the post-write catch-up re-reads the shadow and emits the resulting change', async () => {
+            const api = makeApi();
+            let rs = 13;
+            api.getShadowProperties = jest.fn(async () => [{code: 'return_state', dp_id: 105, value: rs}]);
+            const dev = makeDevice(api, null, {key: 'abc'});
+            await dev._connect(); // state: return_state=13, '105'=13
+
+            const changes = [];
+            dev.on('change', c => changes.push(c));
+            rs = 12; // the gate is now "opening" in the cloud
+            await dev._catchupOnce();
+            expect(changes[0]).toEqual({return_state: 12, '105': 12});
+        });
+
+        test('a successful cloud write arms a state catch-up', async () => {
+            const api = makeApi();
+            api.getShadowProperties = jest.fn().mockResolvedValue([{code: 'switch_1', dp_id: 1, value: false}]);
+            const dev = makeDevice(api, null, {key: 'abc'});
+            await dev._connect();
+            expect(dev._catchupTimers).toBeNull();
+            await dev.update({'1': true});
+            expect(Array.isArray(dev._catchupTimers)).toBe(true);
+            dev.stop();
+        });
+
+        test('a refresh reads via the shadow, so a thing-model device whose /status is empty still updates', async () => {
+            const api = makeApi();
+            let rs = 13;
+            api.getStatus = jest.fn().mockResolvedValue([]); // thing-model-only device: /status comes back empty
+            api.getShadowProperties = jest.fn(async () => [{code: 'return_state', dp_id: 105, value: rs}]);
+            const dev = makeDevice(api, null, {key: 'abc'});
+            await dev._connect();
+
+            const changes = [];
+            dev.on('change', c => changes.push(c));
+            rs = 12;
+            await dev._refreshState();
+
+            expect(api.getShadowProperties).toHaveBeenCalled();
+            expect(changes.some(c => c['105'] === 12)).toBe(true);
+            expect(dev.state['105']).toBe(12); // not wiped by the empty /status
+        });
+    });
+
     describe('connect-failure handling (no log spam)', () => {
         afterEach(() => jest.restoreAllMocks());
 


### PR DESCRIPTION
A thing-model-only device (e.g. a custom gate controller) controlled over
the cloud never advanced its HomeKit state — the garage door sat on
"Opening…" forever. Tested live against such a device: it DOES report its
state to the cloud promptly (the door-state DP flips within ~1s), but

- the iot-03 /status endpoint returns an EMPTY result for it (its
  data-points live only in the thing-model shadow), so _refreshState read
  nothing back; and
- the realtime stream doesn't carry its reports.

So the accessory, which mirrors that status DP, never saw the change.

- _refreshState now reads via the shadow-preferred path
  (_readInitialProperties), not the bare /status, so a device whose
  /status comes back empty still refreshes.
- After a successful cloud write, re-read the device a couple of times
  (2s and 8s, re-armed per write, cloud-path only) to catch the resulting
  transition even when the realtime stream misses it.
- Log each realtime status frame at debug, so a device whose reports never
  arrive over MQTT is diagnosable.

Verified end-to-end: opening the gate emits return_state=12 (→ door OPEN)
~2s later; closing emits 13 (→ CLOSED).
