### PR TITLE
Expose the irrigation rain sensor as a LeakDetected characteristic

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -862,6 +862,15 @@
               "condition": {
                 "functionBody": "return model.devices && model.devices[arrayIndices] && ['IrrigationSystem'].includes(model.devices[arrayIndices].type) && !model.devices[arrayIndices].noBattery;"
               }
+            },
+            "dpRainState": {
+              "type": ["integer", "string"],
+              "placeholder": "49 or rain_sensor_state",
+              "title": "Rain-sensor data-point (numeric id, or cloud code)",
+              "description": "Enum data-point reporting rainfall ('rain' / 'no_rain'), surfaced as a Leak Detected characteristic on the irrigation system so HomeKit can notify and automate on rain. Defaults to DP 49; if your controller doesn't report it, Leak Detected simply stays clear.",
+              "condition": {
+                "functionBody": "return model.devices && model.devices[arrayIndices] && ['IrrigationSystem'].includes(model.devices[arrayIndices].type);"
+              }
             }
           }
         }

--- a/lib/IrrigationSystemAccessory.js
+++ b/lib/IrrigationSystemAccessory.js
@@ -212,15 +212,17 @@ class IrrigationSystemAccessory extends BaseAccessory {
             if (battery) this.accessory.removeService(battery);
         }
 
-        // Rain/leak sensors are no longer supported: they never reported
-        // reliably on these devices, and bundling a sensor in the same accessory
-        // forced the Home app to fragment the sprinkler into "sub-accessories"
-        // (blocking control from the main tile). Drop any left over from an older
-        // version so the accessory stays a clean, single-category sprinkler tile.
+        // Rain state is surfaced as a LeakDetected characteristic ON the
+        // IrrigationSystem service itself (see _registerCharacteristics), never as
+        // a separate LeakSensor/ContactSensor service: a second sensor service
+        // makes the Home app fragment the sprinkler into "sub-accessories" and
+        // blocks control from the main tile. Drop any standalone rain-sensor
+        // service left over from an older version so the accessory stays a clean,
+        // single-category sprinkler tile.
         [Service.ContactSensor, Service.LeakSensor].forEach(S => {
             const svc = this.accessory.getService(S);
             if (svc) {
-                this.log.debug('Removing rain sensor service %s (no longer supported)', svc.displayName);
+                this.log.debug('Removing standalone rain sensor service %s (rain state is now a LeakDetected characteristic)', svc.displayName);
                 this.accessory.removeService(svc);
             }
         });
