### PR TITLE
Apply realtime data-points that arrive without a code

### DIFF
--- a/lib/TuyaCloudDevice.js
+++ b/lib/TuyaCloudDevice.js
@@ -310,9 +310,26 @@ class TuyaCloudDevice extends EventEmitter {
     _propsToState(props) {
         const state = {};
         (props || []).forEach(item => {
-            if (item && typeof item.code === 'string') {
+            if (!item || typeof item !== 'object') return;
+            if (typeof item.code === 'string') {
                 this._indexInto(state, item.code, item.value, item.dp_id != null ? item.dp_id : item.dpId);
+                return;
             }
+            // A realtime item with no `code`: Tuya's MQTT stream delivers some
+            // data-points as a bare { "<dpId>": value } pair — no `code`, no `value`
+            // field. Custom / non-standard DPs come through this way (e.g. an
+            // irrigation timer's `charging`, dp 101, which lives only in the
+            // thing-model shadow, not the standard instruction set, so the message
+            // service never attaches a code). Map the numeric id back to its code,
+            // learned from the shadow on connect, so the change is applied instead of
+            // silently dropped; a still-unmapped id is indexed numerically, which a
+            // LAN-style config resolves.
+            Object.keys(item).forEach(key => {
+                if (!/^\d+$/.test(key)) return;
+                const code = this.codeByDpId[key];
+                if (code != null) this._indexInto(state, code, item[key], key);
+                else state[key] = item[key];
+            });
         });
         return state;
     }

--- a/test/TuyaCloudDevice.test.js
+++ b/test/TuyaCloudDevice.test.js
@@ -279,6 +279,39 @@ describe('TuyaCloudDevice', () => {
         expect(changes[0]).toEqual({switch_1: true, '1': true});
     });
 
+    test('realtime bare numeric-keyed items (no code) are mapped to their code', async () => {
+        // Custom/non-standard DPs (e.g. an irrigation timer's `charging`, dp 101)
+        // arrive over MQTT as a bare { "<dpId>": value } pair with no `code` field.
+        // They must be applied via the learned dp→code map, not dropped.
+        const api = makeApi();
+        api.getShadowProperties = jest.fn().mockResolvedValue([
+            {code: 'switch_1', dp_id: 1, value: false},
+            {code: 'charging', dp_id: 101, value: false}
+        ]);
+        const dev = makeDevice(api);
+        await dev._connect();
+
+        const changes = [];
+        dev.on('change', c => changes.push(c));
+        dev._applyStatus([{'101': true}]); // bare numeric, as the message service delivers `charging`
+        expect(dev.state.charging).toBe(true);
+        expect(dev.state['101']).toBe(true);
+        expect(changes[0]).toEqual({charging: true, '101': true});
+    });
+
+    test('a bare numeric item with no learned code is still indexed numerically', async () => {
+        const api = makeApi();
+        api.getShadowProperties = jest.fn().mockResolvedValue([{code: 'switch_1', dp_id: 1, value: false}]);
+        const dev = makeDevice(api);
+        await dev._connect();
+
+        const changes = [];
+        dev.on('change', c => changes.push(c));
+        dev._applyStatus([{'137': 42}]); // unknown dp, no code mapping
+        expect(dev.state['137']).toBe(42);
+        expect(changes[0]).toEqual({'137': 42});
+    });
+
     test('falls back to /status (code-only) when the shadow is unavailable', async () => {
         const api = makeApi();
         api.getShadowProperties = jest.fn().mockResolvedValue(null);


### PR DESCRIPTION
Tuya's MQTT stream delivers some custom/non-standard data-points as a bare
{ "<dpId>": value } item with no `code` field — e.g. an irrigation timer's
`charging` (dp 101), which exists only in the thing-model shadow, not the
standard instruction set. _propsToState only handled items carrying a string
code, so these changes were silently dropped: the device kept charging while
HomeKit's ChargingState stayed stuck at its last-restart value.

Map the bare numeric id back to its code via the dp map learned from the shadow
on connect, so the change is applied (and an unmapped id is still indexed
numerically for a LAN-style config).
