### PR TITLE
Keep a partial open's auto-stop alive through HomeKit's repeat open

### DIFF
--- a/lib/SimpleGarageDoorAccessory.js
+++ b/lib/SimpleGarageDoorAccessory.js
@@ -271,10 +271,6 @@ class SimpleGarageDoorAccessory extends BaseAccessory {
         // silently dropping the command (the write helpers would otherwise just
         // log and skip, leaving HomeKit to believe the open/close succeeded).
         if (!this.device.connected) throw this._commError();
-        // A direct open/close (the GarageDoorOpener target, a Force switch, or
-        // the partial switch tapped OFF) is manual control: cancel any pending
-        // partial-open auto-stop so it can't halt this movement part-way.
-        this._cancelPartialStop();
 
         // The opener is level-triggered: act only when the requested target
         // differs from the one we've already committed to. HomeKit re-sends the
@@ -291,6 +287,17 @@ class SimpleGarageDoorAccessory extends BaseAccessory {
             this.log.debug(`[SimpleGarageDoor] ${this.device.context.name}: target unchanged — ignoring repeat request`);
             return;
         }
+
+        // A direct open/close (the GarageDoorOpener target, a Force switch, or
+        // the partial switch tapped OFF) is manual control: cancel any pending
+        // partial-open auto-stop so it can't halt this movement part-way. This
+        // must run only for a genuine target change, AFTER the repeat check
+        // above: a partial open drives the committed target to OPEN itself, so
+        // HomeKit's repeat of that OPEN re-enters here, and cancelling on that
+        // swallowed repeat would tear down the auto-stop the partial just armed —
+        // letting the gate run all the way open instead of parking part-way.
+        this._cancelPartialStop();
+
         this._applyTarget(value);
     }
 

--- a/test/SimpleGarageDoorAccessory.test.js
+++ b/test/SimpleGarageDoorAccessory.test.js
@@ -602,6 +602,53 @@ describe('SimpleGarageDoorAccessory._handlePartialOpen', () => {
         expect(device.update).toHaveBeenCalledTimes(3);
     });
 
+    test('A repeat of the partial open\'s own OPEN target does not cancel the pending auto-stop', () => {
+        // The partial open drives TargetDoorState to OPEN itself, then waits for
+        // the gate to report it's moving before arming the auto-stop. HomeKit
+        // re-sends that same OPEN in the meantime (a second controller echoing
+        // it, or its own retry). That swallowed repeat must NOT tear down the
+        // pending partial, or the gate runs all the way open instead of parking
+        // part-way — the reported bug.
+        const { instance, device } = makeSimpleGarage();
+        instance.partialOpenMs = 2000;
+        device.state['105'] = STATE_CLOSING_OR_CLOSED; // starts closed → stop waits for movement
+
+        instance._handlePartialOpen();
+        expect(device.update).toHaveBeenCalledTimes(1);
+        expect(device.update).toHaveBeenNthCalledWith(1, { '101': true }); // open
+        expect(instance.partialPending).toBe(true);
+
+        // HomeKit's repeat of the same OPEN lands before the gate reports moving.
+        instance.setTargetDoorState(TDS.OPEN);
+        expect(instance.partialPending).toBe(true); // still pending — not cancelled
+        expect(device.update).toHaveBeenCalledTimes(1); // and no second open
+
+        // The gate now reports it's moving: the countdown arms and the stop fires.
+        emitState(device, STATE_OPENING_OR_OPEN);
+        expect(instance.partialStopTimer).not.toBeNull();
+        jest.advanceTimersByTime(2000);
+        expect(device.update).toHaveBeenNthCalledWith(2, { '103': true }); // partial stop
+    });
+
+    test('A repeat of OPEN after the auto-stop is armed leaves the timer intact', () => {
+        const { instance, device } = makeSimpleGarage();
+        instance.partialOpenMs = 2000;
+        device.state['105'] = STATE_OPENING_OR_OPEN; // arms immediately
+
+        instance._handlePartialOpen();
+        expect(instance.partialStopTimer).not.toBeNull();
+
+        // A repeat OPEN partway through must not cancel or push out the timer.
+        jest.advanceTimersByTime(500);
+        instance.setTargetDoorState(TDS.OPEN);
+        expect(instance.partialStopTimer).not.toBeNull();
+        expect(device.update).toHaveBeenCalledTimes(1); // no second open
+
+        // The original 2000ms deadline still fires the stop.
+        jest.advanceTimersByTime(1500);
+        expect(device.update).toHaveBeenNthCalledWith(2, { '103': true });
+    });
+
     test('Does nothing when partialOpenMs is not configured', () => {
         const { instance, device } = makeSimpleGarage();
         instance.partialOpenMs = 0;


### PR DESCRIPTION
## Problem

The SimpleGarageDoor **Partial Open** switch never parked the gate part-way — it ran all the way open every time. As reported, the only logs were:

```
[SimpleGarageDoor] Brama: partial open — opening, will stop 5500ms after the gate starts moving
[SimpleGarageDoor] Brama: open (dp101)
[SimpleGarageDoor] Brama: target unchanged — ignoring repeat request
```

## Root cause

A partial open drives `TargetDoorState` to `OPEN` itself, then waits for the gate to report it's moving before arming the auto-stop. But `setTargetDoorState()` called `_cancelPartialStop()` **unconditionally at the top — before** the level-triggered repeat check.

So HomeKit's normal re-send of that same `OPEN` target (a second controller echoing it, or its own retry) re-entered `setTargetDoorState`, ran `_cancelPartialStop()` — wiping `partialPending` — and only *then* hit the repeat check and logged *"target unchanged — ignoring repeat request"*. The damage was already done: when the gate later reported it was moving, `_applyReportedState`'s `if (this.partialPending && isOpen)` guard was now `false`, so the auto-stop never armed.

The partial open defeated itself: it set the target to `OPEN`, and HomeKit's repeat of that `OPEN` tore down the auto-stop as a side effect of a request it then correctly ignored.

## Fix

Move `_cancelPartialStop()` to **after** the repeat-check early return, so it fires only for a genuine target change. The swallowed repeat now leaves the pending partial intact, the auto-stop arms when the gate reports moving, and the gate parks part-way.

A direct close (partial switch tapped OFF, the garage tile, or Force Close) still cancels the partial — that's a real target change and flows past the repeat check as before.

## Verification

- Added 2 regression tests; confirmed both **fail against the original code** and **pass with the fix**.
- Full suite green: **419 tests pass**; `npm run lint` clean.

## Note

If a partial open is mid-flight and someone hits **Force Open**, it's now swallowed as a repeat (gate parks part-way) rather than overriding to full-open. That's an unavoidable consequence of value-based level-triggering — a Force-Open `OPEN` is indistinguishable from HomeKit's repeat `OPEN` — and a rare race versus the reported bug where partial open never worked at all. Telling the two apart would need a separate signal; happy to add that if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018a9gNJQ9hXyUy8aVixfxeX

---
_Generated by [Claude Code](https://claude.ai/code/session_018a9gNJQ9hXyUy8aVixfxeX)_