@@ -265,6 +267,7 @@ class IrrigationSystemAccessory extends BaseAccessory {
         // configured instead and works over either transport.
         this.dpBattery = this._resolveDP(this.device.context.dpBattery, '46');
         this.dpCharging = this._resolveDP(this.device.context.dpCharging, '101');
+        this.dpRainState = this._resolveDP(this.device.context.dpRainState, '49');
 
         // Per-zone runtime state
         this._valves = this._getValveConfigs();
@@ -294,6 +297,15 @@ class IrrigationSystemAccessory extends BaseAccessory {
             .setProps({maxValue: this._maxDuration})
             .updateValue(0)
             .onGet(() => this._systemRemaining());
+
+        // Rain sensor -> LeakDetected, carried on the IrrigationSystem service
+        // itself (a separate LeakSensor service would fragment the tile — see
+        // _verifyCachedPlatformAccessory). "rain" reads as a leak so HomeKit can
+        // notify/automate on it; everything else — "no_rain", or a device that
+        // doesn't report it — stays "no leak".
+        irrigation.getCharacteristic(Characteristic.LeakDetected)
+            .updateValue(this._leakDetected(dps[this.dpRainState]))
+            .onGet(() => this._leakDetected(this.getStateAsync(this.dpRainState)));
 
         // --- Valve characteristics ---
         this._valves.forEach(cfg => {
@@ -423,6 +435,12 @@ class IrrigationSystemAccessory extends BaseAccessory {
             const battery = this.accessory.getService(Service.Battery);
             if (battery) battery.getCharacteristic(Characteristic.ChargingState)
                 .updateValue(this._chargingState(changes[this.dpCharging]));
+        }
+
+        if (changes.hasOwnProperty(this.dpRainState)) {
+            const irrigation = this.accessory.getService(Service.IrrigationSystem);
+            if (irrigation) irrigation.getCharacteristic(Characteristic.LeakDetected)
+                .updateValue(this._leakDetected(changes[this.dpRainState]));
         }
 
         if (valveChanged) this._syncAggregate();
@@ -727,6 +745,21 @@ class IrrigationSystemAccessory extends BaseAccessory {
         return value
             ? Characteristic.ChargingState.CHARGING
             : Characteristic.ChargingState.NOT_CHARGING;
+    }
+
+    /* ------------------------------------------------------------------ *
+     *  Rain sensor mapping
+     * ------------------------------------------------------------------ */
+
+    // rain_sensor_state ("rain"/"no_rain") -> LeakDetected. Only an explicit
+    // "rain" reads as a leak; anything else — "no_rain", an unknown value, or a
+    // device that never reports the sensor — is "no leak", so the characteristic
+    // sits steady at LEAK_NOT_DETECTED on devices without a rain sensor.
+    _leakDetected(value) {
+        const {Characteristic} = this.hap;
+        return ('' + value).trim().toLowerCase() === 'rain'
+            ? Characteristic.LeakDetected.LEAK_DETECTED
+            : Characteristic.LeakDetected.LEAK_NOT_DETECTED;
     }
 
     /* ------------------------------------------------------------------ *

--- a/test/IrrigationSystemAccessory.test.js
+++ b/test/IrrigationSystemAccessory.test.js
@@ -645,6 +645,76 @@ describe('IrrigationSystemAccessory — charging state', () => {
     });
 });
 
+describe('IrrigationSystemAccessory — rain sensor (LeakDetected)', () => {
+    test('exposes LeakDetected on the IrrigationSystem service itself (no separate sensor service)', () => {
+        const { accessory } = makeHarness({ '1': false, '49': 'no_rain' });
+        const irr = irrigation(accessory);
+        expect(irr.getCharacteristic(Characteristic.LeakDetected).value)
+            .toBe(Characteristic.LeakDetected.LEAK_NOT_DETECTED);
+        // A standalone sensor service would fragment the sprinkler tile — it must
+        // never be created; the state rides on the system service instead.
+        expect(accessory.getService(Service.LeakSensor)).toBeUndefined();
+        expect(accessory.getService(Service.ContactSensor)).toBeUndefined();
+    });
+
+    test('reports a leak while the device reports "rain"', () => {
+        const { accessory } = makeHarness({ '1': false, '49': 'rain' });
+        expect(irrigation(accessory).getCharacteristic(Characteristic.LeakDetected).value)
+            .toBe(Characteristic.LeakDetected.LEAK_DETECTED);
+    });
+
+    test('defaults to "no leak" when the device never reports the rain sensor', () => {
+        const { accessory } = makeHarness({ '1': false });
+        expect(irrigation(accessory).getCharacteristic(Characteristic.LeakDetected).value)
+            .toBe(Characteristic.LeakDetected.LEAK_NOT_DETECTED);
+    });
+
+    test('a device-side rain change is mirrored onto LeakDetected', () => {
+        const { accessory, device } = makeHarness({ '1': false, '49': 'no_rain' });
+        const leak = irrigation(accessory).getCharacteristic(Characteristic.LeakDetected);
+
+        device.emitChange({ '49': 'rain' });
+        expect(leak.value).toBe(Characteristic.LeakDetected.LEAK_DETECTED);
+
+        device.emitChange({ '49': 'no_rain' });
+        expect(leak.value).toBe(Characteristic.LeakDetected.LEAK_NOT_DETECTED);
+    });
+
+    test('onGet reflects the live device state', () => {
+        const { accessory, device } = makeHarness({ '1': false, '49': 'no_rain' });
+        const leak = irrigation(accessory).getCharacteristic(Characteristic.LeakDetected);
+        device.state['49'] = 'rain';
+        expect(leak.triggerGet()).toBe(Characteristic.LeakDetected.LEAK_DETECTED);
+    });
+
+    test('onGet throws while disconnected (HomeKit shows "No Response")', () => {
+        const { accessory, device } = makeHarness({ '1': false, '49': 'no_rain' });
+        device.connected = false;
+        expect(() => irrigation(accessory).getCharacteristic(Characteristic.LeakDetected).triggerGet()).toThrow();
+    });
+
+    test('_leakDetected maps only "rain" (case/space-insensitive) to a leak', () => {
+        const { instance } = makeHarness({ '1': false });
+        expect(instance._leakDetected('rain')).toBe(Characteristic.LeakDetected.LEAK_DETECTED);
+        expect(instance._leakDetected(' RAIN ')).toBe(Characteristic.LeakDetected.LEAK_DETECTED);
+        expect(instance._leakDetected('no_rain')).toBe(Characteristic.LeakDetected.LEAK_NOT_DETECTED);
+        expect(instance._leakDetected(undefined)).toBe(Characteristic.LeakDetected.LEAK_NOT_DETECTED);
+        expect(instance._leakDetected(null)).toBe(Characteristic.LeakDetected.LEAK_NOT_DETECTED);
+    });
+
+    test('a custom dpRainState data-point (e.g. a Tuya code) is honoured', () => {
+        const { accessory, device } = makeHarness(
+            { '1': false, rain_sensor_state: 'rain' },
+            { dpRainState: 'rain_sensor_state' }
+        );
+        const leak = irrigation(accessory).getCharacteristic(Characteristic.LeakDetected);
+        expect(leak.value).toBe(Characteristic.LeakDetected.LEAK_DETECTED);
+
+        device.emitChange({ rain_sensor_state: 'no_rain' });
+        expect(leak.value).toBe(Characteristic.LeakDetected.LEAK_NOT_DETECTED);
+    });
+});
+
 describe('IrrigationSystemAccessory — data-points addressed by code', () => {
     // The accessory is transport-agnostic: a data-point may be a numeric id or a
     // Tuya "code". The LAN+cloud TuyaDevice keeps state dual-keyed and translates

--- a/wiki/Supported-Device-Types.md
+++ b/wiki/Supported-Device-Types.md
@@ -758,7 +758,8 @@ Multi-valve Tuya irrigation/sprinkler controllers (the battery-powered Wi-Fi "fa
 
 * one **Irrigation System** tile that contains every zone,
 * one **Valve** per zone (`ValveType = Irrigation`) — each with its own on/off, its own **Duration** picker and a live countdown,
-* an optional **Battery** service (level, low-battery warning, and — for solar/USB-C rechargeable units that report it — live charging status).
+* an optional **Battery** service (level, low-battery warning, and — for solar/USB-C rechargeable units that report it — live charging status),
+* a **Leak Detected** characteristic on the system tile for controllers with a rain sensor (`rain_sensor_state`, DP `49`) — HomeKit reports a leak while it's raining, so you can be notified or automate on it.
 
 Because these devices are slow to respond, all zone changes that happen close together — turning the whole system on/off, or running a scene that toggles several zones — are merged into a **single** Tuya command instead of a burst of them.
 
@@ -807,6 +808,12 @@ Each zone has its own **Duration**. When a zone is switched on it runs for that 
 
 Switching the whole Irrigation System tile **off** closes every open zone, and switching it **on** opens every zone — each as one combined command (mirroring the physical "all" button many of these controllers have). Either direction can be disabled with `masterTurnsOffAllZones` / `masterTurnsOnAllZones`.
 
+#### Rain sensor
+
+Controllers with a rain sensor report it on `rain_sensor_state` (DP `49`, an enum of `rain` / `no_rain`). The plugin surfaces this as a **Leak Detected** characteristic **on the Irrigation System tile itself** — `rain` reads as "leak detected", anything else as "no leak". HomeKit can then show the rainfall state and drive notifications or automations from it (e.g. skip a watering scene while it's raining).
+
+It's deliberately carried on the system tile rather than as a separate sensor accessory: a standalone sensor makes the Home app split the sprinkler into sub-accessories and blocks control from the main tile. There's nothing to turn on — it's present by default, and stays "no leak" on controllers that don't report a rain sensor. The data-point defaults to DP `49` and can be remapped with `dpRainState` (e.g. to the `rain_sensor_state` code on a cloud device).
+
 #### Full Configuration
 
 ```json5
@@ -844,6 +851,9 @@ Switching the whole Irrigation System tile **off** closes every open zone, and s
     "masterTurnsOnAllZones": true,
     "masterTurnsOffAllZones": true,
     "commandDebounce": 500,   /* ms window for merging zone changes into one command */
+
+    /* --- Rain sensor (shown as Leak Detected on the system tile) --- */
+    "dpRainState": 49,   /* enum rain/no_rain DP; omit to use the default, or if not reported */
 
     /* --- Battery (omit / set noBattery:true if mains-powered) --- */
     "dpBattery": 46,


### PR DESCRIPTION
## Summary

Surfaces a Tuya irrigation controller's rain sensor (`rain_sensor_state`, DP 49 — an enum of `rain` / `no_rain`) as a **LeakDetected** characteristic so HomeKit can show, notify, and automate on rainfall. `rain` reads as a leak; `no_rain` (or a device that doesn't report it) reads as no leak.

The characteristic is carried **on the `IrrigationSystem` service itself**, not as a separate `LeakSensor` service. A second sensor service is exactly what previously made the Home app fragment the sprinkler into "sub-accessories" and block control from the main tile (the reason the old standalone rain/leak services were dropped). Putting the reading on the system service keeps the clean single-tile sprinkler while still exposing the state.

Present by default — no configuration required.

## Changes

- **`lib/IrrigationSystemAccessory.js`**
  - Resolve `dpRainState` (default `49`, overridable; a cloud code like `rain_sensor_state` resolves too) alongside `dpBattery`/`dpCharging`.
  - Wire `LeakDetected` onto the `IrrigationSystem` service (initial value + `onGet`, which throws "No Response" while fully unreachable, matching the battery/charging handlers).
  - Mirror device-side DP 49 changes onto the characteristic in `_onDeviceChange`.
  - Add a small `_leakDetected()` mapper (trims/lowercases; only exact `rain` is a leak, so `no_rain` never false-positives on the substring).
  - Update the stale "rain sensors no longer supported" comment — the standalone `LeakSensor`/`ContactSensor` *services* are still removed (they fragment the tile), but the reading now lives as a characteristic on the system service.
- **`config.schema.json`** — document `dpRainState` next to `dpBattery`/`dpCharging` so there are no undocumented irrigation settings.
- **`wiki/Supported-Device-Types.md`** — feature bullet, a new "Rain sensor" subsection, and a `dpRainState` line in the full-config example.

## Tests

- 8 new tests covering initial state, `rain`/`no_rain`, default-when-absent, device-change reflection, live `onGet`, disconnected "No Response", the mapper, and a custom `dpRainState` code.
- Full suite: **445 passed**; **lint clean**; `config.schema.json` validated as JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012sBkC1R8iJCnhGFyGGkXsY)_