### PR TITLE
Serialize per-device cloud writes; reuse HTTP connections

### DIFF
--- a/lib/TuyaCloudApi.js
+++ b/lib/TuyaCloudApi.js
@@ -87,6 +87,10 @@ class TuyaCloudApi {
         this.uid = null;           // linked app-account uid (needed for realtime MQTT)
         this._tokenExpiry = 0;     // ms epoch when the token must be refreshed
         this._tokenPromise = null; // in-flight token request (de-dupes concurrent callers)
+
+        // Reuse TLS connections across requests instead of a fresh handshake each
+        // time — noticeably cuts per-command latency and the startup read burst.
+        this._agent = new https.Agent({keepAlive: true, maxSockets: 8});
     }
 
     isConfigured() {
@@ -365,7 +369,8 @@ class TuyaCloudApi {
                 port: url.port || 443,
                 path: url.pathname + url.search,
                 method,
-                headers
+                headers,
+                agent: this._agent
             }, resp => {
                 let data = '';
                 resp.setEncoding('utf8');

--- a/lib/TuyaCloudDevice.js
+++ b/lib/TuyaCloudDevice.js
@@ -76,6 +76,7 @@ class TuyaCloudDevice extends EventEmitter {
         this._propertiesTried = new Set();
         this._announcedProperties = false;
         this._catchupTimers = null; // post-write state re-reads (see _scheduleStateCatchup)
+        this._writeChain = null;    // serializes cloud writes to this device (see update)
 
         // Bidirectional data-point maps, learned from the device's thing-shadow on
         // connect. They let this cloud transport (and the LAN+cloud TuyaDevice that
@@ -366,7 +367,16 @@ class TuyaCloudDevice extends EventEmitter {
         if (undeliverable.length) this._reportUndeliverableWrite(undeliverable);
         if (!sendable.length) return false;
 
-        return this._dispatch(sendable);
+        // Serialize writes to this device. HomeKit frequently double-sends a
+        // characteristic write, and rapid changes (dragging a thermostat) fire a
+        // burst; running them concurrently both races the per-code endpoint
+        // learning (a duplicate could see a code "tried" but not yet learned and
+        // fail spuriously) and bursts the cloud's QPS limit (uneven latency). One
+        // at a time keeps learning coherent and the request rate smooth. _dispatch
+        // never rejects, so the chain can't break.
+        const run = () => this._dispatch(sendable);
+        this._writeChain = this._writeChain ? this._writeChain.then(run, run) : run();
+        return this._writeChain;
     }
 
     // Send a write, routing each data-point to the cloud endpoint it accepts. Codes
@@ -418,7 +428,7 @@ class TuyaCloudDevice extends EventEmitter {
         }
         if (!this._announcedProperties) {
             this._announcedProperties = true;
-            this.log.info(`${this.context.name}: controlling some of this device's data-points over the Tuya thing-model property endpoint (they aren't in its standard instruction set).`);
+            this.log.debug(`${this.context.name}: controlling some of this device's data-points over the Tuya thing-model property endpoint (they aren't in its standard instruction set).`);
         }
         return this._learn(fresh, 'properties');
     }

--- a/test/TuyaCloudDevice.test.js
+++ b/test/TuyaCloudDevice.test.js
@@ -240,6 +240,29 @@ describe('TuyaCloudDevice', () => {
             expect(api.sendCommands).toHaveBeenCalledWith('dev1', [{code: 'switch_1', value: false}]);
             expect(api.sendProperties).toHaveBeenCalledWith('dev1', [{code: 'wfh_open', value: true}]);
         });
+
+        // HomeKit often double-sends a write; running the two concurrently used to
+        // race the learning (the 2nd saw the code "tried" but not yet learned and
+        // failed). Serializing writes per device fixes it.
+        test('concurrent duplicate writes of an unknown code are serialized, not raced', async () => {
+            const api = makeApi();
+            api.getShadowProperties = jest.fn().mockResolvedValue([{code: 'Power', dp_id: 1, value: false}]);
+            api.sendCommands.mockImplementation((id, cmds) =>
+                cmds.some(c => c.code === 'Power')
+                    ? Promise.reject(new Error('command or value not support (code 2008)'))
+                    : Promise.resolve(true));
+            const dev = makeDevice(api, null, {key: 'abc'});
+            await dev._connect();
+            const warn = jest.spyOn(log, 'warn');
+
+            const [a, b] = await Promise.all([dev.update({'1': true}), dev.update({'1': true})]);
+
+            expect(a).toBe(true);
+            expect(b).toBe(true);
+            expect(warn).not.toHaveBeenCalled();               // the 2nd write didn't spuriously fail
+            expect(api.sendCommands).toHaveBeenCalledTimes(1);  // only the 1st probed commands
+            jest.restoreAllMocks();
+        });
     });
 
     test('realtime code-only deltas are mirrored to numeric ids via the learned map', async () => {


### PR DESCRIPTION
Three cloud-write papercuts, all visible when many writes hit one device
(e.g. dragging the AC thermostat):

- HomeKit double-sends a characteristic write, so two update() calls ran
  concurrently and raced the per-code endpoint learning — the second saw a
  code "tried" but not yet learned, had nothing fresh to probe, and logged a
  spurious "cloud command failed (2008)" warning even though the first write
  succeeded. Serialize writes per device so the learning stays coherent;
  this also smooths the request rate, which was bursting the cloud's QPS
  limit and making some sets take seconds while others were instant.
- Reuse TLS connections (keep-alive agent) instead of a fresh handshake per
  request — cuts per-command latency and the startup read burst.
- Demote the one-time "controlling some data-points over the thing-model
  property endpoint" line from info to debug; it's routine, not actionable.
