### PR TITLE
Keep the gate's dispatch baseline off the stop's own transient

### DIFF
--- a/lib/SimpleGarageDoorAccessory.js
+++ b/lib/SimpleGarageDoorAccessory.js
@@ -120,6 +120,11 @@ class SimpleGarageDoorAccessory extends BaseAccessory {
             ? Characteristic.TargetDoorState.OPEN
             : Characteristic.TargetDoorState.CLOSED;
         this.accessory.context.cachedTargetDoorState = initialTarget;
+        // The level-triggered dispatch baseline (see setTargetDoorState). Held
+        // separately from cachedTargetDoorState because that one mirrors every
+        // reported value for HomeKit's benefit — including the transient "stopped"
+        // our own stop-before-close produces — which must not move this baseline.
+        this._committedTarget = initialTarget;
 
         this.characteristicTargetDoorState = service.getCharacteristic(Characteristic.TargetDoorState)
             .updateValue(initialTarget)
@@ -201,10 +206,23 @@ class SimpleGarageDoorAccessory extends BaseAccessory {
         // (=OPEN), which would fight the close we're about to send. Ignore
         // status reports until the close has gone out.
         if (this.pendingCloseTimer) return;
-        const isOpen = this._mapDpState(changes[this.dpState]);
+        const raw = typeof changes[this.dpState] === 'string' ? parseInt(changes[this.dpState], 10) : changes[this.dpState];
+        const isOpen = this._mapDpState(raw);
         if (isOpen === null) {
             this.log.debug(`[SimpleGarageDoor] ${this.device.context.name}: ignoring unknown state DP value ${JSON.stringify(changes[this.dpState])}`);
             return;
+        }
+        // Keep the level-triggered dispatch baseline honest with the gate's real
+        // position, but only from a DEFINITIVE report — 12 (opening/open) or 13
+        // (closing/closed). A bare 11 (stopped) is skipped: it is exactly what our
+        // own stop-before-close pulse makes the controller report, and over the LAN
+        // that report can land just after the stop→close window. Letting it flip
+        // the committed target back to OPEN is what let HomeKit's repeat close fire
+        // a second stop-before-close into the already-closing gate. A genuine
+        // external open always passes through 12 first, so nothing is missed.
+        if (raw === STATE_OPENING_OR_OPEN || raw === STATE_CLOSING_OR_CLOSED) {
+            const {Characteristic} = this.hap;
+            this._committedTarget = isOpen ? Characteristic.TargetDoorState.OPEN : Characteristic.TargetDoorState.CLOSED;
         }
         this._applyReportedState(isOpen);
     }
@@ -259,16 +277,17 @@ class SimpleGarageDoorAccessory extends BaseAccessory {
         this._cancelPartialStop();
 
         // The opener is level-triggered: act only when the requested target
-        // differs from the one already committed. HomeKit re-sends the same
-        // target after a tap — a second controller echoing it, or its own retry
-        // a few seconds later — and acting on that repeat would fire another
+        // differs from the one we've already committed to. HomeKit re-sends the
+        // same target after a tap — a second controller echoing it, or its own
+        // retry a few seconds later — and acting on that repeat would fire another
         // open/close. For a close that means a second stop-before-close into the
-        // already-closing gate, halting it mid-travel and restarting it. A real
-        // request always flips the target (the Home app toggles to the opposite
-        // state), and the reported state keeps cachedTargetDoorState honest — a
-        // command the controller drops is reverted by the next status read — so
-        // this never swallows a genuine request, only the redundant echoes.
-        if (value === this.accessory.context.cachedTargetDoorState) {
+        // already-closing gate, halting it mid-travel and restarting it (the
+        // reported stutter). A genuine request always flips the target (the Home
+        // app toggles to the opposite state). The committed target is reconciled
+        // with the gate's real position in _onDeviceChange so external operation
+        // still works — but only from a definitive report, never from the
+        // "stopped" transient our own stop produces, so the repeat stays caught.
+        if (value === this._committedTarget) {
             this.log.debug(`[SimpleGarageDoor] ${this.device.context.name}: target unchanged — ignoring repeat request`);
             return;
         }
@@ -282,6 +301,7 @@ class SimpleGarageDoorAccessory extends BaseAccessory {
     _applyTarget(value) {
         const {Characteristic} = this.hap;
         const open = value === Characteristic.TargetDoorState.OPEN;
+        this._committedTarget = value;
         this.accessory.context.cachedTargetDoorState = value;
         if (this.characteristicTargetDoorState) this.characteristicTargetDoorState.updateValue(value);
         if (open) this._sendOpen();

--- a/test/SimpleGarageDoorAccessory.test.js
+++ b/test/SimpleGarageDoorAccessory.test.js
@@ -68,6 +68,7 @@ function makeSimpleGarage(initialContext = {}) {
         updateValue: jest.fn().mockImplementation(function(v) { this.value = v; return this; }),
     };
     accessory.context.cachedTargetDoorState = TDS.CLOSED;
+    instance._committedTarget = TDS.CLOSED;
 
     // Mirror the persistent change listener registered in production.
     device.on('change', changes => instance._onDeviceChange(changes));
@@ -233,6 +234,7 @@ describe('SimpleGarageDoorAccessory.setTargetDoorState — close (stop-before-cl
     function openGate(instance, device, state = STATE_OPENING_OR_OPEN) {
         if (state !== undefined) device.state['105'] = state;
         instance.accessory.context.cachedTargetDoorState = TDS.OPEN;
+        instance._committedTarget = TDS.OPEN;
     }
 
     test('CLOSE fires immediately when the gate is already stopped (state 11)', () => {
@@ -328,6 +330,25 @@ describe('SimpleGarageDoorAccessory.setTargetDoorState — close (stop-before-cl
         jest.advanceTimersByTime(3000);
         instance.setTargetDoorState(TDS.CLOSED); // HomeKit's repeat close
         expect(device.update).toHaveBeenCalledTimes(2); // swallowed — no second stop/close
+    });
+
+    test('A stopped (11) report after the close does not re-enable the repeat (LAN stutter)', () => {
+        // Over the LAN the stop pulse makes the controller report 11 (=OPEN) just
+        // after the close has gone out — outside the stop-before-close window. That
+        // 11 must NOT move the committed target back to OPEN, or HomeKit's repeat
+        // close would fire a second stop-before-close into the already-closing gate.
+        const { instance, device } = makeSimpleGarage();
+        instance.stopBeforeCloseMs = 1500;
+        openGate(instance, device, STATE_OPENING_OR_OPEN);
+
+        instance.setTargetDoorState(TDS.CLOSED);
+        jest.advanceTimersByTime(1500);
+        expect(device.update).toHaveBeenCalledTimes(2); // stop + close
+
+        emitState(device, STATE_STOPPED); // the stop's late 11 report
+        expect(instance._committedTarget).toBe(TDS.CLOSED); // not bounced to OPEN
+        instance.setTargetDoorState(TDS.CLOSED); // HomeKit's repeat
+        expect(device.update).toHaveBeenCalledTimes(2); // swallowed
     });
 
     test('A close runs again once the gate is reported open (committed target tracks reports)', () => {
@@ -631,7 +652,7 @@ describe('SimpleGarageDoorAccessory — force switches', () => {
     test('Force Close fires the close action (immediately when already stopped)', () => {
         const { instance, device, accessory } = makeSimpleGarage();
         device.state['105'] = STATE_STOPPED;
-        accessory.context.cachedTargetDoorState = TDS.OPEN; // gate open → close is a real transition
+        instance._committedTarget = TDS.OPEN; // gate open → close is a real transition
 
         instance.setTargetDoorState(TDS.CLOSED);
 


### PR DESCRIPTION
The level-triggered dispatch deduped against cachedTargetDoorState, but that
field mirrors every reported value — including the "stopped" (11) the
stop-before-close pulse itself makes the controller report. Over the LAN that
report lands just after the stop->close window and bounced the baseline back to
OPEN, so HomeKit's repeat close slipped through and fired a second
stop-before-close into the already-closing gate (the stutter the cloud path
avoided only because its gate never pushes reports).

Track the committed target separately and reconcile it only from a definitive
report — 12 (opening/open) or 13 (closing/closed), never the bare 11 our own
stop produces. A genuine external open always passes through 12 first, so
external operation still updates it. No timers, no config.
