### PR TITLE
Cancel the post-write catch-up when the device reports over MQTT

### DIFF
--- a/lib/TuyaCloudDevice.js
+++ b/lib/TuyaCloudDevice.js
@@ -215,7 +215,22 @@ class TuyaCloudDevice extends EventEmitter {
         // first 'online' is caught. On any (re)connect we re-read the full state
         // to recover anything missed while the stream was down.
         this.messaging.on('online', () => this._refreshState());
-        this.messaging.subscribeDevice(this.context.id, status => this._applyStatus(status));
+        this.messaging.subscribeDevice(this.context.id, status => this._onRealtime(status));
+    }
+
+    // A realtime (MQTT) update arrived for this device, so it reports its changes
+    // over the stream and the post-write catch-up read is redundant — drop any
+    // pending one. A device whose reports never arrive over MQTT (some custom
+    // controllers — the stream carries nothing for them) gets none of these, so its
+    // catch-up stays armed and remains the only way its state reaches HomeKit. This
+    // makes the catch-up self-cancelling: it costs an HTTP read only on devices that
+    // actually need it.
+    _onRealtime(status) {
+        if (this._catchupTimers) {
+            this._catchupTimers.forEach(t => clearTimeout(t));
+            this._catchupTimers = null;
+        }
+        this._applyStatus(status);
     }
 
     async _refreshState() {

--- a/test/TuyaCloudDevice.test.js
+++ b/test/TuyaCloudDevice.test.js
@@ -342,6 +342,19 @@ describe('TuyaCloudDevice', () => {
             dev.stop();
         });
 
+        test('a realtime update cancels the pending catch-up (no redundant read on MQTT-covered devices)', async () => {
+            const api = makeApi();
+            api.getShadowProperties = jest.fn().mockResolvedValue([{code: 'switch_1', dp_id: 1, value: false}]);
+            const dev = makeDevice(api, null, {key: 'abc'});
+            await dev._connect();
+            await dev.update({'1': true});
+            expect(Array.isArray(dev._catchupTimers)).toBe(true);
+
+            dev._onRealtime([{code: 'switch_1', value: true}]); // MQTT delivers → catch-up not needed
+            expect(dev._catchupTimers).toBeNull();
+            dev.stop();
+        });
+
         test('a refresh reads via the shadow, so a thing-model device whose /status is empty still updates', async () => {
             const api = makeApi();
             let rs = 13;


### PR DESCRIPTION
The post-write state catch-up did an HTTP re-read after every cloud write, but
most devices report their changes over the realtime (MQTT) stream, making that
read redundant for them. It's per-device: in testing, some devices deliver
realtime updates and a custom gate delivers none at all.

Cancel any pending catch-up the moment a realtime update arrives for the device.
The catch-up now self-selects — it costs an HTTP read only on devices whose
reports never reach the stream (where it's the only path to HomeKit), and nothing
on devices realtime already covers. It was never in the request's critical path
(a background timer), so this changes only the wasted reads, not latency.
